### PR TITLE
Test router: "The closest messages I have are"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ before_script:
 
 script:
   - golangci-lint run ./... --timeout 2m
-  - go test -p 1 -v -covermode=atomic -coverprofile=profile_full.cov -coverpkg=./... ./...
+  - go test -p 1 -v -race -covermode=atomic -coverprofile=profile_full.cov -coverpkg=./... ./...
   - cat profile_full.cov | grep -v .pb.go | grep -v mock | grep -v test > profile.cov;
   - goveralls -coverprofile=profile.cov -service=travis-pro -repotoken B8NnLqJBg7cuw4oChepQJNnyZ9Tcg5Izy || true

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -431,35 +431,13 @@ func Test_Router_PanicCallback(t *testing.T) { //nolint:paralleltest
 }
 
 func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
-	var (
-		mu             sync.Mutex
-		callbackCalled bool
-		stats          router.Stats
-	)
-
-	tearDownFn := func(t *testing.T) {
-		t.Helper()
-
-		mu.Lock()
-		defer mu.Unlock()
-
-		callbackCalled = false
-		stats = router.Stats{}
-	}
-
-	callbackFn := func(s router.Stats) {
-		mu.Lock()
-		defer mu.Unlock()
-
-		callbackCalled = true
-		stats = s
-	}
+	helper := newStatsTestHelper(t)
 
 	s := &suite.Suite{
 		Cases: []*suite.Case{
 			{
 				Name:     "processing stats without a response",
-				TearDown: []suite.Callback{tearDownFn},
+				TearDown: []suite.Callback{helper.tearDownFn()},
 				Routing: []*router.Routing{
 					router.NewRouting(router.NewMessageHandler(
 						router.MessageProcessorFn(
@@ -471,7 +449,7 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 					),
 				},
 				RouterOptions: []router.Option{
-					router.WithStatsCallback(callbackFn),
+					router.WithStatsCallback(helper.statsCallback()),
 				},
 				Nodes: []*suite.Node{
 					{
@@ -487,9 +465,9 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 							func(t *testing.T) {
 								t.Helper()
 
-								mu.Lock()
-								assert.True(t, callbackCalled)
-								mu.Unlock()
+								assert.True(t, helper.callbackCalled())
+
+								stats := helper.getStats()
 
 								assert.Equal(t, "cmd.test.test_command", stats.InputMessage.Payload.Type)
 								assert.Equal(t, "test_service", stats.InputMessage.Payload.Service)
@@ -502,7 +480,7 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 			},
 			{
 				Name:     "processing stats with a response",
-				TearDown: []suite.Callback{tearDownFn},
+				TearDown: []suite.Callback{helper.tearDownFn()},
 				Routing: []*router.Routing{
 					router.NewRouting(router.NewMessageHandler(
 						router.MessageProcessorFn(
@@ -514,7 +492,7 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 					),
 				},
 				RouterOptions: []router.Option{
-					router.WithStatsCallback(callbackFn),
+					router.WithStatsCallback(helper.statsCallback()),
 				},
 				Nodes: []*suite.Node{
 					{
@@ -530,9 +508,9 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 							func(t *testing.T) {
 								t.Helper()
 
-								mu.Lock()
-								assert.True(t, callbackCalled)
-								mu.Unlock()
+								assert.True(t, helper.callbackCalled())
+
+								stats := helper.getStats()
 
 								assert.Equal(t, "cmd.test.test_command", stats.InputMessage.Payload.Type)
 								assert.Equal(t, "test_service", stats.InputMessage.Payload.Service)
@@ -547,7 +525,7 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 			},
 			{
 				Name:     "panic should not make stats callback fired",
-				TearDown: []suite.Callback{tearDownFn},
+				TearDown: []suite.Callback{helper.tearDownFn()},
 				Routing: []*router.Routing{
 					router.NewRouting(router.NewMessageHandler(
 						router.MessageProcessorFn(
@@ -559,7 +537,7 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 					),
 				},
 				RouterOptions: []router.Option{
-					router.WithStatsCallback(callbackFn),
+					router.WithStatsCallback(helper.statsCallback()),
 				},
 				Nodes: []*suite.Node{
 					{
@@ -575,9 +553,7 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 							func(t *testing.T) {
 								t.Helper()
 
-								mu.Lock()
-								assert.False(t, callbackCalled)
-								mu.Unlock()
+								assert.False(t, helper.called)
 							},
 						},
 					},
@@ -587,4 +563,52 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 	}
 
 	s.Run(t)
+}
+
+type statsTestHelper struct {
+	mu     sync.RWMutex
+	called bool
+	stats  router.Stats
+}
+
+func newStatsTestHelper(t *testing.T) *statsTestHelper {
+	t.Helper()
+
+	return &statsTestHelper{}
+}
+
+func (h *statsTestHelper) callbackCalled() bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return h.called
+}
+
+func (h *statsTestHelper) getStats() router.Stats {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return h.stats
+}
+
+func (h *statsTestHelper) statsCallback() func(router.Stats) {
+	return func(s router.Stats) {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+
+		h.called = true
+		h.stats = s
+	}
+}
+
+func (h *statsTestHelper) tearDownFn() func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+
+		h.mu.Lock()
+		defer h.mu.Unlock()
+
+		h.called = false
+		h.stats = router.Stats{}
+	}
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -432,6 +432,7 @@ func Test_Router_PanicCallback(t *testing.T) { //nolint:paralleltest
 
 func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 	var (
+		mu             sync.Mutex
 		callbackCalled bool
 		stats          router.Stats
 	)
@@ -439,11 +440,17 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 	tearDownFn := func(t *testing.T) {
 		t.Helper()
 
+		mu.Lock()
+		defer mu.Unlock()
+
 		callbackCalled = false
 		stats = router.Stats{}
 	}
 
 	callbackFn := func(s router.Stats) {
+		mu.Lock()
+		defer mu.Unlock()
+
 		callbackCalled = true
 		stats = s
 	}
@@ -480,7 +487,10 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 							func(t *testing.T) {
 								t.Helper()
 
+								mu.Lock()
 								assert.True(t, callbackCalled)
+								mu.Unlock()
+
 								assert.Equal(t, "cmd.test.test_command", stats.InputMessage.Payload.Type)
 								assert.Equal(t, "test_service", stats.InputMessage.Payload.Service)
 								assert.Nil(t, stats.OutputMessage)
@@ -520,7 +530,10 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 							func(t *testing.T) {
 								t.Helper()
 
+								mu.Lock()
 								assert.True(t, callbackCalled)
+								mu.Unlock()
+
 								assert.Equal(t, "cmd.test.test_command", stats.InputMessage.Payload.Type)
 								assert.Equal(t, "test_service", stats.InputMessage.Payload.Service)
 								assert.Equal(t, "evt.test.test_response", stats.OutputMessage.Payload.Type)
@@ -562,7 +575,9 @@ func Test_Router_StatsCallback(t *testing.T) { //nolint:paralleltest
 							func(t *testing.T) {
 								t.Helper()
 
+								mu.Lock()
 								assert.False(t, callbackCalled)
+								mu.Unlock()
 							},
 						},
 					},

--- a/test/suite/expectation.go
+++ b/test/suite/expectation.go
@@ -459,14 +459,20 @@ func (e *Expectation) Never() *Expectation {
 	return e
 }
 
-func (e *Expectation) vote(message *fimpgo.Message) bool {
+func (e *Expectation) vote(message *fimpgo.Message) (voted bool, votesCount int) {
+	voted = true
+
 	for _, v := range e.Voters {
 		if !v.Vote(message) {
-			return false
+			voted = false
+
+			continue
 		}
+
+		votesCount++
 	}
 
-	return true
+	return
 }
 
 func (e *Expectation) assert() bool {

--- a/test/suite/router.go
+++ b/test/suite/router.go
@@ -40,10 +40,6 @@ func NewTestRouter(t *testing.T, mqtt *fimpgo.MqttTransport) *Router {
 
 	channelID := "test-router-" + uuid.New().String()
 	r.router = router.NewRouter(mqtt, channelID, r.expectationsRouting())
-	//WithOptions(
-	//	router.WithAsyncProcessing(5),
-	//	router.WithMessageBuffer(20),
-	//)
 
 	return r
 }
@@ -155,7 +151,7 @@ func (r *Router) failedExpectationsMessage() string {
 		sb.WriteString(fmt.Sprintf("Expectation #%d, occurrence: %s, called times: %d\n", i, e.Occurrence, e.called))
 
 		r.registryMu.RLock()
-		item, ok := r.messageRegistry[e]
+		bucket, ok := r.messageRegistry[e]
 		r.registryMu.RUnlock()
 
 		if !ok {
@@ -164,7 +160,7 @@ func (r *Router) failedExpectationsMessage() string {
 
 		sb.WriteString("\nThe closest messages I have are:\n")
 
-		for _, m := range item.messages {
+		for _, m := range bucket.messages {
 			sb.WriteString(fmt.Sprintf("\nTopic: %s\n", getMessageTopic(r.t, m)))
 
 			b, err := m.Payload.SerializeToJson()


### PR DESCRIPTION
This PR introduces an enhancement to the test router by bringing a broader context to failed tests. If an expectation fails, the router will try to match the "closest" messages it encountered and pretty-print them to stdout. This is a similar behavior to `vectra/mockery` package. The algorithm is based on the number of votes per expectation - the messages with a highest number of votes are selected.

Once the test fails, a developer should see something like this:
```
    router_test.go:80: Test router: some expectations have not been met:
        ---------------------------------------------------------------------------
        Expectation #0, occurrence: at least once, called times: 0
        
        The closest messages I have are:
        
        Topic: pt:j1/mt:cmd/rt:dev/rn:test/ad:1/sv:out_bin_switch/ad:1_0
        {
          "type": "cmd.binary.set",
          "serv": "out_bin_switch",
          "val_t": "object",
          "val": {
            "foo": "foo",
            "bar": 42
          },
          "tags": null,
          "props": null,
          "ver": "1",
          "corid": "",
          "ctime": "2024-07-03T09:50:39.911+02:00",
          "uid": "2feb61ed-c777-46b7-98bc-3322cdc9e63c"
        }
        
        Topic: pt:j1/mt:cmd/rt:dev/rn:test/ad:1/sv:out_bin_switch/ad:1_0
        {
          "type": "cmd.binary.set",
          "serv": "out_bin_switch_invalid",
          "val_t": "bool",
          "val": false,
          "tags": null,
          "props": null,
          "ver": "1",
          "corid": "",
          "ctime": "2024-07-03T09:50:39.911+02:00",
          "uid": "5ea9e9e9-7837-4ebe-bcfb-499faba1e115"
        }
        
    --- FAIL: TestRouterTestSuite/TestRouter (0.06s)
```