### PR TITLE
DEV-1897 Added logger hook that prints the service name before the message.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,7 +35,6 @@ linters:
     - bodyclose
     - asciicheck
     - dupl
-    - depguard
     - errorlint
     - dogsled
     - durationcheck
@@ -95,6 +94,7 @@ linters:
     - interfacer # Deprecated.
     - maligned # Deprecated.
     - scopelint # Deprecated.
+    - depguard # Works wrong.
   fast: false
 linters-settings:
   lll:

--- a/config/routing_test.go
+++ b/config/routing_test.go
@@ -153,7 +153,7 @@ func TestRouteConfig(t *testing.T) { //nolint:paralleltest
 						config.RouteCmdLogSetLevel("test_service", mLog.setter),
 					)
 
-					return
+					return routing, tasks, mocks
 				}),
 				Nodes: []*suite.Node{
 					{


### PR DESCRIPTION
Added a hook to logrus formatter, to be able to use log.WithFields("service", "your service name").
So running: 
```
log.WithField("service", "balance_guard").Infof("change in amperage: [%d]", 14)
```
will result in:
> [2023-10-16T18:25:55.484] [balance_guard] change in amperage: [14] 
