### PR TITLE
Added ability to send multiple commands. ON HOLD.

### DIFF
--- a/adapter/cache/refresher_test.go
+++ b/adapter/cache/refresher_test.go
@@ -105,8 +105,10 @@ func TestRefresher_Refresh(t *testing.T) {
 
 			refresher := cache.NewRefresher(tc.refreshMock.refresh, tc.refresherInterval, tc.refresherOptions...)
 
-			var got interface{}
-			var err error
+			var (
+				got interface{}
+				err error
+			)
 
 			for i := 0; i < tc.repeatCount+1; i++ {
 				if i == tc.resetAt {

--- a/adapter/routing.go
+++ b/adapter/routing.go
@@ -162,7 +162,7 @@ func routeCmdNetworkGetAllNodes(adapter Adapter) *router.Routing {
 // handleCmdNetworkGetAllNodes returns a handler responsible for handling the command.
 func handleCmdNetworkGetAllNodes(adapter Adapter) router.MessageHandler {
 	return router.NewMessageHandler(
-		router.MessageProcessorFn(func(message *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
+		router.MessageProcessorFn(func(_ *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
 			err = adapter.SendConnectivityReport()
 			if err != nil {
 				return nil, fmt.Errorf("adapter: failed to send connectivity report: %w", err)

--- a/adapter/service/chargepoint/routing_test.go
+++ b/adapter/service/chargepoint/routing_test.go
@@ -38,8 +38,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "start charging",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.start", "chargepoint"),
+						Name:     "start charging",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.start", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.state.report", "chargepoint", "charging"),
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.current_session.report", "chargepoint", 1.74),
@@ -47,10 +47,10 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "start charging with mode unsupported by controller",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.start", "chargepoint").
 							AddProperty(chargepoint.PropertyChargingMode, "slow").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.state.report", "chargepoint", "charging"),
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.current_session.report", "chargepoint", 1.74),
@@ -71,10 +71,10 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Nodes: []*suite.Node{
 					{
 						Name: "start charging",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.start", "chargepoint").
 							AddProperty(chargepoint.PropertyChargingMode, "Normal").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.state.report", "chargepoint", "charging"),
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.current_session.report", "chargepoint", 1.74),
@@ -94,8 +94,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "stop charging",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.stop", "chargepoint"),
+						Name:     "stop charging",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.stop", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.state.report", "chargepoint", "ready_to_charge"),
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.current_session.report", "chargepoint", 1.74),
@@ -136,31 +136,31 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set cable lock",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.set", "chargepoint", true),
+						Name:     "set cable lock",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.set", "chargepoint", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBool("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.cable_lock.report", "chargepoint", true).
 								ExpectNoProperty("cable_current"),
 						},
 					},
 					{
-						Name:    "cable lock report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.get_report", "chargepoint"),
+						Name:     "cable lock report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBool("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.cable_lock.report", "chargepoint", true).
 								ExpectNoProperty("cable_current"),
 						},
 					},
 					{
-						Name:    "state report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.state.get_report", "chargepoint"),
+						Name:     "state report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.state.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.state.report", "chargepoint", "charging"),
 						},
 					},
 					{
-						Name:    "current session report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.get_report", "chargepoint"),
+						Name:     "current session report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.current_session.report", "chargepoint", 1.74).
 								ExpectProperty("offered_current", "10").
@@ -168,8 +168,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 						},
 					},
 					{
-						Name:    "set offered current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 10),
+						Name:     "set offered current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 10)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.current_session.report", "chargepoint", 1.74).
 								ExpectProperty("offered_current", "10").
@@ -177,29 +177,29 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 						},
 					},
 					{
-						Name:    "set max current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 16),
+						Name:     "set max current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 16)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.max_current.report", "chargepoint", 16),
 						},
 					},
 					{
-						Name:    "get max current",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.get_report", "chargepoint"),
+						Name:     "get max current",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.max_current.report", "chargepoint", 16),
 						},
 					},
 					{
-						Name:    "set phase mode",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.set", "chargepoint", "NL1L2L3"),
+						Name:     "set phase mode",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.set", "chargepoint", "NL1L2L3")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.phase_mode.report", "chargepoint", "NL1L2L3"),
 						},
 					},
 					{
-						Name:    "get phase mode",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.get_report", "chargepoint"),
+						Name:     "get phase mode",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.phase_mode.report", "chargepoint", "NL1L2L3"),
 						},
@@ -222,7 +222,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.get_report", "chargepoint"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBool("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.cable_lock.report", "chargepoint", true).
 								ExpectProperty("cable_current", "0"),
@@ -240,8 +240,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "start charging",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.start", "chargepoint"),
+						Name:     "start charging",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.start", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -259,8 +259,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "start charging",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.start", "chargepoint"),
+						Name:     "start charging",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.start", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -279,8 +279,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "start charging",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.start", "chargepoint"),
+						Name:     "start charging",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.start", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -297,10 +297,10 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Nodes: []*suite.Node{
 					{
 						Name: "start charging",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.start", "chargepoint").
 							AddProperty(chargepoint.PropertyChargingMode, "dummy").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -317,8 +317,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "stop charging",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.stop", "chargepoint"),
+						Name:     "stop charging",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.stop", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -336,8 +336,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "stop charging",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.stop", "chargepoint"),
+						Name:     "stop charging",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.stop", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -356,8 +356,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "stop charging",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.stop", "chargepoint"),
+						Name:     "stop charging",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.charge.stop", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -380,8 +380,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set cable lock",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.set", "chargepoint", true),
+						Name:     "set cable lock",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.set", "chargepoint", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -405,8 +405,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set cable lock",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.set", "chargepoint", true),
+						Name:     "set cable lock",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.set", "chargepoint", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -430,8 +430,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set offered current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 10),
+						Name:     "set offered current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 10)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -455,8 +455,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set max current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 14),
+						Name:     "set max current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 14)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -469,22 +469,22 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Setup:    routeService(mockedchargepoint.NewController(t), nil),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set offered current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 14),
+						Name:     "set offered current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 14)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "set max current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 14),
+						Name:     "set max current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 14)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "get max current",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.get_report", "chargepoint"),
+						Name:     "get max current",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -497,22 +497,22 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Setup:    routeService(mockedchargepoint.NewController(t), []adapter.SpecificationOption{chargepoint.WithSupportedMaxCurrent(16)}),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set offered current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 14),
+						Name:     "set offered current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 14)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "set max current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 14),
+						Name:     "set max current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 14)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "get max current",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.get_report", "chargepoint"),
+						Name:     "get max current",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -534,7 +534,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.set", "chargepoint", "L1L2"),
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.set", "chargepoint", "L1L2")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -557,7 +557,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.set", "chargepoint", "NL1"),
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.set", "chargepoint", "NL1")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -580,7 +580,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.get_report", "chargepoint"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -593,15 +593,15 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Setup:    routeService(mockedchargepoint.NewController(t), nil),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set phase mode",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.set", "chargepoint", "NL1"),
+						Name:     "set phase mode",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.set", "chargepoint", "NL1")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "get phase mode",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.get_report", "chargepoint"),
+						Name:     "get phase mode",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -623,15 +623,15 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set phase mode",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.set", "chargepoint", "NL1"),
+						Name:     "set phase mode",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.set", "chargepoint", "NL1")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "get phase mode",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.get_report", "chargepoint"),
+						Name:     "get phase mode",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.phase_mode.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
@@ -659,141 +659,141 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "cable lock report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.get_report", "chargepoint"),
+						Name:     "cable lock report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "state report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.state.get_report", "chargepoint"),
+						Name:     "state report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.state.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "current session report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.get_report", "chargepoint"),
+						Name:     "current session report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "max current report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.get_report", "chargepoint"),
+						Name:     "max current report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "set max current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 14),
+						Name:     "set max current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 14)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "set offered current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 10),
+						Name:     "set offered current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 10)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "non-existent thing on start charging",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.charge.start", "chargepoint"),
+						Name:     "non-existent thing on start charging",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.charge.start", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "chargepoint"),
 						},
 					},
 					{
-						Name:    "non-existent thing on stop charging",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.charge.stop", "chargepoint"),
+						Name:     "non-existent thing on stop charging",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.charge.stop", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "chargepoint"),
 						},
 					},
 					{
-						Name:    "non-existent thing on setting cable lock",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.cable_lock.set", "chargepoint"),
+						Name:     "non-existent thing on setting cable lock",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.cable_lock.set", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "chargepoint"),
 						},
 					},
 					{
-						Name:    "non-existent thing on state report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.state.get_report", "chargepoint"),
+						Name:     "non-existent thing on state report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.state.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "chargepoint"),
 						},
 					},
 					{
-						Name:    "non-existent thing on current session report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.current_session.get_report", "chargepoint"),
+						Name:     "non-existent thing on current session report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.current_session.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "chargepoint"),
 						},
 					},
 					{
-						Name:    "non-existent thing on cable lock report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.cable_lock.get_report", "chargepoint"),
+						Name:     "non-existent thing on cable lock report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.cable_lock.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "chargepoint"),
 						},
 					},
 					{
-						Name:    "non-existent thing on max current report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.max_current.get_report", "chargepoint"),
+						Name:     "non-existent thing on max current report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "cmd.max_current.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:3", "chargepoint"),
 						},
 					},
 					{
-						Name:    "non-boolean value on setting cable lock",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.set", "chargepoint", "true"),
+						Name:     "non-boolean value on setting cable lock",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.set", "chargepoint", "true")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "non-integer value on setting offered current",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", "10"),
+						Name:     "non-integer value on setting offered current",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", "10")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "non-integer value on setting max current",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", "10"),
+						Name:     "non-integer value on setting max current",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", "10")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "too-high value on setting offered current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 32),
+						Name:     "too-high value on setting offered current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 32)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "too-small value on setting offered current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 5),
+						Name:     "too-small value on setting offered current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.set_current", "chargepoint", 5)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "too-high value on setting max current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 32),
+						Name:     "too-high value on setting max current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 32)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},
 					},
 					{
-						Name:    "too-small value on setting max current",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 5),
+						Name:     "too-small value on setting max current",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.max_current.set", "chargepoint", 5)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "chargepoint"),
 						},

--- a/adapter/service/chargepoint/routing_test.go
+++ b/adapter/service/chargepoint/routing_test.go
@@ -856,7 +856,7 @@ func setupService(
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(a adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return adapter.NewThing(publisher, thingState, thingCfg, chargepoint.NewService(publisher, chargepointCfg)), nil
 	})
 

--- a/adapter/service/devsys/routing_test.go
+++ b/adapter/service/devsys/routing_test.go
@@ -30,15 +30,15 @@ func TestRouteCarCharger(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "reboot with unspecified mode",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:2", "cmd.thing.reboot", "dev_sys"),
+						Name:     "reboot with unspecified mode",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:2", "cmd.thing.reboot", "dev_sys")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectSuccess("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:2", "dev_sys"),
 						},
 					},
 					{
-						Name:    "reboot with specified mode",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:2", "cmd.thing.reboot", "dev_sys", true),
+						Name:     "reboot with specified mode",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:2", "cmd.thing.reboot", "dev_sys", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectSuccess("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:2", "dev_sys"),
 						},
@@ -53,8 +53,8 @@ func TestRouteCarCharger(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "reboot is unsupported",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:2", "cmd.thing.reboot", "dev_sys"),
+						Name:     "reboot is unsupported",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:2", "cmd.thing.reboot", "dev_sys")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:2", "dev_sys"),
 						},
@@ -70,15 +70,15 @@ func TestRouteCarCharger(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "reboot failed",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:2", "cmd.thing.reboot", "dev_sys"),
+						Name:     "reboot failed",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:2", "cmd.thing.reboot", "dev_sys")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:2", "dev_sys"),
 						},
 					},
 					{
-						Name:    "reboot failed - service not found",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:3", "cmd.thing.reboot", "dev_sys"),
+						Name:     "reboot failed - service not found",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:3", "cmd.thing.reboot", "dev_sys")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:dev_sys/ad:3", "dev_sys"),
 						},

--- a/adapter/service/devsys/routing_test.go
+++ b/adapter/service/devsys/routing_test.go
@@ -136,7 +136,7 @@ func setupService(
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(a adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return adapter.NewThing(publisher, thingState, thingCfg, devsys.NewService(publisher, devSysCfg)), nil
 	})
 

--- a/adapter/service/fanctrl/routing_test.go
+++ b/adapter/service/fanctrl/routing_test.go
@@ -29,13 +29,14 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Nodes: []*cliffSuite.Node{
 					{
 						Name: "Cmd mode get report",
-						Commands: []*fimpgo.Message{cliffSuite.NewMessageBuilder().
-							NullMessage(
-								"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2",
-								"cmd.mode.get_report",
-								"fan_ctrl",
-							).
-							Build(),
+						Commands: []*fimpgo.Message{
+							cliffSuite.NewMessageBuilder().
+								NullMessage(
+									"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2",
+									"cmd.mode.get_report",
+									"fan_ctrl",
+								).
+								Build(),
 						},
 						Expectations: []*cliffSuite.Expectation{
 							cliffSuite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2", "evt.mode.report", "fan_ctrl", "normal"),
@@ -153,7 +154,7 @@ func setupService(t *testing.T, mqtt *fimpgo.MqttTransport, controller *mockedfa
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(a adapter.Adapter, p adapter.Publisher, ts adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, p adapter.Publisher, ts adapter.ThingState) (adapter.Thing, error) {
 		return adapter.NewThing(p, ts, thingCfg, fanctrl.NewService(p, fanCfg)), nil
 	})
 	ad := adapterhelper.PrepareSeededAdapter(t, "../../testdata/adapter/test_adapter", mqtt, factory, adapter.ThingSeeds{seed})

--- a/adapter/service/fanctrl/routing_test.go
+++ b/adapter/service/fanctrl/routing_test.go
@@ -29,13 +29,14 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Nodes: []*cliffSuite.Node{
 					{
 						Name: "Cmd mode get report",
-						Command: cliffSuite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{cliffSuite.NewMessageBuilder().
 							NullMessage(
 								"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2",
 								"cmd.mode.get_report",
 								"fan_ctrl",
 							).
 							Build(),
+						},
 						Expectations: []*cliffSuite.Expectation{
 							cliffSuite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2", "evt.mode.report", "fan_ctrl", "normal"),
 						},
@@ -52,27 +53,27 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Nodes: []*cliffSuite.Node{
 					{
 						Name: "Cmd mode set",
-						Command: cliffSuite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{cliffSuite.NewMessageBuilder().
 							StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2", "cmd.mode.set", "fan_ctrl", "night").
-							Build(),
+							Build()},
 						Expectations: []*cliffSuite.Expectation{
 							cliffSuite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2", "evt.mode.report", "fan_ctrl", "night"),
 						},
 					},
 					{
 						Name: "Device does not exists",
-						Command: cliffSuite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{cliffSuite.NewMessageBuilder().
 							StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:404", "cmd.mode.set", "fan_ctrl", "night").
-							Build(),
+							Build()},
 						Expectations: []*cliffSuite.Expectation{
 							cliffSuite.ExpectMessage("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:404", "evt.error.report", "fan_ctrl"),
 						},
 					},
 					{
 						Name: "Wrong message type",
-						Command: cliffSuite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{cliffSuite.NewMessageBuilder().
 							FloatMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2", "cmd.mode.set", "fan_ctrl", 1).
-							Build(),
+							Build()},
 						Expectations: []*cliffSuite.Expectation{
 							cliffSuite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2", "fan_ctrl"),
 						},
@@ -88,9 +89,9 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Nodes: []*cliffSuite.Node{
 					{
 						Name: "Cmd mode set with error",
-						Command: cliffSuite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{cliffSuite.NewMessageBuilder().
 							StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2", "cmd.mode.set", "fan_ctrl", "night").
-							Build(),
+							Build()},
 						Expectations: []*cliffSuite.Expectation{
 							cliffSuite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2", "fan_ctrl"),
 						},
@@ -106,9 +107,9 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Nodes: []*cliffSuite.Node{
 					{
 						Name: "Cmd mode get_report with error",
-						Command: cliffSuite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{cliffSuite.NewMessageBuilder().
 							StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2", "cmd.mode.get_report", "fan_ctrl", "night").
-							Build(),
+							Build()},
 						Expectations: []*cliffSuite.Expectation{
 							cliffSuite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2", "fan_ctrl"),
 						},

--- a/adapter/service/mediaplayer/routing_test.go
+++ b/adapter/service/mediaplayer/routing_test.go
@@ -388,7 +388,7 @@ func setupService(t *testing.T, mqtt *fimpgo.MqttTransport, controller mediaplay
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(a adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return adapter.NewThing(
 			publisher,
 			thingState,

--- a/adapter/service/mediaplayer/routing_test.go
+++ b/adapter/service/mediaplayer/routing_test.go
@@ -59,253 +59,253 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Set playback success",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.set", "media_player", "play"),
+						Name:     "Set playback success",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.set", "media_player", "play")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "evt.playback.report", "media_player", "play"),
 						},
 					},
 					{
-						Name:    "Set playback wrong action",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.set", "media_player", "not_supported_action"),
+						Name:     "Set playback wrong action",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.set", "media_player", "not_supported_action")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "Set playback - wrong topic",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.playback.set", "media_player", "play"),
+						Name:     "Set playback - wrong topic",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.playback.set", "media_player", "play")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "media_player"),
 						},
 					},
 					{
-						Name:    "Set playback - wrong message type",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.set", "media_player", true),
+						Name:     "Set playback - wrong message type",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.set", "media_player", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "Set playback errored service",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.set", "media_player", "play"),
+						Name:     "Set playback errored service",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.set", "media_player", "play")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "Set playback errored report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.set", "media_player", "play"),
+						Name:     "Set playback errored report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.set", "media_player", "play")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "get playback report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.get_report", "media_player"),
+						Name:     "get playback report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "evt.playback.report", "media_player", "play"),
 						},
 					},
 					{
-						Name:    "get playback report - wrong topic",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.playback.get_report", "media_player"),
+						Name:     "get playback report - wrong topic",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.playback.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "media_player"),
 						},
 					},
 					{
-						Name:    "get playback report - errored sending",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.get_report", "media_player"),
+						Name:     "get playback report - errored sending",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playback.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "set playback mode - success",
-						Command: suite.BoolMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playbackmode.set", "media_player", samplePlaybackMode()),
+						Name:     "set playback mode - success",
+						Commands: []*fimpgo.Message{suite.BoolMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playbackmode.set", "media_player", samplePlaybackMode())},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBoolMap("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "evt.playbackmode.report", "media_player", samplePlaybackMode()),
 						},
 					},
 					{
-						Name:    "set playback mode - wrong topic",
-						Command: suite.BoolMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.playbackmode.set", "media_player", samplePlaybackMode()),
+						Name:     "set playback mode - wrong topic",
+						Commands: []*fimpgo.Message{suite.BoolMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.playbackmode.set", "media_player", samplePlaybackMode())},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "media_player"),
 						},
 					},
 					{
-						Name:    "set playback mode - wrong message type",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playbackmode.set", "media_player", true),
+						Name:     "set playback mode - wrong message type",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playbackmode.set", "media_player", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "set playback mode - errored service",
-						Command: suite.BoolMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playbackmode.set", "media_player", samplePlaybackMode()),
+						Name:     "set playback mode - errored service",
+						Commands: []*fimpgo.Message{suite.BoolMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playbackmode.set", "media_player", samplePlaybackMode())},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "set playback mode - errored report",
-						Command: suite.BoolMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playbackmode.set", "media_player", samplePlaybackMode()),
+						Name:     "set playback mode - errored report",
+						Commands: []*fimpgo.Message{suite.BoolMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playbackmode.set", "media_player", samplePlaybackMode())},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "get playback mode report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playbackmode.get_report", "media_player"),
+						Name:     "get playback mode report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playbackmode.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBoolMap("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "evt.playbackmode.report", "media_player", samplePlaybackMode()),
 						},
 					},
 					{
-						Name:    "get playback mode report - wrong topic",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.playbackmode.get_report", "media_player"),
+						Name:     "get playback mode report - wrong topic",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.playbackmode.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "media_player"),
 						},
 					},
 					{
-						Name:    "get playback mode report - errored sending",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playbackmode.get_report", "media_player"),
+						Name:     "get playback mode report - errored sending",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.playbackmode.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "set volume - success",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.volume.set", "media_player", 10),
+						Name:     "set volume - success",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.volume.set", "media_player", 10)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "evt.volume.report", "media_player", 10),
 						},
 					},
 					{
-						Name:    "set volume - wrong topic",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.volume.set", "media_player", 10),
+						Name:     "set volume - wrong topic",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.volume.set", "media_player", 10)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "media_player"),
 						},
 					},
 					{
-						Name:    "set volume - wrong message type",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.volume.set", "media_player", true),
+						Name:     "set volume - wrong message type",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.volume.set", "media_player", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "set volume - errored service",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.volume.set", "media_player", 10),
+						Name:     "set volume - errored service",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.volume.set", "media_player", 10)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "set volume - errored report",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.volume.set", "media_player", 10),
+						Name:     "set volume - errored report",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.volume.set", "media_player", 10)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "get volume report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.volume.get_report", "media_player"),
+						Name:     "get volume report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.volume.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "evt.volume.report", "media_player", 10),
 						},
 					},
 					{
-						Name:    "get volume report - wrong topic",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.volume.get_report", "media_player"),
+						Name:     "get volume report - wrong topic",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.volume.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "media_player"),
 						},
 					},
 					{
-						Name:    "get volume report - errored sending",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.volume.get_report", "media_player"),
+						Name:     "get volume report - errored sending",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.volume.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "set mute - success",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.mute.set", "media_player", true),
+						Name:     "set mute - success",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.mute.set", "media_player", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBool("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "evt.mute.report", "media_player", true),
 						},
 					},
 					{
-						Name:    "set mute - wrong topic",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.mute.set", "media_player", true),
+						Name:     "set mute - wrong topic",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.mute.set", "media_player", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "media_player"),
 						},
 					},
 					{
-						Name:    "set mute - wrong message type",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.mute.set", "media_player", 10),
+						Name:     "set mute - wrong message type",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.mute.set", "media_player", 10)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "set mute - errored service",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.mute.set", "media_player", true),
+						Name:     "set mute - errored service",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.mute.set", "media_player", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "set mute - errored report",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.mute.set", "media_player", true),
+						Name:     "set mute - errored report",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.mute.set", "media_player", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "get mute report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.mute.get_report", "media_player"),
+						Name:     "get mute report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.mute.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBool("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "evt.mute.report", "media_player", true),
 						},
 					},
 					{
-						Name:    "get mute report - wrong topic",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.mute.get_report", "media_player"),
+						Name:     "get mute report - wrong topic",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.mute.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "media_player"),
 						},
 					},
 					{
-						Name:    "get mute report - errored service",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.mute.get_report", "media_player"),
+						Name:     "get mute report - errored service",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.mute.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},
 					},
 					{
-						Name:    "get metadata report - success",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.metadata.get_report", "media_player"),
+						Name:     "get metadata report - success",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.metadata.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectStringMap("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "evt.metadata.report", "media_player", sampleMetadata()),
 						},
 					},
 					{
-						Name:    "get metadata report - wrong topic",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.metadata.get_report", "media_player"),
+						Name:     "get metadata report - wrong topic",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "cmd.metadata.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:666", "media_player"),
 						},
 					},
 					{
-						Name:    "get metadata report - errored sending",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.metadata.get_report", "media_player"),
+						Name:     "get metadata report - errored sending",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "cmd.metadata.get_report", "media_player")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:media_player/ad:3", "media_player"),
 						},

--- a/adapter/service/ota/routing_test.go
+++ b/adapter/service/ota/routing_test.go
@@ -340,7 +340,7 @@ func setupAdapter(t *testing.T, mqtt *fimpgo.MqttTransport, controller ota.Contr
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "1"}
 
-	factory := adapterhelper.FactoryHelper(func(a adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return adapter.NewThing(publisher, thingState, thingCfg, ota.NewService(publisher, serviceCfg)), nil
 	})
 

--- a/adapter/service/ota/routing_test.go
+++ b/adapter/service/ota/routing_test.go
@@ -33,7 +33,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:ota/ad:1", "cmd.ota_update.start", "ota", testFirmwarePath),
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:ota/ad:1", "cmd.ota_update.start", "ota", testFirmwarePath)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectNull("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:ota/ad:1", "evt.ota_start.report", "ota").Never(),
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:ota/ad:1", "ota").Never(),
@@ -49,7 +49,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:ota/ad:1", "cmd.ota_update.start", "ota", testFirmwarePath),
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:ota/ad:1", "cmd.ota_update.start", "ota", testFirmwarePath)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:ota/ad:1", "ota"),
 						},
@@ -64,7 +64,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:ota/ad:1", "cmd.ota_update.start", "ota", 1),
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:ota/ad:1", "cmd.ota_update.start", "ota", 1)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:ota/ad:1", "ota"),
 						},

--- a/adapter/service/outbinswitch/routing_test.go
+++ b/adapter/service/outbinswitch/routing_test.go
@@ -35,50 +35,50 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Switch binary on",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "cmd.binary.set", "out_bin_switch", true),
+						Name:     "Switch binary on",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "cmd.binary.set", "out_bin_switch", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBool("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "evt.binary.report", "out_bin_switch", true),
 						},
 					},
 					{
-						Name:    "Get binary report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "cmd.binary.get_report", "out_bin_switch"),
+						Name:     "Get binary report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "cmd.binary.get_report", "out_bin_switch")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBool("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "evt.binary.report", "out_bin_switch", false),
 						},
 					},
 					{
-						Name:    "Wrong topic",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:666", "cmd.binary.get_report", "out_bin_switch"),
+						Name:     "Wrong topic",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:666", "cmd.binary.get_report", "out_bin_switch")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:666", "out_bin_switch"),
 						},
 					},
 					{
-						Name:    "Get errored binary report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "cmd.binary.get_report", "out_bin_switch"),
+						Name:     "Get errored binary report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "cmd.binary.get_report", "out_bin_switch")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "out_bin_switch"),
 						},
 					},
 					{
-						Name:    "Switch binary on - wrong topic",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:666", "cmd.binary.set", "out_bin_switch", true),
+						Name:     "Switch binary on - wrong topic",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:666", "cmd.binary.set", "out_bin_switch", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:666", "out_bin_switch"),
 						},
 					},
 					{
-						Name:    "Switch binary on - wrong type",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "cmd.binary.set", "out_bin_switch", true),
+						Name:     "Switch binary on - wrong type",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "cmd.binary.set", "out_bin_switch", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "out_bin_switch"),
 						},
 					},
 					{
-						Name:    "Switch binary on - report error",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "cmd.binary.set", "out_bin_switch", true),
+						Name:     "Switch binary on - report error",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "cmd.binary.set", "out_bin_switch", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_bin_switch/ad:2", "out_bin_switch"),
 						},

--- a/adapter/service/outbinswitch/routing_test.go
+++ b/adapter/service/outbinswitch/routing_test.go
@@ -130,7 +130,7 @@ func setupService(t *testing.T, mqtt *fimpgo.MqttTransport, controller outbinswi
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(a adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return adapter.NewThing(publisher, thingState, thingCfg, outbinswitch.NewService(publisher, switchCfg)), nil
 	})
 

--- a/adapter/service/outlvlswitch/routing_test.go
+++ b/adapter/service/outlvlswitch/routing_test.go
@@ -289,7 +289,7 @@ func setupService(
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(a adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return adapter.NewThing(publisher, thingState, thingCfg, outlvlswitch.NewService(publisher, switchCfg)), nil
 	})
 

--- a/adapter/service/outlvlswitch/routing_test.go
+++ b/adapter/service/outlvlswitch/routing_test.go
@@ -42,40 +42,40 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Start level transition",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", "up"),
+						Name:     "Start level transition",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", "up")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "evt.lvl.report", "out_lvl_switch", 1),
 						},
 					},
 					{
-						Name:    "Stop level transition",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.stop", "out_lvl_switch", ""),
+						Name:     "Stop level transition",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.stop", "out_lvl_switch", "")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "evt.lvl.report", "out_lvl_switch", 2),
 						},
 					},
 					{
-						Name:    "Switch binary",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.binary.set", "out_lvl_switch", true),
+						Name:     "Switch binary",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.binary.set", "out_lvl_switch", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "evt.lvl.report", "out_lvl_switch", 3),
 						},
 					},
 					{
-						Name:    "Set level",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 1),
+						Name:     "Set level",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 1)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "evt.lvl.report", "out_lvl_switch", 4),
 						},
 					},
 					{
 						Name: "Start level transition. Should avoid processing properties when not supported.",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", "up").
 							AddProperty("duration", "5").
 							AddProperty("start_lvl", "4").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "evt.lvl.report", "out_lvl_switch", 5),
 						},
@@ -100,21 +100,21 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Nodes: []*suite.Node{
 					{
 						Name: "Start level transition",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", "up").
 							AddProperty("duration", "5").
 							AddProperty("start_lvl", "4").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "evt.lvl.report", "out_lvl_switch", 2),
 						},
 					},
 					{
 						Name: "Set level",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 1).
 							AddProperty("duration", "1").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "evt.lvl.report", "out_lvl_switch", 3),
 						},
@@ -136,99 +136,99 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Start level transition",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", "up"),
+						Name:     "Start level transition",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", "up")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
-						Name:    "Start level transition. Not string value",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", true),
+						Name:     "Start level transition. Not string value",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
-						Name:    "Start level transition. Incorrect value",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", "invalid"),
+						Name:     "Start level transition. Incorrect value",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", "invalid")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
 						Name: "Start level transition with invalid duration property",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", "up").
 							AddProperty("duration", "invalid").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
 						Name: "Start level transition  with invalid start_lvl property",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", "up").
 							AddProperty("duration", "3").
 							AddProperty("start_lvl", "invalid int").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
 						Name: "Start level transition with start_lvl property out of range",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.start", "out_lvl_switch", "up").
 							AddProperty("duration", "4").
 							AddProperty("start_lvl", "109").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
-						Name:    "Stop level transition",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.stop", "out_lvl_switch", ""),
+						Name:     "Stop level transition",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.stop", "out_lvl_switch", "")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
-						Name:    "Set binary cmd",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.binary.set", "out_lvl_switch", true),
+						Name:     "Set binary cmd",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.binary.set", "out_lvl_switch", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
-						Name:    "Set binary cmd. Not boolean value",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.binary.set", "out_lvl_switch", "invalid"),
+						Name:     "Set binary cmd. Not boolean value",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.binary.set", "out_lvl_switch", "invalid")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
-						Name:    "Set level",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 1),
+						Name:     "Set level",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 1)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
-						Name:    "Set level. Invalid value.",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", "invalid"),
+						Name:     "Set level. Invalid value.",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", "invalid")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
 						Name: "Set level. Invalid duration property",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 1).
 							AddProperty("duration", "invalid").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},

--- a/adapter/service/parameters/routing_test.go
+++ b/adapter/service/parameters/routing_test.go
@@ -35,22 +35,22 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "get parameter specifications",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.sup_params.get_report", "parameters"),
+						Name:     "get parameter specifications",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.sup_params.get_report", "parameters")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectObject("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "evt.sup_params.report", "parameters", testSpecifications(t)),
 						},
 					},
 					{
-						Name:    "get parameter",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.param.get_report", "parameters", "1"),
+						Name:     "get parameter",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.param.get_report", "parameters", "1")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectObject("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "evt.param.report", "parameters", testParameter(t)),
 						},
 					},
 					{
-						Name:    "set parameter",
-						Command: suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.param.set", "parameters", testParameter(t)),
+						Name:     "set parameter",
+						Commands: []*fimpgo.Message{suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.param.set", "parameters", testParameter(t))},
 						Expectations: []*suite.Expectation{
 							suite.ExpectObject("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "evt.param.report", "parameters", testParameter(t)),
 						},
@@ -67,22 +67,22 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "get parameter specifications",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.sup_params.get_report", "parameters"),
+						Name:     "get parameter specifications",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.sup_params.get_report", "parameters")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "parameters"),
 						},
 					},
 					{
-						Name:    "get parameter",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.param.get_report", "parameters", "1"),
+						Name:     "get parameter",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.param.get_report", "parameters", "1")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "parameters"),
 						},
 					},
 					{
-						Name:    "set parameter - error when getting param specifications",
-						Command: suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.param.set", "parameters", testParameter(t)),
+						Name:     "set parameter - error when getting param specifications",
+						Commands: []*fimpgo.Message{suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.param.set", "parameters", testParameter(t))},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "parameters"),
 						},
@@ -99,8 +99,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set parameter",
-						Command: suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.param.set", "parameters", testParameter(t)),
+						Name:     "set parameter",
+						Commands: []*fimpgo.Message{suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.param.set", "parameters", testParameter(t))},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "parameters"),
 						},
@@ -116,8 +116,8 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set parameter",
-						Command: suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.param.set", "parameters", testReadOnlyParameter(t)),
+						Name:     "set parameter",
+						Commands: []*fimpgo.Message{suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "cmd.param.set", "parameters", testReadOnlyParameter(t))},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:parameters/ad:2", "parameters"),
 						},

--- a/adapter/service/parameters/routing_test.go
+++ b/adapter/service/parameters/routing_test.go
@@ -162,7 +162,7 @@ func routeService(
 
 		seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-		factory := adapterhelper.FactoryHelper(func(a adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+		factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 			return adapter.NewThing(publisher, thingState, thingCfg, parameters.NewService(publisher, serviceCfg)), nil
 		})
 

--- a/adapter/service/virtualmeter/listener_test.go
+++ b/adapter/service/virtualmeter/listener_test.go
@@ -118,6 +118,7 @@ func TestHandlerLevelEvent(t *testing.T) { //nolint:paralleltest
 			assert.NoError(t, err, "listener should start")
 
 			time.Sleep(100 * time.Millisecond)
+
 			defer listener.Stop() //nolint:errcheck
 
 			if v.levelEvent != nil {
@@ -125,6 +126,7 @@ func TestHandlerLevelEvent(t *testing.T) { //nolint:paralleltest
 			}
 
 			time.Sleep(50 * time.Millisecond)
+
 			d, err := m.storage.Device("")
 			assert.NoError(t, err, "should return a device")
 			assert.Equal(t, v.expectedDevice, d, "should return the same device as was saved")
@@ -180,6 +182,7 @@ func TestHandlerConnectivityEvent(t *testing.T) { //nolint:paralleltest
 			assert.NoError(t, err, "listener should start")
 
 			time.Sleep(100 * time.Millisecond)
+
 			defer listener.Stop() //nolint:errcheck
 
 			if v.connectivityEvent != nil {
@@ -187,7 +190,9 @@ func TestHandlerConnectivityEvent(t *testing.T) { //nolint:paralleltest
 			}
 
 			time.Sleep(50 * time.Millisecond)
+
 			d, err := m.storage.Device(addr)
+
 			assert.NoError(t, err, "should return a device")
 			assert.Equal(t, v.expectedDevice, d, "should return the same device as was saved")
 		})

--- a/adapter/service/virtualmeter/routing_test.go
+++ b/adapter/service/virtualmeter/routing_test.go
@@ -35,7 +35,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Nodes: []*suite.Node{
 					{
 						Name: "Cmd meter add",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							FloatMapMessage(
 								"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 								"cmd.meter.add",
@@ -44,6 +44,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 							).
 							AddProperty(virtualmeter.PropertyNameUnit, "W").
 							Build(),
+						},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap(
 								"pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
@@ -55,11 +56,11 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Cmd get report after set",
-						Command: suite.NullMessage(
+						Commands: []*fimpgo.Message{suite.NullMessage(
 							"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 							"cmd.meter.get_report",
 							"virtual_meter_elec",
-						),
+						)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap(
 								"pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
@@ -71,7 +72,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Cmd meter add idempotent",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							FloatMapMessage(
 								"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 								"cmd.meter.add",
@@ -79,7 +80,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 								map[string]float64{"on": 123, "off": 321},
 							).
 							AddProperty(virtualmeter.PropertyNameUnit, "W").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap(
 								"pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
@@ -91,11 +92,11 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Cmd meter remove",
-						Command: suite.NullMessage(
+						Commands: []*fimpgo.Message{suite.NullMessage(
 							"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 							"cmd.meter.remove",
 							"virtual_meter_elec",
-						),
+						)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap(
 								"pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
@@ -107,11 +108,11 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Cmd meter remove idempotent",
-						Command: suite.NullMessage(
+						Commands: []*fimpgo.Message{suite.NullMessage(
 							"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 							"cmd.meter.remove",
 							"virtual_meter_elec",
-						),
+						)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap(
 								"pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
@@ -123,11 +124,11 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Cmd get report after remove",
-						Command: suite.NullMessage(
+						Commands: []*fimpgo.Message{suite.NullMessage(
 							"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 							"cmd.meter.get_report",
 							"virtual_meter_elec",
-						),
+						)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap(
 								"pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
@@ -146,7 +147,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Nodes: []*suite.Node{
 					{
 						Name: "Error when unsupported unit property provided",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							FloatMapMessage(
 								"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 								"cmd.meter.add",
@@ -154,28 +155,28 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 								map[string]float64{"on": 100},
 							).
 							AddProperty(virtualmeter.PropertyNameUnit, "invalid").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2", "virtual_meter_elec"),
 						},
 					},
 					{
 						Name: "Error when no unit property provided",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							FloatMapMessage(
 								"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 								"cmd.meter.add",
 								"virtual_meter_elec",
 								map[string]float64{"on": 100},
 							).
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2", "virtual_meter_elec"),
 						},
 					},
 					{
 						Name: "Error when value type isn't float map",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							StringMessage(
 								"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 								"cmd.meter.add",
@@ -183,7 +184,7 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 								"invalid",
 							).
 							AddProperty(virtualmeter.PropertyNameUnit, "W").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2", "virtual_meter_elec"),
 						},

--- a/adapter/service/virtualmeter/routing_test.go
+++ b/adapter/service/virtualmeter/routing_test.go
@@ -35,15 +35,16 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				Nodes: []*suite.Node{
 					{
 						Name: "Cmd meter add",
-						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
-							FloatMapMessage(
-								"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
-								"cmd.meter.add",
-								"virtual_meter_elec",
-								map[string]float64{"on": 100, "off": 1},
-							).
-							AddProperty(virtualmeter.PropertyNameUnit, "W").
-							Build(),
+						Commands: []*fimpgo.Message{
+							suite.NewMessageBuilder().
+								FloatMapMessage(
+									"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
+									"cmd.meter.add",
+									"virtual_meter_elec",
+									map[string]float64{"on": 100, "off": 1},
+								).
+								AddProperty(virtualmeter.PropertyNameUnit, "W").
+								Build(),
 						},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap(
@@ -228,7 +229,7 @@ func setupService(
 	managerWrapper := virtualmeter.NewManager(db, recalculatingPeriod, time.Hour)
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(a adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		outLvlSwitchSpec := outlvlswitch.Specification(
 			"test_adapter",
 			"1",

--- a/adapter/service/virtualmeter/storage_test.go
+++ b/adapter/service/virtualmeter/storage_test.go
@@ -54,6 +54,7 @@ func TestStorage_Device(t *testing.T) { //nolint:paralleltest
 			db, _ := database.NewDatabase(workdir)
 
 			storage := virtualmeter.NewStorage(db)
+
 			defer adapterhelper.TearDownAdapter(workdir)[0](t)
 
 			err := storage.SetDevice(v.setAddr, v.device)

--- a/adapter/service/virtualmeter/tasks_test.go
+++ b/adapter/service/virtualmeter/tasks_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/futurehomeno/fimpgo"
+
 	"github.com/futurehomeno/cliffhanger/adapter/service/virtualmeter"
 	adapterhelper "github.com/futurehomeno/cliffhanger/test/helper/adapter"
 	"github.com/futurehomeno/cliffhanger/test/suite"
@@ -32,7 +34,7 @@ func TestTaskReporting(t *testing.T) {
 					},
 					{
 						Name: "Cmd meter add",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							FloatMapMessage(
 								"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 								"cmd.meter.add",
@@ -40,7 +42,7 @@ func TestTaskReporting(t *testing.T) {
 								map[string]float64{"on": 100, "off": 1},
 							).
 							AddProperty(virtualmeter.PropertyNameUnit, "W").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap(
 								"pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
@@ -52,13 +54,13 @@ func TestTaskReporting(t *testing.T) {
 					},
 					{
 						Name: "should report latest set modes",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage(
 								"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 								"cmd.meter.get_report",
 								"virtual_meter_elec",
 							).
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap(
 								"pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
@@ -70,11 +72,11 @@ func TestTaskReporting(t *testing.T) {
 					},
 					{
 						Name: "Cmd meter remove",
-						Command: suite.NullMessage(
+						Commands: []*fimpgo.Message{suite.NullMessage(
 							"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 							"cmd.meter.remove",
 							"virtual_meter_elec",
-						),
+						)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap(
 								"pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
@@ -86,13 +88,13 @@ func TestTaskReporting(t *testing.T) {
 					},
 					{
 						Name: "should report empty when modes removed",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage(
 								"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",
 								"cmd.meter.get_report",
 								"virtual_meter_elec",
 							).
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap(
 								"pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:virtual_meter_elec/ad:2",

--- a/adapter/thing/battery_test.go
+++ b/adapter/thing/battery_test.go
@@ -196,7 +196,7 @@ func setupBattery(
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(adapter adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return thing.NewBattery(publisher, thingState, cfg), nil
 	})
 

--- a/adapter/thing/battery_test.go
+++ b/adapter/thing/battery_test.go
@@ -32,9 +32,11 @@ func TestRouteBattery(t *testing.T) { //nolint:paralleltest
 				Nodes: []*suite.Node{
 					{
 						Name: "successful get level report",
-						Command: suite.NewMessageBuilder().
-							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:battery/ad:2", "cmd.lvl.get_report", "battery").
-							Build(),
+						Commands: []*fimpgo.Message{
+							suite.NewMessageBuilder().
+								NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:battery/ad:2", "cmd.lvl.get_report", "battery").
+								Build(),
+						},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:battery/ad:2", "evt.lvl.report", "battery", 80),
 						},
@@ -52,36 +54,36 @@ func TestRouteBattery(t *testing.T) { //nolint:paralleltest
 				Nodes: []*suite.Node{
 					{
 						Name: "get level report",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:battery/ad:2", "cmd.lvl.get_report", "battery").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:battery/ad:2", "battery"),
 						},
 					},
 					{
 						Name: "wrong address get level report",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:battery/ad:3", "cmd.lvl.get_report", "battery").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:battery/ad:3", "battery"),
 						},
 					},
 					{
 						Name: "wrong address get level report",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:battery/ad:3", "cmd.lvl.get_report", "battery").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:battery/ad:3", "battery"),
 						},
 					},
 					{
 						Name: "wrong service under provided address level report",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:batteraay/ad:2", "cmd.lvl.get_report", "battery").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:batteraay/ad:2", "battery"),
 						},

--- a/adapter/thing/boiler_test.go
+++ b/adapter/thing/boiler_test.go
@@ -554,7 +554,7 @@ func setupBoiler(
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(adapter adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return thing.NewBoiler(publisher, thingState, cfg), nil
 	})
 

--- a/adapter/thing/boiler_test.go
+++ b/adapter/thing/boiler_test.go
@@ -42,69 +42,69 @@ func TestRouteBoiler(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Mode",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.get_report", "water_heater"),
+						Name:     "Mode",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.get_report", "water_heater")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "evt.mode.report", "water_heater", "test_mode_a"),
 						},
 					},
 					{
-						Name:    "Setpoint",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.get_report", "water_heater", "test_mode_a"),
+						Name:     "Setpoint",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.get_report", "water_heater", "test_mode_a")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectObject("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "evt.setpoint.report", "water_heater", waterheater.Setpoint{Type: "test_mode_a", Temperature: 60, Unit: "C"}),
 						},
 					},
 					{
-						Name:    "State",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.state.get_report", "water_heater"),
+						Name:     "State",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.state.get_report", "water_heater")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "evt.state.report", "water_heater", "idle"),
 						},
 					},
 					{
-						Name:    "Temperature",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_wattemp", "C"),
+						Name:     "Temperature",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_wattemp", "C")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "evt.sensor.report", "sensor_wattemp", 60).
 								ExpectProperty("unit", "C"),
 						},
 					},
 					{
-						Name:    "All sensor units",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_wattemp", ""),
+						Name:     "All sensor units",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_wattemp", "")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "evt.sensor.report", "sensor_wattemp", 60).
 								ExpectProperty("unit", "C"),
 						},
 					},
 					{
-						Name:    "All sensor units with null",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_wattemp"),
+						Name:     "All sensor units with null",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_wattemp")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "evt.sensor.report", "sensor_wattemp", 60).
 								ExpectProperty("unit", "C"),
 						},
 					},
 					{
-						Name:    "Power",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W"),
+						Name:     "Power",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 1500).
 								ExpectProperty("unit", "W"),
 						},
 					},
 					{
-						Name:    "Energy",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "kWh"),
+						Name:     "Energy",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "kWh")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 31.5).
 								ExpectProperty("unit", "kWh"),
 						},
 					},
 					{
-						Name:    "All electricity units",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", ""),
+						Name:     "All electricity units",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 1500).
 								ExpectProperty("unit", "W"),
@@ -113,8 +113,8 @@ func TestRouteBoiler(t *testing.T) { //nolint:paralleltest
 						},
 					},
 					{
-						Name:    "All electricity units with null",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec"),
+						Name:     "All electricity units with null",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 1500).
 								ExpectProperty("unit", "W"),
@@ -139,120 +139,120 @@ func TestRouteBoiler(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Controller error on mode report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.get_report", "water_heater"),
+						Name:     "Controller error on mode report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.get_report", "water_heater")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Non existent thing on mode report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "cmd.mode.get_report", "water_heater"),
+						Name:     "Non existent thing on mode report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "cmd.mode.get_report", "water_heater")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "water_heater"),
 						},
 					},
 					{
-						Name:    "Controller error on setpoint report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.get_report", "water_heater", "test_mode_a"),
+						Name:     "Controller error on setpoint report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.get_report", "water_heater", "test_mode_a")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Non existent thing on setpoint report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "cmd.setpoint.get_report", "water_heater", "test_mode_a"),
+						Name:     "Non existent thing on setpoint report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "cmd.setpoint.get_report", "water_heater", "test_mode_a")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "water_heater"),
 						},
 					},
 					{
-						Name:    "Unsupported mode on setpoint report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.get_report", "water_heater", "unsupported_mode"),
+						Name:     "Unsupported mode on setpoint report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.get_report", "water_heater", "unsupported_mode")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Wrong value type on setpoint report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.get_report", "water_heater"),
+						Name:     "Wrong value type on setpoint report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.get_report", "water_heater")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Controller error on state report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.state.get_report", "water_heater"),
+						Name:     "Controller error on state report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.state.get_report", "water_heater")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Non existent thing on state report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "cmd.state.get_report", "water_heater"),
+						Name:     "Non existent thing on state report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "cmd.state.get_report", "water_heater")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "water_heater"),
 						},
 					},
 					{
-						Name:    "Reporter error on numeric sensor report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_wattemp", "C"),
+						Name:     "Reporter error on numeric sensor report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_wattemp", "C")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "sensor_wattemp"),
 						},
 					},
 					{
-						Name:    "Wrong value type on numeric sensor report",
-						Command: suite.FloatMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_wattemp", 0),
+						Name:     "Wrong value type on numeric sensor report",
+						Commands: []*fimpgo.Message{suite.FloatMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_wattemp", 0)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "sensor_wattemp"),
 						},
 					},
 					{
-						Name:    "Unsupported unit on numeric sensor report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_wattemp", "F"),
+						Name:     "Unsupported unit on numeric sensor report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_wattemp", "F")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "sensor_wattemp"),
 						},
 					},
 					{
-						Name:    "Non existent thing on numeric sensor report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:3", "cmd.sensor.get_report", "sensor_wattemp"),
+						Name:     "Non existent thing on numeric sensor report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:3", "cmd.sensor.get_report", "sensor_wattemp")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:3", "sensor_wattemp"),
 						},
 					},
 					{
-						Name:    "Wrong sensor on numeric sensor report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_temp"),
+						Name:     "Wrong sensor on numeric sensor report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "cmd.sensor.get_report", "sensor_temp")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_wattemp/ad:2", "sensor_temp"),
 						},
 					},
 					{
-						Name:    "Reporter error on electricity meter report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W"),
+						Name:     "Reporter error on electricity meter report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "meter_elec"),
 						},
 					},
 					{
-						Name:    "Wrong value type on electricity meter report",
-						Command: suite.FloatMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", 0),
+						Name:     "Wrong value type on electricity meter report",
+						Commands: []*fimpgo.Message{suite.FloatMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", 0)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "meter_elec"),
 						},
 					},
 					{
-						Name:    "Unsupported unit on electricity meter report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "A"),
+						Name:     "Unsupported unit on electricity meter report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "A")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "meter_elec"),
 						},
 					},
 					{
-						Name:    "Non existent thing on electricity meter report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:3", "cmd.meter.get_report", "meter_elec", "W"),
+						Name:     "Non existent thing on electricity meter report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:3", "cmd.meter.get_report", "meter_elec", "W")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:3", "meter_elec"),
 						},
@@ -275,23 +275,23 @@ func TestRouteBoiler(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Set mode not supporting a setpoint",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.set", "water_heater", "test_mode_c"),
+						Name:     "Set mode not supporting a setpoint",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.set", "water_heater", "test_mode_c")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "evt.mode.report", "water_heater", "test_mode_c"),
 						},
 					},
 					{
-						Name:    "Set mode supporting a setpoint",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.set", "water_heater", "test_mode_a"),
+						Name:     "Set mode supporting a setpoint",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.set", "water_heater", "test_mode_a")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "evt.mode.report", "water_heater", "test_mode_a"),
 							suite.ExpectObject("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "evt.setpoint.report", "water_heater", waterheater.Setpoint{Type: "test_mode_a", Temperature: 60, Unit: "C"}),
 						},
 					},
 					{
-						Name:    "Set setpoint",
-						Command: suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.set", "water_heater", waterheater.Setpoint{Type: "test_mode_a", Temperature: 70, Unit: "C"}),
+						Name:     "Set setpoint",
+						Commands: []*fimpgo.Message{suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.set", "water_heater", waterheater.Setpoint{Type: "test_mode_a", Temperature: 70, Unit: "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectObject("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "evt.setpoint.report", "water_heater", waterheater.Setpoint{Type: "test_mode_a", Temperature: 70, Unit: "C"}),
 						},
@@ -309,71 +309,71 @@ func TestRouteBoiler(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Controller error when setting mode",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.set", "water_heater", "test_mode_a"),
+						Name:     "Controller error when setting mode",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.set", "water_heater", "test_mode_a")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Unsupported mode",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.set", "water_heater", "unsupported_mode"),
+						Name:     "Unsupported mode",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.set", "water_heater", "unsupported_mode")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Setting mode with with wrong type of value",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.set", "water_heater"),
+						Name:     "Setting mode with with wrong type of value",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.mode.set", "water_heater")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Setting mode of non-existent thing",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "cmd.mode.set", "water_heater", "test_mode_a"),
+						Name:     "Setting mode of non-existent thing",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "cmd.mode.set", "water_heater", "test_mode_a")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "water_heater"),
 						},
 					},
 					{
-						Name:    "Controller error when setting setpoint",
-						Command: suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.set", "water_heater", waterheater.Setpoint{Type: "test_mode_a", Temperature: 70, Unit: "C"}),
+						Name:     "Controller error when setting setpoint",
+						Commands: []*fimpgo.Message{suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.set", "water_heater", waterheater.Setpoint{Type: "test_mode_a", Temperature: 70, Unit: "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Setpoint out of specific range",
-						Command: suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.set", "water_heater", waterheater.Setpoint{Type: "test_mode_a", Temperature: 80, Unit: "C"}),
+						Name:     "Setpoint out of specific range",
+						Commands: []*fimpgo.Message{suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.set", "water_heater", waterheater.Setpoint{Type: "test_mode_a", Temperature: 80, Unit: "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Setpoint out of generic range",
-						Command: suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.set", "water_heater", waterheater.Setpoint{Type: "test_mode_b", Temperature: 85, Unit: "C"}),
+						Name:     "Setpoint out of generic range",
+						Commands: []*fimpgo.Message{suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.set", "water_heater", waterheater.Setpoint{Type: "test_mode_b", Temperature: 85, Unit: "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Setpoint unsupported by mode",
-						Command: suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.set", "water_heater", waterheater.Setpoint{Type: "test_mode_c", Temperature: 60, Unit: "C"}),
+						Name:     "Setpoint unsupported by mode",
+						Commands: []*fimpgo.Message{suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.set", "water_heater", waterheater.Setpoint{Type: "test_mode_c", Temperature: 60, Unit: "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Setting setpoint with with wrong type of value",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.set", "water_heater", "60"),
+						Name:     "Setting setpoint with with wrong type of value",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "cmd.setpoint.set", "water_heater", "60")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:2", "water_heater"),
 						},
 					},
 					{
-						Name:    "Setting setpoint of non-existent thing",
-						Command: suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "cmd.setpoint.set", "water_heater", waterheater.Setpoint{Type: "test_mode_c", Temperature: 85, Unit: "C"}),
+						Name:     "Setting setpoint of non-existent thing",
+						Commands: []*fimpgo.Message{suite.ObjectMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "cmd.setpoint.set", "water_heater", waterheater.Setpoint{Type: "test_mode_c", Temperature: 85, Unit: "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:water_heater/ad:3", "water_heater"),
 						},

--- a/adapter/thing/car_charger_test.go
+++ b/adapter/thing/car_charger_test.go
@@ -44,44 +44,44 @@ func TestRouteCarCharger(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set cable lock",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.set", "chargepoint", true),
+						Name:     "set cable lock",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.set", "chargepoint", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBool("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.cable_lock.report", "chargepoint", true),
 						},
 					},
 					{
-						Name:    "cable lock report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.get_report", "chargepoint"),
+						Name:     "cable lock report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.cable_lock.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBool("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.cable_lock.report", "chargepoint", true),
 						},
 					},
 					{
-						Name:    "state report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.state.get_report", "chargepoint"),
+						Name:     "state report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.state.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.state.report", "chargepoint", "charging"),
 						},
 					},
 					{
-						Name:    "current session report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.get_report", "chargepoint"),
+						Name:     "current session report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "cmd.current_session.get_report", "chargepoint")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:chargepoint/ad:2", "evt.current_session.report", "chargepoint", 1.74),
 						},
 					},
 					{
-						Name:    "power",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W"),
+						Name:     "power",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 2).
 								ExpectProperty("unit", "W"),
 						},
 					},
 					{
-						Name:    "energy",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "kWh"),
+						Name:     "energy",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "kWh")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 123.45).
 								ExpectProperty("unit", "kWh"),

--- a/adapter/thing/car_charger_test.go
+++ b/adapter/thing/car_charger_test.go
@@ -216,7 +216,7 @@ func setupCarCharger(
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(adapter adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return thing.NewCarCharger(publisher, thingState, cfg), nil
 	})
 

--- a/adapter/thing/light_test.go
+++ b/adapter/thing/light_test.go
@@ -41,17 +41,17 @@ func TestRouteLight(t *testing.T) { //nolint:paralleltest
 				Nodes: []*suite.Node{
 					{
 						Name: "set level with duration",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 99).
 							AddProperty("duration", "1").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "evt.lvl.report", "out_lvl_switch", 99),
 						},
 					},
 					{
-						Name:    "set level without duration",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 98),
+						Name:     "set level without duration",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 98)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "evt.lvl.report", "out_lvl_switch", 98),
 						},
@@ -69,9 +69,9 @@ func TestRouteLight(t *testing.T) { //nolint:paralleltest
 				Nodes: []*suite.Node{
 					{
 						Name: "get report",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.get_report", "out_lvl_switch").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "evt.lvl.report", "out_lvl_switch", 99),
 						},
@@ -88,41 +88,41 @@ func TestRouteLight(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set level",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 99),
+						Name:     "set level",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 99)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
-						Name:    "wrong value type",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", "99"),
+						Name:     "wrong value type",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", "99")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
-						Name:    "wrong address",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:3", "cmd.lvl.set", "out_lvl_switch", 99),
+						Name:     "wrong address",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:3", "cmd.lvl.set", "out_lvl_switch", 99)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:3", "out_lvl_switch"),
 						},
 					},
 					{
 						Name: "wrong address and wrong format of duration",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:3", "cmd.lvl.get_report", "out_lvl_switch").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:3", "out_lvl_switch"),
 						},
 					},
 					{
 						Name: "set level with wrong format of duration",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 99).
 							AddProperty("duration", "1s").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
@@ -140,8 +140,8 @@ func TestRouteLight(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set level",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 99),
+						Name:     "set level",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.set", "out_lvl_switch", 99)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
@@ -158,22 +158,22 @@ func TestRouteLight(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set binary",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.binary.set", "out_lvl_switch", true),
+						Name:     "set binary",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.binary.set", "out_lvl_switch", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
-						Name:    "wrong value type",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.binary.set", "out_lvl_switch", "true"),
+						Name:     "wrong value type",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.binary.set", "out_lvl_switch", "true")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
 					},
 					{
-						Name:    "wrong address",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:3", "cmd.binary.set", "out_lvl_switch", true),
+						Name:     "wrong address",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:3", "cmd.binary.set", "out_lvl_switch", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:3", "out_lvl_switch"),
 						},
@@ -191,8 +191,8 @@ func TestRouteLight(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set binary",
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.binary.set", "out_lvl_switch", true),
+						Name:     "set binary",
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.binary.set", "out_lvl_switch", true)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
@@ -209,8 +209,8 @@ func TestRouteLight(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "get level",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.get_report", "out_lvl_switch"),
+						Name:     "get level",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "cmd.lvl.get_report", "out_lvl_switch")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:out_lvl_switch/ad:2", "out_lvl_switch"),
 						},
@@ -228,8 +228,8 @@ func TestRouteLight(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set color",
-						Command: suite.IntMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "cmd.color.set", "color_ctrl", validColor),
+						Name:     "set color",
+						Commands: []*fimpgo.Message{suite.IntMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "cmd.color.set", "color_ctrl", validColor)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectIntMap("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "evt.color.report", "color_ctrl", validColor),
 						},
@@ -246,8 +246,8 @@ func TestRouteLight(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "get color",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "cmd.color.get_report", "color_ctrl"),
+						Name:     "get color",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "cmd.color.get_report", "color_ctrl")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectIntMap("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "evt.color.report", "color_ctrl", validColor),
 						},
@@ -264,22 +264,22 @@ func TestRouteLight(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "controller error",
-						Command: suite.IntMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "cmd.color.set", "color_ctrl", validColor),
+						Name:     "controller error",
+						Commands: []*fimpgo.Message{suite.IntMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "cmd.color.set", "color_ctrl", validColor)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "color_ctrl"),
 						},
 					},
 					{
-						Name:    "wrong colorValue type",
-						Command: suite.FloatMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "cmd.color.set", "color_ctrl", invalidColor),
+						Name:     "wrong colorValue type",
+						Commands: []*fimpgo.Message{suite.FloatMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "cmd.color.set", "color_ctrl", invalidColor)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "color_ctrl"),
 						},
 					},
 					{
-						Name:    "wrong address",
-						Command: suite.IntMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:3", "cmd.color.set", "color_ctrl", validColor),
+						Name:     "wrong address",
+						Commands: []*fimpgo.Message{suite.IntMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:3", "cmd.color.set", "color_ctrl", validColor)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:3", "color_ctrl"),
 						},
@@ -297,8 +297,8 @@ func TestRouteLight(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "report error",
-						Command: suite.IntMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "cmd.color.set", "color_ctrl", validColor),
+						Name:     "report error",
+						Commands: []*fimpgo.Message{suite.IntMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "cmd.color.set", "color_ctrl", validColor)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:color_ctrl/ad:2", "color_ctrl"),
 						},

--- a/adapter/thing/light_test.go
+++ b/adapter/thing/light_test.go
@@ -461,7 +461,7 @@ func setupLight(
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(adapter adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return thing.NewLight(publisher, thingState, cfg), nil
 	})
 

--- a/adapter/thing/main_elec_test.go
+++ b/adapter/thing/main_elec_test.go
@@ -292,7 +292,7 @@ func setupMainElec(
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(adapter adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return thing.NewMainElec(publisher, thingState, cfg), nil
 	})
 

--- a/adapter/thing/main_elec_test.go
+++ b/adapter/thing/main_elec_test.go
@@ -36,24 +36,24 @@ func TestRouteMainElec(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Power",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W"),
+						Name:     "Power",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 1500).
 								ExpectProperty("unit", "W"),
 						},
 					},
 					{
-						Name:    "Energy",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "kWh"),
+						Name:     "Energy",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "kWh")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 165.78).
 								ExpectProperty("unit", "kWh"),
 						},
 					},
 					{
-						Name:    "All electricity units",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", ""),
+						Name:     "All electricity units",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 1500).
 								ExpectProperty("unit", "W"),
@@ -62,8 +62,8 @@ func TestRouteMainElec(t *testing.T) { //nolint:paralleltest
 						},
 					},
 					{
-						Name:    "All electricity units with null",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec"),
+						Name:     "All electricity units with null",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 1500).
 								ExpectProperty("unit", "W"),
@@ -82,36 +82,36 @@ func TestRouteMainElec(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Reporter error on power report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W"),
+						Name:     "Reporter error on power report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "meter_elec"),
 						},
 					},
 					{
-						Name:    "Wrong value type on electricity meter report",
-						Command: suite.FloatMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", 0),
+						Name:     "Wrong value type on electricity meter report",
+						Commands: []*fimpgo.Message{suite.FloatMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", 0)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "meter_elec"),
 						},
 					},
 					{
-						Name:    "Unsupported unit on electricity meter report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "A"),
+						Name:     "Unsupported unit on electricity meter report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "A")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "meter_elec"),
 						},
 					},
 					{
-						Name:    "Non existent thing on electricity meter report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:3", "cmd.meter.get_report", "meter_elec", "W"),
+						Name:     "Non existent thing on electricity meter report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:3", "cmd.meter.get_report", "meter_elec", "W")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:3", "meter_elec"),
 						},
 					},
 					{
-						Name:    "Unsupported extended report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter_ext.get_report", "meter_elec"),
+						Name:     "Unsupported extended report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter_ext.get_report", "meter_elec")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "meter_elec"),
 						},
@@ -130,8 +130,8 @@ func TestRouteMainElec(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Extended report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter_ext.get_report", "meter_elec"),
+						Name:     "Extended report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter_ext.get_report", "meter_elec")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter_ext.report", "meter_elec", map[string]float64{"p_import": 1500, "e_import": 165.78}),
 						},
@@ -150,15 +150,15 @@ func TestRouteMainElec(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Reporter error on extended report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter_ext.get_report", "meter_elec"),
+						Name:     "Reporter error on extended report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter_ext.get_report", "meter_elec")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "meter_elec"),
 						},
 					},
 					{
-						Name:    "Non existent thing on on extended report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:3", "cmd.meter_ext.get_report", "meter_elec"),
+						Name:     "Non existent thing on on extended report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:3", "cmd.meter_ext.get_report", "meter_elec")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:3", "meter_elec"),
 						},

--- a/adapter/thing/scene_test.go
+++ b/adapter/thing/scene_test.go
@@ -43,8 +43,8 @@ func TestRouteScene(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "set scene",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "cmd.scene.set", "scene_ctrl", sceneColorloop),
+						Name:     "set scene",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "cmd.scene.set", "scene_ctrl", sceneColorloop)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "evt.scene.report", "scene_ctrl", sceneColorloop),
 						},
@@ -60,8 +60,8 @@ func TestRouteScene(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "get scene",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "cmd.scene.get_report", "scene_ctrl"),
+						Name:     "get scene",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "cmd.scene.get_report", "scene_ctrl")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "evt.scene.report", "scene_ctrl", sceneColorloop),
 						},
@@ -77,29 +77,29 @@ func TestRouteScene(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "controller error",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "cmd.scene.set", "scene_ctrl", sceneColorloop),
+						Name:     "controller error",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "cmd.scene.set", "scene_ctrl", sceneColorloop)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "scene_ctrl"),
 						},
 					},
 					{
-						Name:    "invalid value type",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "cmd.scene.set", "scene_ctrl", 1),
+						Name:     "invalid value type",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "cmd.scene.set", "scene_ctrl", 1)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "scene_ctrl"),
 						},
 					},
 					{
-						Name:    "wrong address",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:3", "cmd.scene.set", "scene_ctrl", sceneColorloop),
+						Name:     "wrong address",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:3", "cmd.scene.set", "scene_ctrl", sceneColorloop)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:3", "scene_ctrl"),
 						},
 					},
 					{
-						Name:    "unsupported scene",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "cmd.scene.set", "scene_ctrl", sceneUnsupported),
+						Name:     "unsupported scene",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "cmd.scene.set", "scene_ctrl", sceneUnsupported)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "scene_ctrl"),
 						},
@@ -116,8 +116,8 @@ func TestRouteScene(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "report error",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "cmd.scene.set", "scene_ctrl", sceneColorloop),
+						Name:     "report error",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "cmd.scene.set", "scene_ctrl", sceneColorloop)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:scene_ctrl/ad:2", "scene_ctrl"),
 						},

--- a/adapter/thing/scene_test.go
+++ b/adapter/thing/scene_test.go
@@ -231,7 +231,7 @@ func setupScene(
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(adapter adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return thing.NewScene(publisher, thingState, cfg), nil
 	})
 

--- a/adapter/thing/sensor_test.go
+++ b/adapter/thing/sensor_test.go
@@ -167,7 +167,7 @@ func setupPresence(
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(adapter adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return thing.NewSensor(publisher, thingState, cfg), nil
 	})
 

--- a/adapter/thing/sensor_test.go
+++ b/adapter/thing/sensor_test.go
@@ -34,9 +34,9 @@ func TestRouteSensor(t *testing.T) { //nolint:paralleltest
 				Nodes: []*suite.Node{
 					{
 						Name: "get report",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_presence/ad:2", "cmd.presence.get_report", "sensor_presence").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBool("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_presence/ad:2", "evt.presence.report", "sensor_presence", true),
 						},
@@ -54,18 +54,18 @@ func TestRouteSensor(t *testing.T) { //nolint:paralleltest
 				Nodes: []*suite.Node{
 					{
 						Name: "get report error",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_presence/ad:2", "cmd.presence.get_report", "sensor_presence").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_presence/ad:2", "sensor_presence"),
 						},
 					},
 					{
 						Name: "wrong address",
-						Command: suite.NewMessageBuilder().
+						Commands: []*fimpgo.Message{suite.NewMessageBuilder().
 							NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_presence/ad:3", "cmd.presence.get_report", "sensor_presence").
-							Build(),
+							Build()},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_presence/ad:3", "sensor_presence"),
 						},

--- a/adapter/thing/thermostat_test.go
+++ b/adapter/thing/thermostat_test.go
@@ -42,69 +42,69 @@ func TestRouteThermostat(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Mode",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.get_report", "thermostat"),
+						Name:     "Mode",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.get_report", "thermostat")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "evt.mode.report", "thermostat", "test_mode_a"),
 						},
 					},
 					{
-						Name:    "Setpoint",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.get_report", "thermostat", "test_mode_a"),
+						Name:     "Setpoint",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.get_report", "thermostat", "test_mode_a")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectStringMap("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "evt.setpoint.report", "thermostat", map[string]string{"type": "test_mode_a", "temp": "21.0", "unit": "C"}),
 						},
 					},
 					{
-						Name:    "State",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.state.get_report", "thermostat"),
+						Name:     "State",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.state.get_report", "thermostat")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "evt.state.report", "thermostat", "idle"),
 						},
 					},
 					{
-						Name:    "Temperature",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_temp", "C"),
+						Name:     "Temperature",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_temp", "C")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "evt.sensor.report", "sensor_temp", 21.5).
 								ExpectProperty("unit", "C"),
 						},
 					},
 					{
-						Name:    "All sensor units",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_temp", ""),
+						Name:     "All sensor units",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_temp", "")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "evt.sensor.report", "sensor_temp", 21.5).
 								ExpectProperty("unit", "C"),
 						},
 					},
 					{
-						Name:    "All sensor units with null",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_temp"),
+						Name:     "All sensor units with null",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_temp")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "evt.sensor.report", "sensor_temp", 21.5).
 								ExpectProperty("unit", "C"),
 						},
 					},
 					{
-						Name:    "Power",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W"),
+						Name:     "Power",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 2).
 								ExpectProperty("unit", "W"),
 						},
 					},
 					{
-						Name:    "Energy",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "kWh"),
+						Name:     "Energy",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "kWh")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 123.45).
 								ExpectProperty("unit", "kWh"),
 						},
 					},
 					{
-						Name:    "All electricity units",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", ""),
+						Name:     "All electricity units",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 2).
 								ExpectProperty("unit", "W"),
@@ -113,8 +113,8 @@ func TestRouteThermostat(t *testing.T) { //nolint:paralleltest
 						},
 					},
 					{
-						Name:    "All electricity units with null",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec"),
+						Name:     "All electricity units with null",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "evt.meter.report", "meter_elec", 2).
 								ExpectProperty("unit", "W"),
@@ -139,120 +139,120 @@ func TestRouteThermostat(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Controller error on mode report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.get_report", "thermostat"),
+						Name:     "Controller error on mode report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.get_report", "thermostat")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Non existent thing on mode report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "cmd.mode.get_report", "thermostat"),
+						Name:     "Non existent thing on mode report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "cmd.mode.get_report", "thermostat")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "thermostat"),
 						},
 					},
 					{
-						Name:    "Controller error on setpoint report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.get_report", "thermostat", "test_mode_a"),
+						Name:     "Controller error on setpoint report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.get_report", "thermostat", "test_mode_a")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Non existent thing on setpoint report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "cmd.setpoint.get_report", "thermostat", "test_mode_a"),
+						Name:     "Non existent thing on setpoint report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "cmd.setpoint.get_report", "thermostat", "test_mode_a")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "thermostat"),
 						},
 					},
 					{
-						Name:    "Unsupported mode on setpoint report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.get_report", "thermostat", "unsupported_mode"),
+						Name:     "Unsupported mode on setpoint report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.get_report", "thermostat", "unsupported_mode")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Wrong value type on setpoint report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.get_report", "thermostat"),
+						Name:     "Wrong value type on setpoint report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.get_report", "thermostat")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Controller error on state report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.state.get_report", "thermostat"),
+						Name:     "Controller error on state report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.state.get_report", "thermostat")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Non existent thing on state report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "cmd.state.get_report", "thermostat"),
+						Name:     "Non existent thing on state report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "cmd.state.get_report", "thermostat")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "thermostat"),
 						},
 					},
 					{
-						Name:    "Reporter error on numeric sensor report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_temp", "C"),
+						Name:     "Reporter error on numeric sensor report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_temp", "C")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "sensor_temp"),
 						},
 					},
 					{
-						Name:    "Wrong value type on numeric sensor report",
-						Command: suite.FloatMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_temp", 0),
+						Name:     "Wrong value type on numeric sensor report",
+						Commands: []*fimpgo.Message{suite.FloatMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_temp", 0)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "sensor_temp"),
 						},
 					},
 					{
-						Name:    "Unsupported unit on numeric sensor report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_temp", "F"),
+						Name:     "Unsupported unit on numeric sensor report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_temp", "F")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "sensor_temp"),
 						},
 					},
 					{
-						Name:    "Non existent thing on numeric sensor report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:3", "cmd.sensor.get_report", "sensor_temp"),
+						Name:     "Non existent thing on numeric sensor report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:3", "cmd.sensor.get_report", "sensor_temp")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:3", "sensor_temp"),
 						},
 					},
 					{
-						Name:    "Wrong sensor on numeric sensor report",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_wattemp"),
+						Name:     "Wrong sensor on numeric sensor report",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "cmd.sensor.get_report", "sensor_wattemp")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:sensor_temp/ad:2", "sensor_wattemp"),
 						},
 					},
 					{
-						Name:    "Reporter error on electricity meter report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W"),
+						Name:     "Reporter error on electricity meter report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "W")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "meter_elec"),
 						},
 					},
 					{
-						Name:    "Wrong value type on electricity meter report",
-						Command: suite.FloatMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", 0),
+						Name:     "Wrong value type on electricity meter report",
+						Commands: []*fimpgo.Message{suite.FloatMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", 0)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "meter_elec"),
 						},
 					},
 					{
-						Name:    "Unsupported unit on electricity meter report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "A"),
+						Name:     "Unsupported unit on electricity meter report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "cmd.meter.get_report", "meter_elec", "A")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:2", "meter_elec"),
 						},
 					},
 					{
-						Name:    "Non existent thing on electricity meter report",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:3", "cmd.meter.get_report", "meter_elec", "W"),
+						Name:     "Non existent thing on electricity meter report",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:3", "cmd.meter.get_report", "meter_elec", "W")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:meter_elec/ad:3", "meter_elec"),
 						},
@@ -275,23 +275,23 @@ func TestRouteThermostat(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Set mode not supporting a setpoint",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.set", "thermostat", "test_mode_c"),
+						Name:     "Set mode not supporting a setpoint",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.set", "thermostat", "test_mode_c")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "evt.mode.report", "thermostat", "test_mode_c"),
 						},
 					},
 					{
-						Name:    "Set mode supporting a setpoint",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.set", "thermostat", "test_mode_a"),
+						Name:     "Set mode supporting a setpoint",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.set", "thermostat", "test_mode_a")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "evt.mode.report", "thermostat", "test_mode_a"),
 							suite.ExpectStringMap("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "evt.setpoint.report", "thermostat", map[string]string{"type": "test_mode_a", "temp": "21.0", "unit": "C"}),
 						},
 					},
 					{
-						Name:    "Set setpoint",
-						Command: suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_a", "temp": "20.0", "unit": "C"}),
+						Name:     "Set setpoint",
+						Commands: []*fimpgo.Message{suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_a", "temp": "20.0", "unit": "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectStringMap("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "evt.setpoint.report", "thermostat", map[string]string{"type": "test_mode_a", "temp": "20.0", "unit": "C"}),
 						},
@@ -309,85 +309,85 @@ func TestRouteThermostat(t *testing.T) { //nolint:paralleltest
 				),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Controller error when setting mode",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.set", "thermostat", "test_mode_a"),
+						Name:     "Controller error when setting mode",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.set", "thermostat", "test_mode_a")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Unsupported mode",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.set", "thermostat", "unsupported_mode"),
+						Name:     "Unsupported mode",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.set", "thermostat", "unsupported_mode")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Setting mode with with wrong type of value",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.set", "thermostat"),
+						Name:     "Setting mode with with wrong type of value",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.mode.set", "thermostat")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Setting mode of non-existent thing",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "cmd.mode.set", "thermostat", "test_mode_a"),
+						Name:     "Setting mode of non-existent thing",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "cmd.mode.set", "thermostat", "test_mode_a")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "thermostat"),
 						},
 					},
 					{
-						Name:    "Controller error when setting setpoint",
-						Command: suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_a", "temp": "20.0", "unit": "C"}),
+						Name:     "Controller error when setting setpoint",
+						Commands: []*fimpgo.Message{suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_a", "temp": "20.0", "unit": "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Unsupported mode when setting setpoint",
-						Command: suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_c", "temp": "20.0", "unit": "C"}),
+						Name:     "Unsupported mode when setting setpoint",
+						Commands: []*fimpgo.Message{suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_c", "temp": "20.0", "unit": "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Missing unit when setting setpoint",
-						Command: suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_a", "temp": "20.0"}),
+						Name:     "Missing unit when setting setpoint",
+						Commands: []*fimpgo.Message{suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_a", "temp": "20.0"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Missing temperature when setting setpoint",
-						Command: suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_a", "unit": "C"}),
+						Name:     "Missing temperature when setting setpoint",
+						Commands: []*fimpgo.Message{suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_a", "unit": "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Missing mode when setting setpoint",
-						Command: suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"temp": "20.0", "unit": "C"}),
+						Name:     "Missing mode when setting setpoint",
+						Commands: []*fimpgo.Message{suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"temp": "20.0", "unit": "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Invalid temperature when setting setpoint",
-						Command: suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_a", "temp": "20C", "unit": "C"}),
+						Name:     "Invalid temperature when setting setpoint",
+						Commands: []*fimpgo.Message{suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_a", "temp": "20C", "unit": "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Setting setpoint with wrong type of value",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", "22"),
+						Name:     "Setting setpoint with wrong type of value",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "cmd.setpoint.set", "thermostat", "22")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:2", "thermostat"),
 						},
 					},
 					{
-						Name:    "Setting setpoint of non-existent thing",
-						Command: suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_a", "temp": "21.0", "unit": "C"}),
+						Name:     "Setting setpoint of non-existent thing",
+						Commands: []*fimpgo.Message{suite.StringMapMessage("pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "cmd.setpoint.set", "thermostat", map[string]string{"type": "test_mode_a", "temp": "21.0", "unit": "C"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:thermostat/ad:3", "thermostat"),
 						},

--- a/adapter/thing/thermostat_test.go
+++ b/adapter/thing/thermostat_test.go
@@ -563,7 +563,7 @@ func setupThermostat(
 
 	seed := &adapter.ThingSeed{ID: "B", CustomAddress: "2"}
 
-	factory := adapterhelper.FactoryHelper(func(adapter adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
+	factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, thingState adapter.ThingState) (adapter.Thing, error) {
 		return thing.NewThermostat(publisher, thingState, cfg), nil
 	})
 

--- a/config/routing_test.go
+++ b/config/routing_test.go
@@ -39,25 +39,25 @@ func TestHandleCmdLogGetLevel(t *testing.T) { //nolint:paralleltest
 	}{
 		{
 			name:       "happy path",
-			logSetter:  func(s string) error { return nil },
+			logSetter:  func(_ string) error { return nil },
 			msg:        makeCommand("string", "error"),
 			wantLogLvl: log.ErrorLevel,
 		},
 		{
 			name:      "error when checking payload value",
-			logSetter: func(s string) error { return nil },
+			logSetter: func(_ string) error { return nil },
 			msg:       makeCommand("bool", true),
 			wantErr:   true,
 		},
 		{
 			name:      "error when parsing log level",
-			logSetter: func(s string) error { return nil },
+			logSetter: func(_ string) error { return nil },
 			msg:       makeCommand("string", "dummy"),
 			wantErr:   true,
 		},
 		{
 			name:      "error when saving log level",
-			logSetter: func(s string) error { return errors.New("test error") },
+			logSetter: func(_ string) error { return errors.New("test error") },
 			msg:       makeCommand("string", "error"),
 			wantErr:   true,
 		},
@@ -92,7 +92,7 @@ func TestRouteConfig(t *testing.T) { //nolint:paralleltest
 		Cases: []*suite.Case{
 			{
 				Name: "Successful getter and setter",
-				Setup: suite.BaseSetup(func(t *testing.T, mqtt *fimpgo.MqttTransport) (routing []*router.Routing, tasks []*task.Task, mocks []suite.Mock) {
+				Setup: suite.BaseSetup(func(t *testing.T, _ *fimpgo.MqttTransport) (routing []*router.Routing, tasks []*task.Task, mocks []suite.Mock) {
 					t.Helper()
 
 					mDuration := newConfigMock[time.Duration]().mockGetter(time.Second).mockSetter(time.Minute, nil)
@@ -347,7 +347,7 @@ func TestRouteConfig(t *testing.T) { //nolint:paralleltest
 			},
 			{
 				Name: "Errors and edge cases",
-				Setup: suite.BaseSetup(func(t *testing.T, mqtt *fimpgo.MqttTransport) (routing []*router.Routing, tasks []*task.Task, mocks []suite.Mock) {
+				Setup: suite.BaseSetup(func(t *testing.T, _ *fimpgo.MqttTransport) (routing []*router.Routing, tasks []*task.Task, mocks []suite.Mock) {
 					t.Helper()
 
 					mDuration := newConfigMock[time.Duration]().mockSetter(time.Second, errors.New("test"))

--- a/config/routing_test.go
+++ b/config/routing_test.go
@@ -157,188 +157,188 @@ func TestRouteConfig(t *testing.T) { //nolint:paralleltest
 				}),
 				Nodes: []*suite.Node{
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_duration", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_duration", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_duration_report", "test_service", "1s"),
 						},
 					},
 					{
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_duration", "test_service", "1m"),
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_duration", "test_service", "1m")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_duration_report", "test_service", "1m"),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_string", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_string", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_string_report", "test_service", "abc"),
 						},
 					},
 					{
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_string", "test_service", "def"),
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_string", "test_service", "def")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_string_report", "test_service", "def"),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_bool", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_bool", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBool("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_bool_report", "test_service", true),
 						},
 					},
 					{
-						Command: suite.BoolMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_bool", "test_service", false),
+						Commands: []*fimpgo.Message{suite.BoolMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_bool", "test_service", false)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBool("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_bool_report", "test_service", false),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_int", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_int", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_int_report", "test_service", 1),
 						},
 					},
 					{
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_int", "test_service", 2),
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_int", "test_service", 2)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectInt("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_int_report", "test_service", 2),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_float", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_float", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_float_report", "test_service", 1),
 						},
 					},
 					{
-						Command: suite.FloatMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_float", "test_service", 2),
+						Commands: []*fimpgo.Message{suite.FloatMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_float", "test_service", 2)},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloat("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_float_report", "test_service", 2),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_string_map", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_string_map", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectStringMap("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_string_map_report", "test_service", map[string]string{"a": "b"}),
 						},
 					},
 					{
-						Command: suite.StringMapMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_string_map", "test_service", map[string]string{"c": "d"}),
+						Commands: []*fimpgo.Message{suite.StringMapMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_string_map", "test_service", map[string]string{"c": "d"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectStringMap("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_string_map_report", "test_service", map[string]string{"c": "d"}),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_bool_map", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_bool_map", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBoolMap("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_bool_map_report", "test_service", map[string]bool{"a": true}),
 						},
 					},
 					{
-						Command: suite.BoolMapMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_bool_map", "test_service", map[string]bool{"c": false}),
+						Commands: []*fimpgo.Message{suite.BoolMapMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_bool_map", "test_service", map[string]bool{"c": false})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBoolMap("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_bool_map_report", "test_service", map[string]bool{"c": false}),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_int_map", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_int_map", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectIntMap("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_int_map_report", "test_service", map[string]int64{"a": 1}),
 						},
 					},
 					{
-						Command: suite.IntMapMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_int_map", "test_service", map[string]int64{"c": 2}),
+						Commands: []*fimpgo.Message{suite.IntMapMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_int_map", "test_service", map[string]int64{"c": 2})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectIntMap("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_int_map_report", "test_service", map[string]int64{"c": 2}),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_float_map", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_float_map", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_float_map_report", "test_service", map[string]float64{"a": 1}),
 						},
 					},
 					{
-						Command: suite.FloatMapMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_float_map", "test_service", map[string]float64{"c": 2}),
+						Commands: []*fimpgo.Message{suite.FloatMapMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_float_map", "test_service", map[string]float64{"c": 2})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatMap("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_float_map_report", "test_service", map[string]float64{"c": 2}),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_string_array", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_string_array", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectStringArray("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_string_array_report", "test_service", []string{"b"}),
 						},
 					},
 					{
-						Command: suite.StringArrayMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_string_array", "test_service", []string{"d"}),
+						Commands: []*fimpgo.Message{suite.StringArrayMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_string_array", "test_service", []string{"d"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectStringArray("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_string_array_report", "test_service", []string{"d"}),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_bool_array", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_bool_array", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBoolArray("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_bool_array_report", "test_service", []bool{true}),
 						},
 					},
 					{
-						Command: suite.BoolArrayMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_bool_array", "test_service", []bool{false}),
+						Commands: []*fimpgo.Message{suite.BoolArrayMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_bool_array", "test_service", []bool{false})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectBoolArray("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_bool_array_report", "test_service", []bool{false}),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_int_array", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_int_array", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectIntArray("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_int_array_report", "test_service", []int64{1}),
 						},
 					},
 					{
-						Command: suite.IntArrayMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_int_array", "test_service", []int64{2}),
+						Commands: []*fimpgo.Message{suite.IntArrayMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_int_array", "test_service", []int64{2})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectIntArray("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_int_array_report", "test_service", []int64{2}),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_float_array", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_float_array", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatArray("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_float_array_report", "test_service", []float64{1}),
 						},
 					},
 					{
-						Command: suite.FloatArrayMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_float_array", "test_service", []float64{2}),
+						Commands: []*fimpgo.Message{suite.FloatArrayMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_float_array", "test_service", []float64{2})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectFloatArray("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_float_array_report", "test_service", []float64{2}),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_object", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_test_setting_object", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectObject("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_object_report", "test_service", &TestObject{A: "a"}),
 						},
 					},
 					{
-						Command: suite.ObjectMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_object", "test_service", &TestObject{A: "b"}),
+						Commands: []*fimpgo.Message{suite.ObjectMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_object", "test_service", &TestObject{A: "b"})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectObject("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_object_report", "test_service", &TestObject{A: "b"}),
 						},
 					},
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_report", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.get_report", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectObject("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.report", "test_service", &TestObject{A: "a"}),
 						},
 					},
 
 					{
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.log.get_level", "test_service"),
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.log.get_level", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.log.level_report", "test_service", "debug"),
 						},
 					},
 					{
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.log.set_level", "test_service", "info"),
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.log.set_level", "test_service", "info")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.log.level_report", "test_service", "info"),
 						},
@@ -366,36 +366,36 @@ func TestRouteConfig(t *testing.T) { //nolint:paralleltest
 				}),
 				Nodes: []*suite.Node{
 					{
-						Name:    "Invalid duration format",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_duration", "test_service", "invalid"),
+						Name:     "Invalid duration format",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_duration", "test_service", "invalid")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:app/rn:test/ad:1", "test_service"),
 						},
 					},
 					{
-						Name:    "Invalid value type",
-						Command: suite.IntMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_duration", "test_service", int64(time.Second)),
+						Name:     "Invalid value type",
+						Commands: []*fimpgo.Message{suite.IntMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_duration", "test_service", int64(time.Second))},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:app/rn:test/ad:1", "test_service"),
 						},
 					},
 					{
-						Name:    "Setter error",
-						Command: suite.StringMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_duration", "test_service", "1s"),
+						Name:     "Setter error",
+						Commands: []*fimpgo.Message{suite.StringMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_duration", "test_service", "1s")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:app/rn:test/ad:1", "test_service"),
 						},
 					},
 					{
-						Name:    "Unmarshalling error",
-						Command: suite.ObjectMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_object", "test_service", json.RawMessage(`{"a": 1}`)),
+						Name:     "Unmarshalling error",
+						Commands: []*fimpgo.Message{suite.ObjectMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_object", "test_service", json.RawMessage(`{"a": 1}`))},
 						Expectations: []*suite.Expectation{
 							suite.ExpectError("pt:j1/mt:evt/rt:app/rn:test/ad:1", "test_service"),
 						},
 					},
 					{
-						Name:    "Properly handle an empty slice",
-						Command: suite.IntArrayMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_int_array", "test_service", []int64{}),
+						Name:     "Properly handle an empty slice",
+						Commands: []*fimpgo.Message{suite.IntArrayMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.config.set_test_setting_int_array", "test_service", []int64{})},
 						Expectations: []*suite.Expectation{
 							suite.ExpectIntArray("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.config.test_setting_int_array_report", "test_service", []int64{}),
 						},

--- a/database/database.go
+++ b/database/database.go
@@ -250,7 +250,7 @@ func (d *database) Keys(bucket string) ([]string, error) {
 	var keys []string
 
 	err := d.db.View(func(tx *buntdb.Tx) error {
-		return tx.AscendKeys(fmt.Sprintf("%s:*", bucket), func(key, value string) bool {
+		return tx.AscendKeys(fmt.Sprintf("%s:*", bucket), func(key, _ string) bool {
 			keys = append(keys, key)
 
 			return true
@@ -275,7 +275,7 @@ func (d *database) KeysFrom(bucket, from string) ([]string, error) {
 	toString := fmt.Sprintf("%s:%s", bucket, string([]byte{255}))
 
 	err := d.db.View(func(tx *buntdb.Tx) error {
-		return tx.AscendRange("", fromString, toString, func(key, value string) bool {
+		return tx.AscendRange("", fromString, toString, func(key, _ string) bool {
 			keys = append(keys, key)
 
 			return true
@@ -300,7 +300,7 @@ func (d *database) KeysBetween(bucket, from, to string) ([]string, error) {
 	toString := fmt.Sprintf("%s:%s", bucket, to)
 
 	err := d.db.View(func(tx *buntdb.Tx) error {
-		return tx.AscendRange("", fromString, toString, func(key, value string) bool {
+		return tx.AscendRange("", fromString, toString, func(key, _ string) bool {
 			keys = append(keys, key)
 
 			return true

--- a/prime/client_test.go
+++ b/prime/client_test.go
@@ -561,6 +561,7 @@ func TestClient(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
 			client := prime.NewClient(tc.syncClientMock, "test", 5*time.Second)
 
 			got, err := tc.call(client)

--- a/prime/observer/observer_test.go
+++ b/prime/observer/observer_test.go
@@ -69,11 +69,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "add new device",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentDevice,
 							ParamRaw:  json.RawMessage(`{"id":2}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForDeviceChange()))
@@ -87,11 +87,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "add existing device",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentDevice,
 							ParamRaw:  json.RawMessage(`{"id":2}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForDeviceChange()))
@@ -105,11 +105,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Edit existing device",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdEdit,
 							Component: prime.ComponentDevice,
 							ParamRaw:  json.RawMessage(`{"id":2}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForDeviceChange()))
@@ -123,11 +123,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Edit new device",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdEdit,
 							Component: prime.ComponentDevice,
 							ParamRaw:  json.RawMessage(`{"id":3}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForDeviceChange()))
@@ -141,11 +141,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Delete device",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdDelete,
 							Component: prime.ComponentDevice,
 							ID:        3,
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForDeviceChange()))
@@ -159,11 +159,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "add new thing",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentThing,
 							ParamRaw:  json.RawMessage(`{"id":2}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForThingChange()))
@@ -177,11 +177,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "add existing thing",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentThing,
 							ParamRaw:  json.RawMessage(`{"id":2}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForThingChange()))
@@ -195,11 +195,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Edit existing thing",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdEdit,
 							Component: prime.ComponentThing,
 							ParamRaw:  json.RawMessage(`{"id":2}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForThingChange()))
@@ -213,11 +213,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Edit new thing",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdEdit,
 							Component: prime.ComponentThing,
 							ParamRaw:  json.RawMessage(`{"id":3}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForThingChange()))
@@ -231,11 +231,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Delete thing",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdDelete,
 							Component: prime.ComponentThing,
 							ID:        3,
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForThingChange()))
@@ -249,11 +249,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "add new room",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentRoom,
 							ParamRaw:  json.RawMessage(`{"id":2}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForRoomChange()))
@@ -267,11 +267,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "add existing room",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentRoom,
 							ParamRaw:  json.RawMessage(`{"id":2}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForRoomChange()))
@@ -285,11 +285,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Edit existing room",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdEdit,
 							Component: prime.ComponentRoom,
 							ParamRaw:  json.RawMessage(`{"id":2}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForRoomChange()))
@@ -303,11 +303,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Edit new room",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdEdit,
 							Component: prime.ComponentRoom,
 							ParamRaw:  json.RawMessage(`{"id":3}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForRoomChange()))
@@ -321,11 +321,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Delete room",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdDelete,
 							Component: prime.ComponentRoom,
 							ID:        3,
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForRoomChange()))
@@ -339,11 +339,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Added new area",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentArea,
 							ParamRaw:  json.RawMessage(`{"id":2}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForAreaChange()))
@@ -357,11 +357,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "add existing area",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentArea,
 							ParamRaw:  json.RawMessage(`{"id":2}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForAreaChange()))
@@ -375,11 +375,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Edit existing area",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdEdit,
 							Component: prime.ComponentArea,
 							ParamRaw:  json.RawMessage(`{"id":2}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForAreaChange()))
@@ -393,11 +393,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Edit new area",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdEdit,
 							Component: prime.ComponentArea,
 							ParamRaw:  json.RawMessage(`{"id":3}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForAreaChange()))
@@ -411,11 +411,11 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 					},
 					{
 						Name: "Delete area",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdDelete,
 							Component: prime.ComponentArea,
 							ID:        3,
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								assert.NotNil(t, <-testEventManager.WaitFor(time.Second, observer.WaitForAreaChange()))
@@ -428,112 +428,112 @@ func TestObserver(t *testing.T) { //nolint:paralleltest
 						},
 					},
 					{
-						Name:    "Corrupted notification",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, json.RawMessage(`{"cmd":1}`)),
+						Name:     "Corrupted notification",
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, json.RawMessage(`{"cmd":1}`))},
 					},
 					{
 						Name: "Unobserved notification",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdSet,
 							Component: prime.ComponentState,
 							ID:        1,
-						}),
+						})},
 					},
 					{
 						Name: "Failed add new device",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentDevice,
 							ParamRaw:  json.RawMessage(`{"id":"2"}`),
-						}),
+						})},
 					},
 					{
 						Name: "Failed edit device",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdEdit,
 							Component: prime.ComponentDevice,
 							ParamRaw:  json.RawMessage(`{"id":"2"}`),
-						}),
+						})},
 					},
 					{
 						Name: "Failed delete device",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdDelete,
 							Component: prime.ComponentDevice,
 							ID:        "A",
-						}),
+						})},
 					},
 					{
 						Name: "Failed add new thing",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentThing,
 							ParamRaw:  json.RawMessage(`{"id":"2"}`),
-						}),
+						})},
 					},
 					{
 						Name: "Failed edit thing",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdEdit,
 							Component: prime.ComponentThing,
 							ParamRaw:  json.RawMessage(`{"id":"2"}`),
-						}),
+						})},
 					},
 					{
 						Name: "Failed delete thing",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdDelete,
 							Component: prime.ComponentThing,
 							ID:        "a",
-						}),
+						})},
 					},
 					{
 						Name: "Failed add new room",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentRoom,
 							ParamRaw:  json.RawMessage(`{"id":"2"}`),
-						}),
+						})},
 					},
 					{
 						Name: "Failed edit room",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdEdit,
 							Component: prime.ComponentRoom,
 							ParamRaw:  json.RawMessage(`{"id":"2"}`),
-						}),
+						})},
 					},
 					{
 						Name: "Failed delete room",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdDelete,
 							Component: prime.ComponentRoom,
 							ID:        "A",
-						}),
+						})},
 					},
 					{
 						Name: "Failed add new area",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentArea,
 							ParamRaw:  json.RawMessage(`{"id":"2"}`),
-						}),
+						})},
 					},
 					{
 						Name: "Failed edit area",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdEdit,
 							Component: prime.ComponentArea,
 							ParamRaw:  json.RawMessage(`{"id":"2"}`),
-						}),
+						})},
 					},
 					{
 						Name: "Failed delete area",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdDelete,
 							Component: prime.ComponentArea,
 							ID:        "A",
-						}),
+						})},
 					},
 					suite.SleepNode(50 * time.Millisecond), // sleeping to allow observer to process all incoming messages
 					{
@@ -656,11 +656,11 @@ func TestObserver_AddOrEdit_NoComponentsAtStartup(t *testing.T) { //nolint:paral
 					suite.SleepNode(5 * time.Millisecond),
 					{
 						Name: "add new device",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentDevice,
 							ParamRaw:  json.RawMessage(`{"id":1}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								time.Sleep(30 * time.Millisecond)
@@ -670,11 +670,11 @@ func TestObserver_AddOrEdit_NoComponentsAtStartup(t *testing.T) { //nolint:paral
 					},
 					{
 						Name: "add new thing",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentThing,
 							ParamRaw:  json.RawMessage(`{"id":1}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								time.Sleep(30 * time.Millisecond)
@@ -684,11 +684,11 @@ func TestObserver_AddOrEdit_NoComponentsAtStartup(t *testing.T) { //nolint:paral
 					},
 					{
 						Name: "add new room",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentRoom,
 							ParamRaw:  json.RawMessage(`{"id":1}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								time.Sleep(30 * time.Millisecond)
@@ -698,11 +698,11 @@ func TestObserver_AddOrEdit_NoComponentsAtStartup(t *testing.T) { //nolint:paral
 					},
 					{
 						Name: "add new area",
-						Command: suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
+						Commands: []*fimpgo.Message{suite.ObjectMessage(prime.NotifyTopic, prime.EvtPD7Notify, prime.ServiceName, &prime.Notify{
 							Cmd:       prime.CmdAdd,
 							Component: prime.ComponentArea,
 							ParamRaw:  json.RawMessage(`{"id":1}`),
-						}),
+						})},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								time.Sleep(30 * time.Millisecond)

--- a/root/app_test.go
+++ b/root/app_test.go
@@ -95,6 +95,7 @@ func TestApp_Run(t *testing.T) { //nolint:paralleltest
 
 			go func() {
 				time.Sleep(100 * time.Millisecond)
+
 				if tc.triggerStop {
 					_ = app.Stop()
 				}

--- a/root/app_test.go
+++ b/root/app_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/futurehomeno/fimpgo"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/futurehomeno/cliffhanger/discovery"
@@ -140,7 +141,7 @@ func TestApp_Reset(t *testing.T) { //nolint:paralleltest
 				}),
 				Nodes: []*suite.Node{
 					{
-						Command: suite.NullMessage(root.GatewayEvtTopic, root.EvtGatewayFactoryReset, "gateway"),
+						Commands: []*fimpgo.Message{suite.NullMessage(root.GatewayEvtTopic, root.EvtGatewayFactoryReset, "gateway")},
 						Callbacks: []suite.Callback{
 							func(t *testing.T) {
 								t.Helper()

--- a/root/routing.go
+++ b/root/routing.go
@@ -25,7 +25,7 @@ func routeFactoryReset(rootApp App) *router.Routing {
 // handleFactoryReset handles factory reset event.
 func handleFactoryReset(rootApp App) router.MessageHandler {
 	return router.NewMessageHandler(
-		router.MessageProcessorFn(func(message *fimpgo.Message) (*fimpgo.FimpMessage, error) {
+		router.MessageProcessorFn(func(_ *fimpgo.Message) (*fimpgo.FimpMessage, error) {
 			// Factory reset requires stopping the application first, which includes stopping the message router.
 			// In order to avoid a deadlock we need to run the reset in a separate goroutine, so the message router can be stopped.
 			go func() {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -16,7 +16,7 @@ import (
 func Test_Router(t *testing.T) { //nolint:paralleltest
 	panicRouting := router.NewRouting(router.NewMessageHandler(
 		router.MessageProcessorFn(
-			func(message *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
+			func(_ *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
 				panic("test panic")
 			})),
 		router.ForService("test_service"),
@@ -360,7 +360,7 @@ func Test_Router_PanicCallback(t *testing.T) { //nolint:paralleltest
 				Routing: []*router.Routing{
 					router.NewRouting(router.NewMessageHandler(
 						router.MessageProcessorFn(
-							func(message *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
+							func(_ *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
 								panic("oops")
 							})),
 						router.ForService("test_service"),
@@ -395,7 +395,7 @@ func Test_Router_PanicCallback(t *testing.T) { //nolint:paralleltest
 				Routing: []*router.Routing{
 					router.NewRouting(router.NewMessageHandler(
 						router.MessageProcessorFn(
-							func(message *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
+							func(_ *fimpgo.Message) (_ *fimpgo.FimpMessage, err error) {
 								return nil, nil
 							})),
 						router.ForService("test_service"),
@@ -456,7 +456,7 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 				Routing: []*router.Routing{
 					router.NewRouting(router.NewMessageHandler(
 						router.MessageProcessorFn(
-							func(message *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
+							func(_ *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
 								return nil, nil
 							})),
 						router.ForService("test_service"),
@@ -496,7 +496,7 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 				Routing: []*router.Routing{
 					router.NewRouting(router.NewMessageHandler(
 						router.MessageProcessorFn(
-							func(message *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
+							func(_ *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
 								return fimpgo.NewStringMessage("evt.test.test_response", "test_service", "test", nil, nil, nil), nil
 							})),
 						router.ForService("test_service"),
@@ -538,7 +538,7 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 				Routing: []*router.Routing{
 					router.NewRouting(router.NewMessageHandler(
 						router.MessageProcessorFn(
-							func(message *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
+							func(_ *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
 								panic("oops")
 							})),
 						router.ForService("test_service"),

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -29,8 +29,8 @@ func Test_Router(t *testing.T) { //nolint:paralleltest
 				Routing: []*router.Routing{panicRouting},
 				Nodes: []*suite.Node{
 					{
-						Name:    "Send command raising panic",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service"),
+						Name:     "Send command raising panic",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.test.test_event", "test_service", "test_value").Never(),
 						},
@@ -94,12 +94,12 @@ func Test_Router_Concurrency(t *testing.T) { //nolint:paralleltest
 						Timeout: 1 * time.Nanosecond,
 					},
 					{
-						Name:    "Send command 1",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_1", "test_service"),
+						Name:     "Send command 1",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_1", "test_service")},
 					},
 					{
-						Name:    "Send command 2",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_2", "test_service"),
+						Name:     "Send command 2",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_2", "test_service")},
 					},
 					{
 						Name: "Check commands",
@@ -147,12 +147,12 @@ func Test_Router_Concurrency(t *testing.T) { //nolint:paralleltest
 						Timeout: 1 * time.Nanosecond,
 					},
 					{
-						Name:    "Send command 1",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_1", "test_service"),
+						Name:     "Send command 1",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_1", "test_service")},
 					},
 					{
-						Name:    "Send command 2",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_2", "test_service"),
+						Name:     "Send command 2",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_2", "test_service")},
 					},
 					{
 						Name: "Check commands",
@@ -199,13 +199,13 @@ func Test_Router_Concurrency(t *testing.T) { //nolint:paralleltest
 						Timeout: 1 * time.Nanosecond,
 					},
 					{
-						Name:    "Send command 1",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_1", "test_service"),
+						Name:     "Send command 1",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_1", "test_service")},
 					},
 					suite.SleepNode(50 * time.Millisecond),
 					{
-						Name:    "Send command 2",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_2", "test_service"),
+						Name:     "Send command 2",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command_2", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.test.test_event", "test_service", "cmd.test.test_command_1"),
 							suite.ExpectError("pt:j1/mt:evt/rt:app/rn:test/ad:1", "test_service"),
@@ -266,16 +266,16 @@ func Test_Router_OptionalSuccessConfirmation(t *testing.T) { //nolint:parallelte
 				},
 				Nodes: []*suite.Node{
 					{
-						Name:    "Message processor returns nil - send success confirmation",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.confirm1", "test_service"),
+						Name:     "Message processor returns nil - send success confirmation",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.confirm1", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectNull("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.success.report", "test_service").ExactlyOnce(),
 						},
 						Timeout: timeout,
 					},
 					{
-						Name:    "Message processor returns a message - do not send success confirmation",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.confirm2", "test_service"),
+						Name:     "Message processor returns a message - do not send success confirmation",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.confirm2", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectNull("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.success.report", "test_service").Never(),
 							suite.ExpectString("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.test.test_event", "test_service", "test").ExactlyOnce(),
@@ -283,8 +283,8 @@ func Test_Router_OptionalSuccessConfirmation(t *testing.T) { //nolint:parallelte
 						Timeout: timeout,
 					},
 					{
-						Name:    "Error returned by processor cannot trigger success confirmation",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.confirm3", "test_service"),
+						Name:     "Error returned by processor cannot trigger success confirmation",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.confirm3", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectNull("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.success.report", "test_service").Never(),
 							suite.ExpectError("pt:j1/mt:evt/rt:app/rn:test/ad:1", "test_service").ExactlyOnce(),
@@ -302,16 +302,16 @@ func Test_Router_OptionalSuccessConfirmation(t *testing.T) { //nolint:parallelte
 				},
 				Nodes: []*suite.Node{
 					{
-						Name:    "Message processor returns nil - do not send success confirmation",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.do_not_confirm1", "test_service"),
+						Name:     "Message processor returns nil - do not send success confirmation",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.do_not_confirm1", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectNull("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.success.report", "test_service").Never(),
 						},
 						Timeout: timeout,
 					},
 					{
-						Name:    "Message processor returns a message - do not send success confirmation",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.do_not_confirm2", "test_service"),
+						Name:     "Message processor returns a message - do not send success confirmation",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.do_not_confirm2", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectNull("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.success.report", "test_service").Never(),
 							suite.ExpectString("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.test.test_event", "test_service", "test").ExactlyOnce(),
@@ -319,8 +319,8 @@ func Test_Router_OptionalSuccessConfirmation(t *testing.T) { //nolint:parallelte
 						Timeout: timeout,
 					},
 					{
-						Name:    "Error returned by processor cannot trigger success confirmation",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.do_not_confirm3", "test_service"),
+						Name:     "Error returned by processor cannot trigger success confirmation",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.do_not_confirm3", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectNull("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.success.report", "test_service").Never(),
 							suite.ExpectError("pt:j1/mt:evt/rt:app/rn:test/ad:1", "test_service").ExactlyOnce(),
@@ -371,9 +371,9 @@ func Test_Router_PanicCallback(t *testing.T) { //nolint:paralleltest
 				},
 				Nodes: []*suite.Node{
 					{
-						Name:    "send a command raising panic",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service"),
-						Timeout: -1,
+						Name:     "send a command raising panic",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service")},
+						Timeout:  -1,
 					},
 					suite.SleepNode(50 * time.Millisecond),
 					{
@@ -406,9 +406,9 @@ func Test_Router_PanicCallback(t *testing.T) { //nolint:paralleltest
 				},
 				Nodes: []*suite.Node{
 					{
-						Name:    "send a command not raising panic",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service"),
-						Timeout: -1,
+						Name:     "send a command not raising panic",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service")},
+						Timeout:  -1,
 					},
 					suite.SleepNode(50 * time.Millisecond),
 					{
@@ -468,9 +468,9 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 				},
 				Nodes: []*suite.Node{
 					{
-						Name:    "send a command that should be processed",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service"),
-						Timeout: -1,
+						Name:     "send a command that should be processed",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service")},
+						Timeout:  -1,
 					},
 					suite.SleepNode(50 * time.Millisecond),
 					{
@@ -508,9 +508,9 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 				},
 				Nodes: []*suite.Node{
 					{
-						Name:    "send a command that should be processed",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service"),
-						Timeout: -1,
+						Name:     "send a command that should be processed",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service")},
+						Timeout:  -1,
 					},
 					suite.SleepNode(50 * time.Millisecond),
 					{
@@ -550,9 +550,9 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 				},
 				Nodes: []*suite.Node{
 					{
-						Name:    "send a command that should be processed",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service"),
-						Timeout: -1,
+						Name:     "send a command that should be processed",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service")},
+						Timeout:  -1,
 					},
 					suite.SleepNode(50 * time.Millisecond),
 					{

--- a/security/encryption.go
+++ b/security/encryption.go
@@ -59,7 +59,6 @@ func writeKeyFile(path string) (newKey string, err error) {
 	}
 
 	_, err = f.WriteString(key)
-
 	if err != nil {
 		return "", fmt.Errorf("security: could not write string to key file: %w", err)
 	}

--- a/task/manager_test.go
+++ b/task/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/futurehomeno/fimpgo"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/futurehomeno/cliffhanger/task"
@@ -147,8 +148,8 @@ func TestManager(t *testing.T) {
 				Tasks: []*task.Task{task.New(func() { panic("test panic 1") }, 0)},
 				Nodes: []*suite.Node{
 					{
-						Name:    "Execute task raising panic",
-						Command: suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service"),
+						Name:     "Execute task raising panic",
+						Commands: []*fimpgo.Message{suite.NullMessage("pt:j1/mt:cmd/rt:app/rn:test/ad:1", "cmd.test.test_command", "test_service")},
 						Expectations: []*suite.Expectation{
 							suite.ExpectString("pt:j1/mt:evt/rt:app/rn:test/ad:1", "evt.test.test_event", "test_service", "test_value").Never(),
 						},


### PR DESCRIPTION
Regex for changes which should cover most cases:

Command: (.*),
Commands: []*fimpgo.Message{$1},

Command: suite.NewMessageBuilder\(\)((.|\n)*?)Build\(\),
Commands: []*fimpgo.Message{suite.NewMessageBuilder\(\)$1Build()},