### PR TITLE
DEV-2033: Fixed a bug with deleting stuck device

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -431,7 +431,7 @@ func (a *adapter) destroyThing(address string) error {
 		a.unregisterThing(t)
 	}
 
-	err = a.sendExclusionReport(ts.Address())
+	err = a.sendExclusionReport(address)
 	if err != nil {
 		return fmt.Errorf("adapter: failed to send exclusion report for thing with address %s: %w", ts.Address(), err)
 	}

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -433,7 +433,7 @@ func (a *adapter) destroyThing(address string) error {
 
 	err = a.sendExclusionReport(address)
 	if err != nil {
-		return fmt.Errorf("adapter: failed to send exclusion report for thing with address %s: %w", ts.Address(), err)
+		return fmt.Errorf("adapter: failed to send exclusion report for thing with address %s: %w", address, err)
 	}
 
 	return nil


### PR DESCRIPTION
Currently device can't be removed if it's not found in the adapter's state file.
Thus we can have a stuck devices (due updates, migration and just bugs) that can't be removed.
