### PR TITLE
Detached MQTT test router.

### DIFF
--- a/adapter/thing/main_elec_test.go
+++ b/adapter/thing/main_elec_test.go
@@ -193,10 +193,10 @@ func TestTaskMainElec(t *testing.T) { //nolint:paralleltest
 					{
 						Name: "One change and one error during four report cycles",
 						Expectations: []*suite.Expectation{
-							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 1500).ExpectProperty("unit", "W").ExactlyOnce(),
-							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 750).ExpectProperty("unit", "W").ExactlyOnce(),
-							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 167.89).ExpectProperty("unit", "kWh").ExactlyOnce(),
-							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 167.99).ExpectProperty("unit", "kWh").ExactlyOnce(),
+							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 1500).ExpectProperty("unit", "W"),
+							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 750).ExpectProperty("unit", "W"),
+							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 167.89).ExpectProperty("unit", "kWh"),
+							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 167.99).ExpectProperty("unit", "kWh"),
 						},
 					},
 				},

--- a/prime/observer/observer_test.go
+++ b/prime/observer/observer_test.go
@@ -533,6 +533,7 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 							ID:        "A",
 						}),
 					},
+					suite.SleepNode(50 * time.Millisecond), // sleeping to allow observer to process all incoming messages
 					{
 						Name: "Failed lazy load on getting devices",
 						Expectations: []*suite.Expectation{

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -202,6 +202,7 @@ func Test_Router_Concurrency(t *testing.T) { //nolint:paralleltest
 						Name:    "Send command 1",
 						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_1", "test_service"),
 					},
+					suite.SleepNode(50 * time.Millisecond),
 					{
 						Name:    "Send command 2",
 						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_2", "test_service"),

--- a/test/suite/expectation.go
+++ b/test/suite/expectation.go
@@ -9,14 +9,29 @@ import (
 	"github.com/futurehomeno/cliffhanger/router"
 )
 
-type Occurrence int
-
 const (
 	AtLeastOnce Occurrence = iota
 	ExactlyOnce
 	AtMostOnce
 	Never
 )
+
+type Occurrence int
+
+func (o Occurrence) String() string {
+	switch o {
+	case AtLeastOnce:
+		return "at least once"
+	case ExactlyOnce:
+		return "exactly once"
+	case AtMostOnce:
+		return "at most once"
+	case Never:
+		return "never"
+	default:
+		return "unknown"
+	}
+}
 
 func ExpectMessage(topic, messageType, service string) *Expectation {
 	return NewExpectation().

--- a/test/suite/router.go
+++ b/test/suite/router.go
@@ -1,0 +1,198 @@
+package suite
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/futurehomeno/fimpgo"
+	"github.com/google/uuid"
+
+	"github.com/futurehomeno/cliffhanger/router"
+)
+
+// Router is an MQTT router used for testing purposes.
+// It allows to set expectations for incoming messages and assert if they have been met.
+type Router struct {
+	t      *testing.T
+	mqtt   *fimpgo.MqttTransport
+	router router.Router
+
+	mu           sync.RWMutex
+	expectations []*Expectation
+}
+
+// NewTestRouter creates new instance of a Router.
+func NewTestRouter(t *testing.T, mqtt *fimpgo.MqttTransport) *Router {
+	t.Helper()
+
+	r := &Router{
+		t:    t,
+		mqtt: mqtt,
+	}
+
+	channelID := "test-router-" + uuid.New().String()
+	r.router = router.NewRouter(mqtt, channelID, r.expectationsRouting())
+
+	return r
+}
+
+// Start starts the router and initiates processing of incoming messages.
+func (r *Router) Start() {
+	r.t.Helper()
+
+	r.cleanUpExpectations()
+
+	if err := r.router.Start(); err != nil {
+		r.t.Fatalf("failed to start the router: %s", err)
+	}
+}
+
+// Stop stops the router.
+func (r *Router) Stop() {
+	r.t.Helper()
+
+	if err := r.router.Stop(); err != nil {
+		r.t.Fatalf("failed to stop the router: %s", err)
+	}
+}
+
+// Expect adds expectations to the router.
+func (r *Router) Expect(e ...*Expectation) {
+	r.t.Helper()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.expectations = append(r.expectations, e...)
+}
+
+// AssertExpectations checks if all expectations have been met.
+// Accepts a timeout as a parameter. If the timeout is reached before all expectations are met, the test fails.
+func (r *Router) AssertExpectations(timeout time.Duration) {
+	r.t.Helper()
+
+	defer r.cleanUpExpectations()
+
+	t := time.NewTimer(timeout)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			if !r.expectationsMet() {
+				r.t.Errorf("failed to assert expectations within %s", timeout)
+			}
+
+			return
+		default:
+			if r.shouldWaitUntilTimeout() {
+				continue
+			}
+
+			if r.expectationsMet() {
+				return
+			}
+		}
+	}
+}
+
+func (r *Router) expectationsMet() bool {
+	r.t.Helper()
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, e := range r.expectations {
+		if !e.assert() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (r *Router) cleanUpExpectations() {
+	r.t.Helper()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.expectations = nil
+}
+
+func (r *Router) expectationsRouting() *router.Routing {
+	r.t.Helper()
+
+	return router.NewRouting(router.NewMessageHandler(
+		router.MessageProcessorFn(func(message *fimpgo.Message) (*fimpgo.FimpMessage, error) {
+			return r.processMessage(message)
+		}),
+	))
+}
+
+func (r *Router) processMessage(message *fimpgo.Message) (*fimpgo.FimpMessage, error) {
+	r.t.Helper()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, e := range r.expectations {
+		if !e.vote(message) {
+			continue
+		}
+
+		if e.called == 1 && (e.Occurrence == ExactlyOnce || e.Occurrence == AtMostOnce) {
+			continue
+		}
+
+		e.called++
+
+		if e.PublishFn != nil {
+			e.Publish = e.PublishFn()
+		}
+
+		publishMessage(r.t, r.mqtt, e.Publish)
+
+		if e.ReplyFn != nil {
+			e.Reply = e.ReplyFn()
+		}
+
+		return e.Reply, nil
+	}
+
+	return nil, nil
+}
+
+func (r *Router) shouldWaitUntilTimeout() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, e := range r.expectations {
+		if e.Occurrence == Never {
+			return true
+		}
+	}
+
+	return false
+}
+
+func publishMessage(t *testing.T, mqtt *fimpgo.MqttTransport, message *fimpgo.Message) {
+	t.Helper()
+
+	if message == nil {
+		return
+	}
+
+	var err error
+
+	if message.Topic != "" {
+		err = mqtt.PublishToTopic(message.Topic, message.Payload)
+	} else {
+		err = mqtt.Publish(message.Addr, message.Payload)
+	}
+
+	if err != nil {
+		t.Fatalf("failed to publish a message: %s", err)
+	}
+}

--- a/test/suite/router_test.go
+++ b/test/suite/router_test.go
@@ -1,0 +1,68 @@
+package suite_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/futurehomeno/fimpgo"
+	"github.com/stretchr/testify/suite"
+
+	cliffSuite "github.com/futurehomeno/cliffhanger/test/suite"
+)
+
+type RouterTestSuite struct {
+	suite.Suite
+
+	mqtt   *fimpgo.MqttTransport
+	router *cliffSuite.Router
+}
+
+func TestRouterTestSuite(t *testing.T) { //nolint:paralleltest
+	suite.Run(t, new(RouterTestSuite))
+}
+
+func (suite *RouterTestSuite) SetupTest() {
+	suite.mqtt = fimpgo.NewMqttTransport("tcp://localhost:11883", "router-test-suite", "", "", true, 1, 1)
+	suite.Require().NoError(suite.mqtt.Start())
+	suite.Require().NoError(suite.mqtt.Subscribe("#"))
+
+	suite.router = cliffSuite.NewTestRouter(suite.T(), suite.mqtt)
+	suite.router.Start()
+}
+
+func (suite *RouterTestSuite) TearDownTest() {
+	suite.router.Stop()
+	suite.mqtt.Stop()
+}
+
+func (suite *RouterTestSuite) TestRouter() {
+	topic := "pt:j1/mt:cmd/rt:dev/rn:test/ad:1/sv:out_bin_switch/ad:1_0"
+	assertionsTimeout := 50 * time.Millisecond
+
+	// first set of expectations
+	suite.router.Expect(
+		cliffSuite.ExpectBool(topic, "cmd.binary.set", "out_bin_switch", true),
+	)
+
+	addr, err := fimpgo.NewAddressFromString(topic)
+	suite.Require().NoError(err)
+
+	msg := fimpgo.NewBoolMessage("cmd.binary.set", "out_bin_switch", true, nil, nil, nil)
+
+	err = suite.mqtt.Publish(addr, msg)
+	suite.Require().NoError(err)
+
+	suite.router.AssertExpectations(assertionsTimeout)
+
+	// second set of expectations
+	suite.router.Expect(
+		cliffSuite.ExpectBool(topic, "cmd.binary.set", "out_bin_switch", false),
+	)
+
+	msg = fimpgo.NewBoolMessage("cmd.binary.set", "out_bin_switch", false, nil, nil, nil)
+
+	err = suite.mqtt.Publish(addr, msg)
+	suite.Require().NoError(err)
+
+	suite.router.AssertExpectations(assertionsTimeout)
+}


### PR DESCRIPTION
This PR introduces an MQTT test router. It is now detached from `suite.Node` and can be used in other contexts as well (e.g. `testify/suite` or regular table-driven tests).

Thank you!