### PR TITLE
refactor: atomic Store interface for telemetry

### DIFF
--- a/telemetry/store.go
+++ b/telemetry/store.go
@@ -19,6 +19,9 @@ type State struct {
 // the reporter was last enabled at, and the validity window all survive
 // application restarts. Consumer applications implement this against their
 // own configuration storage.
+//
+// Implementations do not need to be thread-safe: the telemetry reporter
+// serializes all Load/Save calls under its own mutex.
 type Store interface {
 	// Load returns the current persisted state.
 	Load() State

--- a/telemetry/store.go
+++ b/telemetry/store.go
@@ -7,22 +7,28 @@ import (
 	"github.com/futurehomeno/cliffhanger/config"
 )
 
+// State is the persisted telemetry configuration. All fields are written
+// atomically by Store.Save so partial-update failures cannot occur.
+type State struct {
+	Enabled   bool
+	EnabledAt time.Time
+	Validity  time.Duration
+}
+
 // Store persists telemetry configuration so the enabled flag, the timestamp
 // the reporter was last enabled at, and the validity window all survive
 // application restarts. Consumer applications implement this against their
 // own configuration storage.
 type Store interface {
-	Enabled() bool
-	SetEnabled(enabled bool) error
-	EnabledAt() time.Time
-	SetEnabledAt(t time.Time) error
-	Validity() time.Duration
-	SetValidity(validity time.Duration) error
+	// Load returns the current persisted state.
+	Load() State
+	// Save atomically persists the full state.
+	Save(State) error
 }
 
 // NewDefaultStore adapts a config.Default-backed persistence layer to the
 // Store interface. The accessor must return a pointer to the embedded Default
-// block; save persists any field mutation to disk.
+// block; save persists the entire config to disk.
 func NewDefaultStore(accessor func() *config.Default, save func() error) Store {
 	return &defaultStore{accessor: accessor, save: save}
 }
@@ -32,125 +38,79 @@ type defaultStore struct {
 	save     func() error
 }
 
-func (s *defaultStore) Enabled() bool {
-	v := s.accessor().TelemetryEnabled
-	if v == nil {
-		return true
-	}
+func (s *defaultStore) Load() State {
+	cfg := s.accessor()
 
-	return *v
-}
+	var st State
 
-func (s *defaultStore) SetEnabled(enabled bool) error {
-	v := enabled
-	s.accessor().TelemetryEnabled = &v
-
-	return s.save()
-}
-
-func (s *defaultStore) EnabledAt() time.Time {
-	raw := s.accessor().TelemetryEnabledAt
-	if raw == "" {
-		return time.Time{}
-	}
-
-	t, err := time.Parse(time.RFC3339Nano, raw)
-	if err != nil {
-		return time.Time{}
-	}
-
-	return t
-}
-
-func (s *defaultStore) SetEnabledAt(t time.Time) error {
-	if t.IsZero() {
-		s.accessor().TelemetryEnabledAt = ""
+	if cfg.TelemetryEnabled == nil {
+		st.Enabled = true
 	} else {
-		s.accessor().TelemetryEnabledAt = t.UTC().Format(time.RFC3339Nano)
+		st.Enabled = *cfg.TelemetryEnabled
 	}
 
-	return s.save()
+	if cfg.TelemetryEnabledAt != "" {
+		if t, err := time.Parse(time.RFC3339Nano, cfg.TelemetryEnabledAt); err == nil {
+			st.EnabledAt = t
+		}
+	}
+
+	if cfg.TelemetryValidity != "" {
+		if d, err := time.ParseDuration(cfg.TelemetryValidity); err == nil && d > 0 {
+			st.Validity = d
+		}
+	}
+
+	if st.Validity <= 0 {
+		st.Validity = DefaultValidity
+	}
+
+	return st
 }
 
-func (s *defaultStore) Validity() time.Duration {
-	raw := s.accessor().TelemetryValidity
-	if raw == "" {
-		return DefaultValidity
+func (s *defaultStore) Save(st State) error {
+	cfg := s.accessor()
+
+	v := st.Enabled
+	cfg.TelemetryEnabled = &v
+
+	if st.EnabledAt.IsZero() {
+		cfg.TelemetryEnabledAt = ""
+	} else {
+		cfg.TelemetryEnabledAt = st.EnabledAt.UTC().Format(time.RFC3339Nano)
 	}
 
-	d, err := time.ParseDuration(raw)
-	if err != nil || d <= 0 {
-		return DefaultValidity
-	}
-
-	return d
-}
-
-func (s *defaultStore) SetValidity(validity time.Duration) error {
-	s.accessor().TelemetryValidity = validity.String()
+	cfg.TelemetryValidity = st.Validity.String()
 
 	return s.save()
 }
 
 // NewMemoryStore returns an in-memory Store suitable for tests or
 // applications that do not need telemetry state to survive restarts.
-// The initial validity is DefaultValidity; with an empty enabledAt, New
-// will stamp a fresh window on every restart.
 func NewMemoryStore(enabled bool) Store {
-	return &memoryStore{enabled: enabled, validity: DefaultValidity}
+	return &memoryStore{state: State{
+		Enabled:  enabled,
+		Validity: DefaultValidity,
+	}}
 }
 
 type memoryStore struct {
-	lock      sync.Mutex
-	enabled   bool
-	enabledAt time.Time
-	validity  time.Duration
+	lock  sync.Mutex
+	state State
 }
 
-func (s *memoryStore) Enabled() bool {
+func (s *memoryStore) Load() State {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	return s.enabled
+	return s.state
 }
 
-func (s *memoryStore) SetEnabled(enabled bool) error {
+func (s *memoryStore) Save(st State) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	s.enabled = enabled
-
-	return nil
-}
-
-func (s *memoryStore) EnabledAt() time.Time {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	return s.enabledAt
-}
-
-func (s *memoryStore) SetEnabledAt(t time.Time) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	s.enabledAt = t
-
-	return nil
-}
-
-func (s *memoryStore) Validity() time.Duration {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	return s.validity
-}
-
-func (s *memoryStore) SetValidity(validity time.Duration) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	s.validity = validity
+	s.state = st
 
 	return nil
 }

--- a/telemetry/store.go
+++ b/telemetry/store.go
@@ -71,6 +71,13 @@ func (s *defaultStore) Load() State {
 func (s *defaultStore) Save(st State) error {
 	cfg := s.accessor()
 
+	// Snapshot so we can restore on save failure. The shared config.Default
+	// must not carry unsaved telemetry mutations that a later unrelated
+	// save() could flush to disk.
+	prevEnabled := cfg.TelemetryEnabled
+	prevEnabledAt := cfg.TelemetryEnabledAt
+	prevValidity := cfg.TelemetryValidity
+
 	v := st.Enabled
 	cfg.TelemetryEnabled = &v
 
@@ -82,7 +89,15 @@ func (s *defaultStore) Save(st State) error {
 
 	cfg.TelemetryValidity = st.Validity.String()
 
-	return s.save()
+	if err := s.save(); err != nil {
+		cfg.TelemetryEnabled = prevEnabled
+		cfg.TelemetryEnabledAt = prevEnabledAt
+		cfg.TelemetryValidity = prevValidity
+
+		return err
+	}
+
+	return nil
 }
 
 // NewMemoryStore returns an in-memory Store suitable for tests or

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -91,7 +91,7 @@ func New(mqtt *fimpgo.MqttTransport, source string, store Store) (Telemetry, err
 			}
 		}
 
-		if elapsed >= validity(st) {
+		if elapsed >= st.Validity {
 			r.enabled = false
 
 			st.Enabled = false
@@ -224,9 +224,27 @@ func (r *telemetryT) SetValidity(validity time.Duration) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
+	// Compute the final state in one pass so we need only a single Save.
+	newEnabled := r.enabled
+	newEnabledAt := r.enabledAt
+	shouldDisable := false
+
+	if r.enabled && !r.enabledAt.IsZero() {
+		elapsed := time.Since(r.enabledAt)
+		if elapsed < 0 {
+			elapsed = 0 // clock skew: treat future timestamps as "just enabled"
+		}
+
+		if elapsed >= validity {
+			newEnabled = false
+			newEnabledAt = time.Time{}
+			shouldDisable = true
+		}
+	}
+
 	st := State{
-		Enabled:   r.enabled,
-		EnabledAt: r.enabledAt,
+		Enabled:   newEnabled,
+		EnabledAt: newEnabledAt,
 		Validity:  validity,
 	}
 
@@ -235,25 +253,22 @@ func (r *telemetryT) SetValidity(validity time.Duration) error {
 	}
 
 	r.validity = validity
-
-	if r.timer == nil || r.enabledAt.IsZero() {
-		return nil
-	}
-
-	elapsed := time.Since(r.enabledAt)
-	if elapsed < 0 {
-		elapsed = 0 // clock skew: treat future timestamps as "just enabled"
-	}
-
 	r.stopTimerLocked()
 
-	if elapsed >= validity {
-		r.disableLocked("validity reduced below elapsed time")
+	if shouldDisable {
+		r.enabled = false
+		r.enabledAt = time.Time{}
+		r.timer = nil
 
-		return nil
+		log.Infof("[cliff] Telemetry disabled: validity reduced below elapsed time")
+	} else if r.enabled && !r.enabledAt.IsZero() {
+		elapsed := time.Since(r.enabledAt)
+		if elapsed < 0 {
+			elapsed = 0
+		}
+
+		r.startTimerLocked(validity - elapsed)
 	}
-
-	r.startTimerLocked(validity - elapsed)
 
 	return nil
 }
@@ -302,14 +317,4 @@ func (r *telemetryT) disableLocked(reason string) {
 	}
 
 	log.Infof("[cliff] Telemetry disabled: %s", reason)
-}
-
-// validity is a helper that returns the state's validity, falling back to
-// DefaultValidity when zero or negative.
-func validity(st State) time.Duration {
-	if st.Validity <= 0 {
-		return DefaultValidity
-	}
-
-	return st.Validity
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -224,13 +224,16 @@ func (r *telemetryT) SetValidity(validity time.Duration) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	// Compute the final state in one pass so we need only a single Save.
+	// Compute elapsed once and use it for both the Save decision and the
+	// post-Save timer scheduling, avoiding a TOCTOU gap during slow saves.
+	var elapsed time.Duration
+
 	newEnabled := r.enabled
 	newEnabledAt := r.enabledAt
 	shouldDisable := false
 
 	if r.enabled && !r.enabledAt.IsZero() {
-		elapsed := time.Since(r.enabledAt)
+		elapsed = time.Since(r.enabledAt)
 		if elapsed < 0 {
 			elapsed = 0 // clock skew: treat future timestamps as "just enabled"
 		}
@@ -258,15 +261,9 @@ func (r *telemetryT) SetValidity(validity time.Duration) error {
 	if shouldDisable {
 		r.enabled = false
 		r.enabledAt = time.Time{}
-		r.timer = nil
 
 		log.Infof("[cliff] Telemetry disabled: validity reduced below elapsed time")
 	} else if r.enabled && !r.enabledAt.IsZero() {
-		elapsed := time.Since(r.enabledAt)
-		if elapsed < 0 {
-			elapsed = 0
-		}
-
 		r.startTimerLocked(validity - elapsed)
 	}
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -53,9 +53,9 @@ func New(mqtt *fimpgo.MqttTransport, source string, store Store) (Telemetry, err
 		return nil, errors.New("store is required")
 	}
 
-	validity := store.Validity()
-	if validity <= 0 {
-		validity = DefaultValidity
+	st := store.Load()
+	if st.Validity <= 0 {
+		st.Validity = DefaultValidity
 	}
 
 	r := &telemetryT{
@@ -63,15 +63,17 @@ func New(mqtt *fimpgo.MqttTransport, source string, store Store) (Telemetry, err
 		source:   fimptype.ResourceNameT(source),
 		store:    store,
 		topic:    Topic,
-		enabled:  store.Enabled(),
-		validity: validity,
+		enabled:  st.Enabled,
+		validity: st.Validity,
 	}
 
 	if r.enabled { //nolint:nestif
-		enabledAt := store.EnabledAt()
+		enabledAt := st.EnabledAt
 		if enabledAt.IsZero() {
 			enabledAt = time.Now()
-			if err := store.SetEnabledAt(enabledAt); err != nil {
+
+			st.EnabledAt = enabledAt
+			if err := store.Save(st); err != nil {
 				return nil, fmt.Errorf("telemetry: persist enabled_at: %w", err)
 			}
 		}
@@ -83,26 +85,26 @@ func New(mqtt *fimpgo.MqttTransport, source string, store Store) (Telemetry, err
 			enabledAt = time.Now()
 			elapsed = 0
 
-			if err := store.SetEnabledAt(enabledAt); err != nil {
+			st.EnabledAt = enabledAt
+			if err := store.Save(st); err != nil {
 				return nil, fmt.Errorf("telemetry: persist normalized enabled_at: %w", err)
 			}
 		}
 
-		if elapsed >= validity {
+		if elapsed >= validity(st) {
 			r.enabled = false
 
-			if err := store.SetEnabled(false); err != nil {
-				return nil, fmt.Errorf("telemetry: persist enabled: %w", err)
-			}
+			st.Enabled = false
+			st.EnabledAt = time.Time{}
 
-			if err := store.SetEnabledAt(time.Time{}); err != nil {
-				return nil, fmt.Errorf("telemetry: clear enabled_at: %w", err)
+			if err := store.Save(st); err != nil {
+				return nil, fmt.Errorf("telemetry: persist disabled state: %w", err)
 			}
 
 			log.Infof("[cliff] Telemetry disabled: validity expired before startup")
 		} else {
 			r.enabledAt = enabledAt
-			r.startTimerLocked(validity - elapsed)
+			r.startTimerLocked(st.Validity - elapsed)
 		}
 	}
 
@@ -119,7 +121,7 @@ func New(mqtt *fimpgo.MqttTransport, source string, store Store) (Telemetry, err
 // held. That keeps the in-memory state and the on-disk state consistent under
 // concurrent callers, at the cost of blocking Report / IsEnabled / Validity
 // while the store persists. A slow or blocking store will back up those
-// callers — acceptable for the file-backed config.Default store, but worth
+// callers - acceptable for the file-backed config.Default store, but worth
 // revisiting for stores with higher write latency.
 type telemetryT struct {
 	mqtt   *fimpgo.MqttTransport
@@ -176,38 +178,25 @@ func (r *telemetryT) Enable(enabled bool) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
+	st := State{
+		Enabled:  enabled,
+		Validity: r.validity,
+	}
+
 	if enabled {
-		enabledAt := time.Now()
-		wasEnabled := r.enabled
+		st.EnabledAt = time.Now()
+	}
 
-		if err := r.store.SetEnabled(true); err != nil {
-			return fmt.Errorf("telemetry: persist enabled: %w", err)
-		}
+	if err := r.store.Save(st); err != nil {
+		return fmt.Errorf("telemetry: persist state: %w", err)
+	}
 
-		if err := r.store.SetEnabledAt(enabledAt); err != nil {
-			if !wasEnabled {
-				_ = r.store.SetEnabled(false) // best-effort rollback only if we changed state
-			}
+	r.stopTimerLocked()
+	r.enabled = enabled
+	r.enabledAt = st.EnabledAt
 
-			return fmt.Errorf("telemetry: persist enabled_at: %w", err)
-		}
-
-		r.stopTimerLocked()
-		r.enabled = true
-		r.enabledAt = enabledAt
+	if enabled {
 		r.startTimerLocked(r.validity)
-	} else {
-		if err := r.store.SetEnabled(false); err != nil {
-			return fmt.Errorf("telemetry: persist enabled: %w", err)
-		}
-
-		if err := r.store.SetEnabledAt(time.Time{}); err != nil {
-			return fmt.Errorf("telemetry: clear enabled_at: %w", err)
-		}
-
-		r.stopTimerLocked()
-		r.enabled = false
-		r.enabledAt = time.Time{}
 	}
 
 	return nil
@@ -235,7 +224,13 @@ func (r *telemetryT) SetValidity(validity time.Duration) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	if err := r.store.SetValidity(validity); err != nil {
+	st := State{
+		Enabled:   r.enabled,
+		EnabledAt: r.enabledAt,
+		Validity:  validity,
+	}
+
+	if err := r.store.Save(st); err != nil {
 		return fmt.Errorf("telemetry: persist validity: %w", err)
 	}
 
@@ -271,6 +266,8 @@ func (r *telemetryT) startTimerLocked(d time.Duration) {
 		r.lock.Lock()
 		defer r.lock.Unlock()
 
+		// Guard against a stale callback: if stopTimerLocked replaced
+		// r.timer since this AfterFunc was scheduled, bail out.
 		if r.timer != t {
 			return
 		}
@@ -298,13 +295,21 @@ func (r *telemetryT) disableLocked(reason string) {
 	r.enabledAt = time.Time{}
 	r.timer = nil
 
-	if err := r.store.SetEnabled(false); err != nil {
+	st := State{Validity: r.validity}
+
+	if err := r.store.Save(st); err != nil {
 		log.WithError(err).Errorf("[cliff] Telemetry: failed to persist disabled state")
 	}
 
-	if err := r.store.SetEnabledAt(time.Time{}); err != nil {
-		log.WithError(err).Errorf("[cliff] Telemetry: failed to clear enabled_at")
+	log.Infof("[cliff] Telemetry disabled: %s", reason)
+}
+
+// validity is a helper that returns the state's validity, falling back to
+// DefaultValidity when zero or negative.
+func validity(st State) time.Duration {
+	if st.Validity <= 0 {
+		return DefaultValidity
 	}
 
-	log.Infof("[cliff] Telemetry disabled: %s", reason)
+	return st.Validity
 }

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -336,31 +336,17 @@ func TestReporter(t *testing.T) { //nolint:paralleltest
 }
 
 // stubStore exposes raw fields for white-box testing of New's restart-resume
-// logic. Unlike NewMemoryStore, it lets tests seed non-zero enabledAt values.
+// logic. Unlike NewMemoryStore, it lets tests seed non-zero state values.
 type stubStore struct {
-	enabled   bool
-	enabledAt time.Time
-	validity  time.Duration
-
-	setEnabledCalls   int
-	setEnabledAtCalls int
+	state     telemetry.State
+	saveCalls int
 }
 
-func (s *stubStore) Enabled() bool                     { return s.enabled }
-func (s *stubStore) EnabledAt() time.Time              { return s.enabledAt }
-func (s *stubStore) Validity() time.Duration           { return s.validity }
-func (s *stubStore) SetValidity(v time.Duration) error { s.validity = v; return nil }
+func (s *stubStore) Load() telemetry.State { return s.state }
 
-func (s *stubStore) SetEnabled(enabled bool) error {
-	s.enabled = enabled
-	s.setEnabledCalls++
-
-	return nil
-}
-
-func (s *stubStore) SetEnabledAt(t time.Time) error {
-	s.enabledAt = t
-	s.setEnabledAtCalls++
+func (s *stubStore) Save(st telemetry.State) error {
+	s.state = st
+	s.saveCalls++
 
 	return nil
 }
@@ -371,45 +357,44 @@ func TestNew_ResumesValidityWindowAcrossRestart(t *testing.T) {
 	t.Run("mid-window: resumes with remaining time", func(t *testing.T) {
 		t.Parallel()
 
-		store := &stubStore{
-			enabled:   true,
-			enabledAt: time.Now().Add(-10 * time.Minute),
-			validity:  time.Hour,
-		}
+		store := &stubStore{state: telemetry.State{
+			Enabled:   true,
+			EnabledAt: time.Now().Add(-10 * time.Minute),
+			Validity:  time.Hour,
+		}}
 
 		tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
 		require.NoError(t, err)
 
 		assert.True(t, tel.IsEnabled())
 		assert.Equal(t, time.Hour, tel.Validity())
-		assert.Equal(t, 0, store.setEnabledCalls, "must not re-persist enabled on resume")
-		assert.Equal(t, 0, store.setEnabledAtCalls, "must not re-stamp enabledAt on resume")
+		assert.Equal(t, 0, store.saveCalls, "must not re-persist on resume")
 	})
 
 	t.Run("already expired: auto-disables and persists", func(t *testing.T) {
 		t.Parallel()
 
-		store := &stubStore{
-			enabled:   true,
-			enabledAt: time.Now().Add(-40 * 24 * time.Hour),
-			validity:  30 * 24 * time.Hour,
-		}
+		store := &stubStore{state: telemetry.State{
+			Enabled:   true,
+			EnabledAt: time.Now().Add(-40 * 24 * time.Hour),
+			Validity:  30 * 24 * time.Hour,
+		}}
 
 		tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
 		require.NoError(t, err)
 
 		assert.False(t, tel.IsEnabled())
-		assert.False(t, store.enabled)
-		assert.True(t, store.enabledAt.IsZero())
+		assert.False(t, store.state.Enabled)
+		assert.True(t, store.state.EnabledAt.IsZero())
 	})
 
 	t.Run("enabled with zero enabledAt: stamps fresh window", func(t *testing.T) {
 		t.Parallel()
 
-		store := &stubStore{
-			enabled:  true,
-			validity: time.Hour,
-		}
+		store := &stubStore{state: telemetry.State{
+			Enabled:  true,
+			Validity: time.Hour,
+		}}
 
 		before := time.Now()
 
@@ -417,8 +402,8 @@ func TestNew_ResumesValidityWindowAcrossRestart(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.True(t, tel.IsEnabled())
-		assert.False(t, store.enabledAt.IsZero())
-		assert.True(t, !store.enabledAt.Before(before))
+		assert.False(t, store.state.EnabledAt.IsZero())
+		assert.True(t, !store.state.EnabledAt.Before(before))
 	})
 }
 
@@ -430,20 +415,24 @@ func TestNewDefaultStore_RoundTrip(t *testing.T) {
 	store := telemetry.NewDefaultStore(func() *config.Default { return d }, func() error { saves++; return nil })
 
 	// Defaults when nothing is persisted.
-	assert.True(t, store.Enabled(), "unset enabled should default to true")
-	assert.True(t, store.EnabledAt().IsZero())
-	assert.Equal(t, telemetry.DefaultValidity, store.Validity())
-
-	require.NoError(t, store.SetEnabled(false))
-	require.NoError(t, store.SetValidity(2*time.Hour))
+	st := store.Load()
+	assert.True(t, st.Enabled, "unset enabled should default to true")
+	assert.True(t, st.EnabledAt.IsZero())
+	assert.Equal(t, telemetry.DefaultValidity, st.Validity)
 
 	stamp := time.Date(2026, 4, 20, 12, 0, 0, 123_000_000, time.UTC)
-	require.NoError(t, store.SetEnabledAt(stamp))
 
-	// In-memory side reflects the writes.
-	assert.False(t, store.Enabled())
-	assert.Equal(t, 2*time.Hour, store.Validity())
-	assert.True(t, store.EnabledAt().Equal(stamp))
+	require.NoError(t, store.Save(telemetry.State{
+		Enabled:   false,
+		EnabledAt: stamp,
+		Validity:  2 * time.Hour,
+	}))
+
+	// Load reflects the writes.
+	st = store.Load()
+	assert.False(t, st.Enabled)
+	assert.Equal(t, 2*time.Hour, st.Validity)
+	assert.True(t, st.EnabledAt.Equal(stamp))
 
 	// Raw fields serialize the way the format contract says they should.
 	assert.NotNil(t, d.TelemetryEnabled)
@@ -451,11 +440,16 @@ func TestNewDefaultStore_RoundTrip(t *testing.T) {
 	assert.Equal(t, "2h0m0s", d.TelemetryValidity)
 	assert.Equal(t, "2026-04-20T12:00:00.123Z", d.TelemetryEnabledAt)
 
-	// Clearing enabledAt writes an empty string, not "0001-01-01..." —
+	// Clearing enabledAt writes an empty string, not "0001-01-01..." -
 	// a malformed RFC3339Nano in the file must round-trip to zero time.
-	require.NoError(t, store.SetEnabledAt(time.Time{}))
+	require.NoError(t, store.Save(telemetry.State{
+		Enabled:  false,
+		Validity: 2 * time.Hour,
+	}))
 	assert.Equal(t, "", d.TelemetryEnabledAt)
-	assert.True(t, store.EnabledAt().IsZero())
 
-	assert.Greater(t, saves, 0, "every Set* must call save")
+	st = store.Load()
+	assert.True(t, st.EnabledAt.IsZero())
+
+	assert.Equal(t, 2, saves, "each Save must call save exactly once")
 }

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -1,6 +1,7 @@
 package telemetry_test
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -452,4 +453,124 @@ func TestNewDefaultStore_RoundTrip(t *testing.T) {
 	assert.True(t, st.EnabledAt.IsZero())
 
 	assert.Equal(t, 2, saves, "each Save must call save exactly once")
+}
+
+// failStore lets tests inject Save failures.
+type failStore struct {
+	state   telemetry.State
+	saveErr error
+}
+
+func (s *failStore) Load() telemetry.State { return s.state }
+
+func (s *failStore) Save(st telemetry.State) error {
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+
+	s.state = st
+
+	return nil
+}
+
+func TestEnable_SaveFailure_LeavesStateUnchanged(t *testing.T) {
+	t.Parallel()
+
+	store := &failStore{state: telemetry.State{
+		Enabled:  false,
+		Validity: telemetry.DefaultValidity,
+	}}
+
+	tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
+	require.NoError(t, err)
+	assert.False(t, tel.IsEnabled())
+
+	// Inject failure and try to enable.
+	store.saveErr = errors.New("disk full")
+	err = tel.Enable(true)
+	require.Error(t, err)
+
+	// In-memory state must remain disabled.
+	assert.False(t, tel.IsEnabled(), "Enable must not change in-memory state on Save failure")
+	assert.False(t, store.state.Enabled, "Store must not be mutated on Save failure")
+}
+
+func TestSetValidity_SaveFailure_LeavesStateUnchanged(t *testing.T) {
+	t.Parallel()
+
+	store := &failStore{state: telemetry.State{
+		Enabled:  true,
+		Validity: telemetry.DefaultValidity,
+	}}
+
+	tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
+	require.NoError(t, err)
+
+	store.saveErr = errors.New("disk full")
+	err = tel.SetValidity(time.Hour)
+	require.Error(t, err)
+
+	assert.Equal(t, telemetry.DefaultValidity, tel.Validity(), "SetValidity must not change in-memory state on Save failure")
+}
+
+func TestSetValidity_BelowElapsed_SingleSave(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{state: telemetry.State{
+		Enabled:   true,
+		EnabledAt: time.Now().Add(-10 * time.Minute),
+		Validity:  time.Hour,
+	}}
+
+	tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
+	require.NoError(t, err)
+	assert.True(t, tel.IsEnabled())
+
+	store.saveCalls = 0
+
+	require.NoError(t, tel.SetValidity(time.Millisecond))
+
+	assert.False(t, tel.IsEnabled(), "should auto-disable")
+	assert.Equal(t, 1, store.saveCalls, "SetValidity must perform exactly one Save")
+	assert.False(t, store.state.Enabled, "persisted state must be disabled")
+	assert.True(t, store.state.EnabledAt.IsZero(), "persisted enabledAt must be cleared")
+}
+
+func TestDefaultStore_SaveFailure_RestoresConfig(t *testing.T) {
+	t.Parallel()
+
+	enabled := true
+	d := &config.Default{
+		TelemetryEnabled:   &enabled,
+		TelemetryEnabledAt: "2026-04-20T12:00:00Z",
+		TelemetryValidity:  "1h0m0s",
+	}
+
+	fail := true
+	store := telemetry.NewDefaultStore(
+		func() *config.Default { return d },
+		func() error {
+			if fail {
+				return errors.New("disk full")
+			}
+
+			return nil
+		},
+	)
+
+	err := store.Save(telemetry.State{
+		Enabled:  false,
+		Validity: 2 * time.Hour,
+	})
+	require.Error(t, err)
+
+	// Config must be rolled back to pre-Save state.
+	assert.NotNil(t, d.TelemetryEnabled)
+	assert.True(t, *d.TelemetryEnabled, "TelemetryEnabled must be restored")
+	assert.Equal(t, "2026-04-20T12:00:00Z", d.TelemetryEnabledAt, "TelemetryEnabledAt must be restored")
+	assert.Equal(t, "1h0m0s", d.TelemetryValidity, "TelemetryValidity must be restored")
+
+	// Load must still return the original state.
+	st := store.Load()
+	assert.True(t, st.Enabled)
 }


### PR DESCRIPTION
## Summary

- Replace the six-method `Store` interface (3 getter/setter pairs) with `Load()/Save(State)` to eliminate partial-update failures where one field persists but another fails
- `SetValidity` now computes the final state (including auto-disable when validity drops below elapsed) in one pass before calling `Save`, removing the double-save path
- `defaultStore.Save` snapshots config fields and restores them on save failure, preventing unsaved mutations from leaking into the shared `config.Default`
- Net reduction in code complexity: `Enable` went from 40 lines with rollback logic to 26 lines

## Test plan

- [x] All 23 telemetry tests pass (4 new failure-path tests added)
- [x] `TestEnable_SaveFailure_LeavesStateUnchanged` - verifies in-memory state unchanged on Save error
- [x] `TestSetValidity_SaveFailure_LeavesStateUnchanged` - verifies validity unchanged on Save error
- [x] `TestSetValidity_BelowElapsed_SingleSave` - asserts exactly 1 Save call when auto-disabling
- [x] `TestDefaultStore_SaveFailure_RestoresConfig` - verifies config.Default fields rolled back on error