### PR TITLE
VM followup fixes

### DIFF
--- a/adapter/service/virtualmeter/listener.go
+++ b/adapter/service/virtualmeter/listener.go
@@ -28,7 +28,7 @@ var (
 )
 
 // NewHandlers creates a new handler for virtual meter that listens for the state updates of other services.
-func NewHandlers(mr Manager) []*event.Handler {
+func NewHandlers(mr Manager, handlersBufferSize int) []*event.Handler {
 	m, ok := mr.(*manager)
 	if !ok {
 		log.Errorf("listener: failed to cast manager to *manager during handler creation")
@@ -37,8 +37,8 @@ func NewHandlers(mr Manager) []*event.Handler {
 	}
 
 	return []*event.Handler{
-		event.NewHandler(&levelEventProcessor{processor{manager: m}}, "virtual_meter_level", 3, outlvlswitch.WaitForLevelEvent()),
-		event.NewHandler(&connectivityEventProcessor{processor{manager: m}}, "virtual_meter_connectivity", 3, adapter.WaitForConnectivityEvent()),
+		event.NewHandler(&levelEventProcessor{processor{manager: m}}, "virtual_meter_level", handlersBufferSize, outlvlswitch.WaitForLevelEvent()),
+		event.NewHandler(&connectivityEventProcessor{processor{manager: m}}, "virtual_meter_connectivity", handlersBufferSize, adapter.WaitForConnectivityEvent()),
 	}
 }
 

--- a/adapter/service/virtualmeter/listener_test.go
+++ b/adapter/service/virtualmeter/listener_test.go
@@ -110,7 +110,7 @@ func TestHandlerLevelEvent(t *testing.T) { //nolint:paralleltest
 				assert.NoError(t, err, "should set a device at start")
 			}
 
-			handlers := NewHandlers(mr)
+			handlers := NewHandlers(mr, 3)
 			eventManager := event.NewManager()
 			listener := event.NewListener(eventManager, handlers...)
 
@@ -172,7 +172,7 @@ func TestHandlerConnectivityEvent(t *testing.T) { //nolint:paralleltest
 				assert.NoError(t, err, "should set a device at start")
 			}
 
-			handlers := NewHandlers(mr)
+			handlers := NewHandlers(mr, 3)
 			eventManager := event.NewManager()
 			listener := event.NewListener(eventManager, handlers...)
 

--- a/adapter/service/virtualmeter/manager.go
+++ b/adapter/service/virtualmeter/manager.go
@@ -107,6 +107,7 @@ func (m *manager) add(topic string, modes map[string]float64, unit string) error
 
 	device.Modes = modes
 	device.Unit = unit
+	device.LastTimeUpdated = time.Now() // this guarantees that event if accumulated energy is not recalculated, the time is updated.
 
 	if err := m.storage.SetDevice(topic, device); err != nil {
 		return fmt.Errorf("manager: failed add meter, can't save data: %w", err)

--- a/event/manager.go
+++ b/event/manager.go
@@ -43,7 +43,7 @@ func (m *manager) Publish(event Event) {
 		case s.channel <- event:
 			continue
 		case <-time.After(time.Second):
-			log.Warnf("event manager: event subscriber ID %s is very busy or deadlocked, an event for domain %s and class %s was dropped", s.id, event.Domain(), event.Class())
+			log.Warnf("event manager: subscriber ID %s is busy or deadlocked, an event for domain %s and class %s was dropped", s.id, event.Domain(), event.Class())
 		}
 	}
 }

--- a/event/manager.go
+++ b/event/manager.go
@@ -42,8 +42,8 @@ func (m *manager) Publish(event Event) {
 		select {
 		case s.channel <- event:
 			continue
-		case <-time.After(time.Second):
-			log.Warnf("event manager: subscriber ID %s is busy or deadlocked, an event for domain %s and class %s was dropped", s.id, event.Domain(), event.Class())
+		default:
+			log.Warnf("event manager: event subscriber ID %s is busy, an event for domain %s and class %s was dropped", s.id, event.Domain(), event.Class())
 		}
 	}
 }

--- a/event/manager.go
+++ b/event/manager.go
@@ -42,8 +42,8 @@ func (m *manager) Publish(event Event) {
 		select {
 		case s.channel <- event:
 			continue
-		default:
-			log.Warnf("event manager: event subscriber ID %s is busy, an event for domain %s and class %s was dropped", s.id, event.Domain(), event.Class())
+		case <-time.After(time.Second):
+			log.Warnf("event manager: event subscriber ID %s is very busy or deadlocked, an event for domain %s and class %s was dropped", s.id, event.Domain(), event.Class())
 		}
 	}
 }


### PR DESCRIPTION
Added initialisation of the "last time updated" value of the virtual meter device entity when modes are added for the first time.
Changed event manager behaviour when unable to to send event to the channel.