### PR TITLE
feat: add optional custom headers to ProxyClientConfig

### DIFF
--- a/auth/client.go
+++ b/auth/client.go
@@ -22,6 +22,7 @@ type ProxyClientConfig struct {
 	Retry       int
 	RetryDelay  time.Duration
 	Timeout     time.Duration
+	Headers     map[string]string
 }
 
 // setDefaults sets default configuration for a authentication proxy client.
@@ -89,6 +90,10 @@ func (c *proxyClient) getToken(request any, url string) (*OAuth2TokenResponse, e
 
 	r.Header.Add("Content-Type", "application/json")
 	r.Header.Add("Authorization", "Bearer "+c.cfg.Token)
+
+	for k, v := range c.cfg.Headers {
+		r.Header.Add(k, v)
+	}
 
 	for i := 0; i <= c.cfg.Retry; i++ {
 		var response *OAuth2TokenResponse

--- a/auth/client.go
+++ b/auth/client.go
@@ -48,8 +48,16 @@ type ProxyClient interface {
 func NewProxyClient(cfg *ProxyClientConfig) ProxyClient {
 	cfg.setDefaults()
 
+	headers := make(map[string]string, len(cfg.Headers))
+	for k, v := range cfg.Headers {
+		headers[k] = v
+	}
+
+	cfgCopy := *cfg
+	cfgCopy.Headers = headers
+
 	return &proxyClient{
-		cfg: cfg,
+		cfg: &cfgCopy,
 		client: &http.Client{
 			Timeout: cfg.Timeout,
 		},
@@ -92,6 +100,10 @@ func (c *proxyClient) getToken(request any, url string) (*OAuth2TokenResponse, e
 	r.Header.Add("Authorization", "Bearer "+c.cfg.Token)
 
 	for k, v := range c.cfg.Headers {
+		if http.CanonicalHeaderKey(k) == "Authorization" || http.CanonicalHeaderKey(k) == "Content-Type" {
+			continue
+		}
+
 		r.Header.Add(k, v)
 	}
 


### PR DESCRIPTION
## Summary
- Adds an optional `Headers` field to `ProxyClientConfig` for sending custom HTTP headers with auth proxy requests
- Fully backward-compatible: existing adapters that don't set `Headers` are unaffected

## Motivation
Allows edge adapters to send version info (e.g. `X-Adapter-Version`) with token refresh requests, enabling kraken-control to identify and filter requests by adapter version.

## Test plan
- [ ] Verify existing adapters build without changes
- [ ] Verify adapters setting `Headers` send them on auth-code and refresh requests