### PR TITLE
feat: required events, suppressed sources, config pull

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Default struct {
 	TelemetryEnabledAt  string `json:"telemetry_enabled_at,omitempty"`
 	TelemetryValidity   string `json:"telemetry_validity,omitempty"`
 	TelemetrySuppressed *bool  `json:"telemetry_suppressed,omitempty"`
-	ConfiguredAt       string `json:"configured_at"`
+	ConfiguredAt        string `json:"configured_at"`
 }
 
 // NewDefault creates a new instance of a default configuration.

--- a/config/config.go
+++ b/config/config.go
@@ -17,9 +17,10 @@ type Default struct {
 	LogLevel           string `json:"log_level"`
 	LogFormat          string `json:"log_format"`
 	LogRevertTimeout   string `json:"log_revert_timeout,omitempty"`
-	TelemetryEnabled   *bool  `json:"telemetry_enabled,omitempty"`
-	TelemetryEnabledAt string `json:"telemetry_enabled_at,omitempty"`
-	TelemetryValidity  string `json:"telemetry_validity,omitempty"`
+	TelemetryEnabled    *bool  `json:"telemetry_enabled,omitempty"`
+	TelemetryEnabledAt  string `json:"telemetry_enabled_at,omitempty"`
+	TelemetryValidity   string `json:"telemetry_validity,omitempty"`
+	TelemetrySuppressed *bool  `json:"telemetry_suppressed,omitempty"`
 	ConfiguredAt       string `json:"configured_at"`
 }
 

--- a/telemetry/config_pull.go
+++ b/telemetry/config_pull.go
@@ -99,14 +99,27 @@ func NewConfigPull(mqtt *fimpgo.MqttTransport, source string, reporter Telemetry
 		opt(cp)
 	}
 
+	if cp.fallbackPoll <= 0 {
+		return nil, fmt.Errorf("telemetry: config pull: fallback poll interval must be positive")
+	}
+
+	if cp.timeout <= 0 {
+		return nil, fmt.Errorf("telemetry: config pull: request timeout must be positive")
+	}
+
 	return cp, nil
 }
 
 // Start begins the config pull loop. The first poll fires immediately
-// and is non-blocking (runs in a background goroutine).
+// and is non-blocking (runs in a background goroutine). Calling Start
+// on an already-running service is a no-op.
 func (cp *ConfigPull) Start() error {
 	cp.lock.Lock()
 	defer cp.lock.Unlock()
+
+	if cp.timer != nil {
+		return nil // already running
+	}
 
 	if cp.client == nil {
 		cp.client = fimpgo.NewSyncClient(cp.mqtt)
@@ -161,7 +174,9 @@ func (cp *ConfigPull) scheduleLocked(delay time.Duration) {
 			return
 		}
 
-		// Release lock during network I/O.
+		// Release lock during network I/O. If Stop() is called
+		// concurrently, it cancels the SyncClient's transport which
+		// causes SendFimp to return an error promptly.
 		client := cp.client
 		cp.lock.Unlock()
 
@@ -193,6 +208,12 @@ func (cp *ConfigPull) poll(client SyncRequester) time.Duration {
 		return cp.fallbackPoll
 	}
 
+	if resp.Interface != EvtConfigReport {
+		log.Warnf("[cliff] Telemetry config pull: unexpected response type %q, retrying in %s", resp.Interface, cp.fallbackPoll)
+
+		return cp.fallbackPoll
+	}
+
 	var cfg ConfigResponse
 	if err := resp.GetObjectValue(&cfg); err != nil {
 		log.WithError(err).Warnf("[cliff] Telemetry config pull: failed to parse response, retrying in %s", cp.fallbackPoll)
@@ -200,6 +221,9 @@ func (cp *ConfigPull) poll(client SyncRequester) time.Duration {
 		return cp.fallbackPoll
 	}
 
+	// Enable and SetSuppressed are applied independently: a failure in
+	// one should not prevent the other from being applied. The next poll
+	// will reconcile any partial state.
 	if err := cp.reporter.Enable(cfg.Enabled); err != nil {
 		log.WithError(err).Errorf("[cliff] Telemetry config pull: failed to apply enabled=%v", cfg.Enabled)
 	}

--- a/telemetry/config_pull.go
+++ b/telemetry/config_pull.go
@@ -1,0 +1,232 @@
+package telemetry
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/futurehomeno/fimpgo"
+	log "github.com/sirupsen/logrus"
+)
+
+// SyncRequester is the subset of fimpgo.SyncClient used by ConfigPull.
+// Extracted as an interface for testability.
+type SyncRequester interface {
+	SendFimp(topic string, fimpMsg *fimpgo.FimpMessage, timeout int) (*fimpgo.FimpMessage, error)
+	AddSubscription(topic string) error
+	Stop()
+}
+
+// ConfigPull periodically pulls telemetry configuration from the cloud
+// and applies it to the reporter. It implements root.Service (Start/Stop).
+//
+// Apps opt in by constructing a ConfigPull and passing it to WithServices()
+// on the EdgeAppBuilder.
+type ConfigPull struct {
+	mqtt         *fimpgo.MqttTransport
+	source       string
+	reporter     Telemetry
+	fallbackPoll time.Duration
+	requestTopic string
+	timeout      int
+
+	lock    sync.Mutex
+	timer   *time.Timer
+	stopped bool
+	client  SyncRequester
+}
+
+// ConfigPullOption configures optional parameters for NewConfigPull.
+type ConfigPullOption func(*ConfigPull)
+
+// WithFallbackPoll sets the fallback polling interval used when the cloud
+// response does not include next_update or on error. Default: DefaultPollInterval.
+func WithFallbackPoll(d time.Duration) ConfigPullOption {
+	return func(cp *ConfigPull) {
+		cp.fallbackPoll = d
+	}
+}
+
+// WithRequestTopic overrides the MQTT topic for config requests.
+// Default: ConfigRequestTopic.
+func WithRequestTopic(topic string) ConfigPullOption {
+	return func(cp *ConfigPull) {
+		cp.requestTopic = topic
+	}
+}
+
+// WithRequestTimeout sets the MQTT request timeout in seconds.
+// Default: 30.
+func WithRequestTimeout(seconds int) ConfigPullOption {
+	return func(cp *ConfigPull) {
+		cp.timeout = seconds
+	}
+}
+
+// WithSyncRequester injects a SyncRequester for testing.
+func WithSyncRequester(client SyncRequester) ConfigPullOption {
+	return func(cp *ConfigPull) {
+		cp.client = client
+	}
+}
+
+// NewConfigPull creates a config pull service that periodically fetches
+// telemetry config from the cloud and applies it to the reporter.
+func NewConfigPull(mqtt *fimpgo.MqttTransport, source string, reporter Telemetry, opts ...ConfigPullOption) (*ConfigPull, error) {
+	if mqtt == nil {
+		return nil, fmt.Errorf("telemetry: config pull: mqtt transport is nil")
+	}
+
+	if source == "" {
+		return nil, fmt.Errorf("telemetry: config pull: source is not set")
+	}
+
+	if reporter == nil {
+		return nil, fmt.Errorf("telemetry: config pull: reporter is nil")
+	}
+
+	cp := &ConfigPull{
+		mqtt:         mqtt,
+		source:       source,
+		reporter:     reporter,
+		fallbackPoll: DefaultPollInterval,
+		requestTopic: ConfigRequestTopic,
+		timeout:      30,
+	}
+
+	for _, opt := range opts {
+		opt(cp)
+	}
+
+	return cp, nil
+}
+
+// Start begins the config pull loop. The first poll fires immediately
+// and is non-blocking (runs in a background goroutine).
+func (cp *ConfigPull) Start() error {
+	cp.lock.Lock()
+	defer cp.lock.Unlock()
+
+	if cp.client == nil {
+		cp.client = fimpgo.NewSyncClient(cp.mqtt)
+	}
+
+	responseTopic := fmt.Sprintf("pt:j1/mt:cmd/rt:app/rn:%s/ad:1", cp.source)
+
+	if err := cp.client.AddSubscription(responseTopic); err != nil {
+		return fmt.Errorf("telemetry: config pull: subscribe: %w", err)
+	}
+
+	cp.stopped = false
+	cp.scheduleLocked(0)
+
+	log.Infof("[cliff] Telemetry config pull started (source=%s)", cp.source)
+
+	return nil
+}
+
+// Stop cancels any pending poll and stops the sync client.
+func (cp *ConfigPull) Stop() error {
+	cp.lock.Lock()
+	defer cp.lock.Unlock()
+
+	cp.stopped = true
+
+	if cp.timer != nil {
+		cp.timer.Stop()
+		cp.timer = nil
+	}
+
+	if cp.client != nil {
+		cp.client.Stop()
+		cp.client = nil
+	}
+
+	log.Infof("[cliff] Telemetry config pull stopped (source=%s)", cp.source)
+
+	return nil
+}
+
+// scheduleLocked schedules the next poll after the given delay.
+// Must be called with cp.lock held.
+func (cp *ConfigPull) scheduleLocked(delay time.Duration) {
+	var t *time.Timer
+
+	t = time.AfterFunc(delay, func() {
+		cp.lock.Lock()
+
+		if cp.stopped || cp.timer != t {
+			cp.lock.Unlock()
+			return
+		}
+
+		// Release lock during network I/O.
+		client := cp.client
+		cp.lock.Unlock()
+
+		nextDelay := cp.poll(client)
+
+		cp.lock.Lock()
+		defer cp.lock.Unlock()
+
+		if cp.stopped {
+			return
+		}
+
+		cp.scheduleLocked(nextDelay)
+	})
+
+	cp.timer = t
+}
+
+// poll sends a config request and applies the response. Returns the
+// delay until the next poll.
+func (cp *ConfigPull) poll(client SyncRequester) time.Duration {
+	msg := fimpgo.NewNullMessage(CmdGetConfig, Service, nil, nil, nil)
+	msg.ResponseToTopic = fmt.Sprintf("pt:j1/mt:cmd/rt:app/rn:%s/ad:1", cp.source)
+
+	resp, err := client.SendFimp(cp.requestTopic, msg, cp.timeout)
+	if err != nil {
+		log.WithError(err).Warnf("[cliff] Telemetry config pull failed, retrying in %s", cp.fallbackPoll)
+
+		return cp.fallbackPoll
+	}
+
+	var cfg ConfigResponse
+	if err := resp.GetObjectValue(&cfg); err != nil {
+		log.WithError(err).Warnf("[cliff] Telemetry config pull: failed to parse response, retrying in %s", cp.fallbackPoll)
+
+		return cp.fallbackPoll
+	}
+
+	if err := cp.reporter.Enable(cfg.Enabled); err != nil {
+		log.WithError(err).Errorf("[cliff] Telemetry config pull: failed to apply enabled=%v", cfg.Enabled)
+	}
+
+	suppressed := slices.Contains(cfg.Suppressed, cp.source)
+
+	if err := cp.reporter.SetSuppressed(suppressed); err != nil {
+		log.WithError(err).Errorf("[cliff] Telemetry config pull: failed to apply suppressed=%v", suppressed)
+	}
+
+	log.Infof("[cliff] Telemetry config applied (enabled=%v, suppressed=%v)", cfg.Enabled, suppressed)
+
+	if cfg.NextUpdate == "" {
+		return cp.fallbackPoll
+	}
+
+	nextUpdate, err := time.Parse(time.RFC3339, cfg.NextUpdate)
+	if err != nil {
+		log.WithError(err).Warnf("[cliff] Telemetry config pull: failed to parse next_update %q", cfg.NextUpdate)
+
+		return cp.fallbackPoll
+	}
+
+	delay := time.Until(nextUpdate)
+	if delay <= 0 {
+		return cp.fallbackPoll
+	}
+
+	return delay
+}

--- a/telemetry/config_pull_test.go
+++ b/telemetry/config_pull_test.go
@@ -107,6 +107,32 @@ func TestConfigPull_AppliesConfig(t *testing.T) {
 	require.NoError(t, cp.Stop())
 }
 
+func TestConfigPull_DisablesTelemetry(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSyncRequester{
+		response: configResponse(t, false, nil, ""),
+	}
+
+	store := telemetry.NewMemoryStore(true)
+	tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
+	require.NoError(t, err)
+	assert.True(t, tel.IsEnabled())
+
+	cp, err := telemetry.NewConfigPull(&fimpgo.MqttTransport{}, testSource, tel,
+		telemetry.WithSyncRequester(mock),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, cp.Start())
+
+	time.Sleep(100 * time.Millisecond)
+
+	assert.False(t, tel.IsEnabled(), "config should disable telemetry")
+
+	require.NoError(t, cp.Stop())
+}
+
 func TestConfigPull_SuppressesMatchingSource(t *testing.T) {
 	t.Parallel()
 

--- a/telemetry/config_pull_test.go
+++ b/telemetry/config_pull_test.go
@@ -2,6 +2,7 @@ package telemetry_test
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,11 +17,11 @@ import (
 type mockSyncRequester struct {
 	response *fimpgo.FimpMessage
 	err      error
-	calls    int
+	calls    atomic.Int32
 }
 
 func (m *mockSyncRequester) SendFimp(_ string, _ *fimpgo.FimpMessage, _ int) (*fimpgo.FimpMessage, error) {
-	m.calls++
+	m.calls.Add(1)
 
 	if m.err != nil {
 		return nil, m.err
@@ -102,7 +103,7 @@ func TestConfigPull_AppliesConfig(t *testing.T) {
 
 	assert.True(t, tel.IsEnabled(), "config should enable telemetry")
 	assert.False(t, tel.IsSuppressed(), "source not in suppressed list")
-	assert.GreaterOrEqual(t, mock.calls, 1)
+	assert.GreaterOrEqual(t, mock.calls.Load(), int32(1))
 
 	require.NoError(t, cp.Stop())
 }
@@ -180,7 +181,7 @@ func TestConfigPull_ErrorUsesFallback(t *testing.T) {
 	// Wait for initial poll + one retry.
 	time.Sleep(150 * time.Millisecond)
 
-	assert.GreaterOrEqual(t, mock.calls, 2, "should retry after fallback interval")
+	assert.GreaterOrEqual(t, mock.calls.Load(), int32(2), "should retry after fallback interval")
 
 	require.NoError(t, cp.Stop())
 }
@@ -205,12 +206,12 @@ func TestConfigPull_StopCancelsPending(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	callsBefore := mock.calls
+	callsBefore := mock.calls.Load()
 	require.NoError(t, cp.Stop())
 
 	// After stop, no more polls should fire.
 	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, callsBefore, mock.calls, "no more polls after Stop")
+	assert.Equal(t, callsBefore, mock.calls.Load(), "no more polls after Stop")
 }
 
 func TestConfigPull_PastNextUpdateUsesFallback(t *testing.T) {
@@ -236,7 +237,7 @@ func TestConfigPull_PastNextUpdateUsesFallback(t *testing.T) {
 	// Wait for initial poll + fallback retry.
 	time.Sleep(150 * time.Millisecond)
 
-	assert.GreaterOrEqual(t, mock.calls, 2, "past next_update should use fallback interval")
+	assert.GreaterOrEqual(t, mock.calls.Load(), int32(2), "past next_update should use fallback interval")
 
 	require.NoError(t, cp.Stop())
 }

--- a/telemetry/config_pull_test.go
+++ b/telemetry/config_pull_test.go
@@ -1,0 +1,216 @@
+package telemetry_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/futurehomeno/fimpgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/futurehomeno/cliffhanger/telemetry"
+)
+
+// mockSyncRequester implements telemetry.SyncRequester for testing.
+type mockSyncRequester struct {
+	response *fimpgo.FimpMessage
+	err      error
+	calls    int
+}
+
+func (m *mockSyncRequester) SendFimp(_ string, _ *fimpgo.FimpMessage, _ int) (*fimpgo.FimpMessage, error) {
+	m.calls++
+
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return m.response, nil
+}
+
+func (m *mockSyncRequester) AddSubscription(_ string) error { return nil }
+func (m *mockSyncRequester) Stop()                          {}
+
+func configResponse(t *testing.T, enabled bool, suppressed []string, nextUpdate string) *fimpgo.FimpMessage {
+	t.Helper()
+
+	resp := &telemetry.ConfigResponse{
+		Enabled:    enabled,
+		Suppressed: suppressed,
+		NextUpdate: nextUpdate,
+	}
+
+	msg := fimpgo.NewObjectMessage(telemetry.EvtConfigReport, telemetry.Service, resp, nil, nil, nil)
+
+	// Round-trip through JSON to simulate MQTT serialization so that
+	// GetObjectValue can parse the payload.
+	raw, err := msg.SerializeToJson()
+	require.NoError(t, err)
+
+	parsed, err := fimpgo.NewMessageFromBytes(raw)
+	require.NoError(t, err)
+
+	return parsed
+}
+
+func TestNewConfigPull_Validation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil mqtt", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := telemetry.NewConfigPull(nil, "source", nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty source", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := telemetry.NewConfigPull(&fimpgo.MqttTransport{}, "", nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("nil reporter", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := telemetry.NewConfigPull(&fimpgo.MqttTransport{}, "source", nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestConfigPull_AppliesConfig(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSyncRequester{
+		response: configResponse(t, true, []string{"other-app"}, ""),
+	}
+
+	store := telemetry.NewMemoryStore(false)
+	tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
+	require.NoError(t, err)
+
+	cp, err := telemetry.NewConfigPull(&fimpgo.MqttTransport{}, testSource, tel,
+		telemetry.WithSyncRequester(mock),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, cp.Start())
+
+	// Give the async poll time to complete.
+	time.Sleep(100 * time.Millisecond)
+
+	assert.True(t, tel.IsEnabled(), "config should enable telemetry")
+	assert.False(t, tel.IsSuppressed(), "source not in suppressed list")
+	assert.GreaterOrEqual(t, mock.calls, 1)
+
+	require.NoError(t, cp.Stop())
+}
+
+func TestConfigPull_SuppressesMatchingSource(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSyncRequester{
+		response: configResponse(t, true, []string{testSource, "other-app"}, ""),
+	}
+
+	store := telemetry.NewMemoryStore(true)
+	tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
+	require.NoError(t, err)
+
+	cp, err := telemetry.NewConfigPull(&fimpgo.MqttTransport{}, testSource, tel,
+		telemetry.WithSyncRequester(mock),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, cp.Start())
+
+	time.Sleep(100 * time.Millisecond)
+
+	assert.True(t, tel.IsSuppressed(), "source should be suppressed")
+
+	require.NoError(t, cp.Stop())
+}
+
+func TestConfigPull_ErrorUsesFallback(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSyncRequester{
+		err: errors.New("cloud unreachable"),
+	}
+
+	store := telemetry.NewMemoryStore(true)
+	tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
+	require.NoError(t, err)
+
+	cp, err := telemetry.NewConfigPull(&fimpgo.MqttTransport{}, testSource, tel,
+		telemetry.WithSyncRequester(mock),
+		telemetry.WithFallbackPoll(50*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, cp.Start())
+
+	// Wait for initial poll + one retry.
+	time.Sleep(150 * time.Millisecond)
+
+	assert.GreaterOrEqual(t, mock.calls, 2, "should retry after fallback interval")
+
+	require.NoError(t, cp.Stop())
+}
+
+func TestConfigPull_StopCancelsPending(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSyncRequester{
+		response: configResponse(t, true, nil, time.Now().Add(time.Hour).Format(time.RFC3339)),
+	}
+
+	store := telemetry.NewMemoryStore(true)
+	tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
+	require.NoError(t, err)
+
+	cp, err := telemetry.NewConfigPull(&fimpgo.MqttTransport{}, testSource, tel,
+		telemetry.WithSyncRequester(mock),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, cp.Start())
+
+	time.Sleep(100 * time.Millisecond)
+
+	callsBefore := mock.calls
+	require.NoError(t, cp.Stop())
+
+	// After stop, no more polls should fire.
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, callsBefore, mock.calls, "no more polls after Stop")
+}
+
+func TestConfigPull_PastNextUpdateUsesFallback(t *testing.T) {
+	t.Parallel()
+
+	pastTime := time.Now().Add(-time.Hour).Format(time.RFC3339)
+	mock := &mockSyncRequester{
+		response: configResponse(t, true, nil, pastTime),
+	}
+
+	store := telemetry.NewMemoryStore(true)
+	tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
+	require.NoError(t, err)
+
+	cp, err := telemetry.NewConfigPull(&fimpgo.MqttTransport{}, testSource, tel,
+		telemetry.WithSyncRequester(mock),
+		telemetry.WithFallbackPoll(50*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, cp.Start())
+
+	// Wait for initial poll + fallback retry.
+	time.Sleep(150 * time.Millisecond)
+
+	assert.GreaterOrEqual(t, mock.calls, 2, "past next_update should use fallback interval")
+
+	require.NoError(t, cp.Stop())
+}

--- a/telemetry/defs.go
+++ b/telemetry/defs.go
@@ -28,10 +28,28 @@ const (
 	// commands. Once the window elapses since the last Enable(true),
 	// the reporter auto-disables.
 	SettingValidity = "telemetry_validity"
+	// SettingSuppressed is the config parameter name for the suppressed state.
+	SettingSuppressed = "telemetry_suppressed"
 
 	// DefaultValidity is the default window telemetry stays enabled after
 	// Enable(true). After that it auto-disables via a background timer.
 	DefaultValidity = 30 * 24 * time.Hour
+
+	// CmdGetConfig is the FIMP message type for requesting telemetry config
+	// from the cloud.
+	CmdGetConfig = "cmd.telemetry.get_config"
+	// EvtConfigReport is the FIMP message type for telemetry config response
+	// from the cloud.
+	EvtConfigReport = "evt.telemetry.config_report"
+
+	// ConfigRequestTopic is the MQTT topic for config requests to the cloud.
+	// Uses mt:rsp so CloudBridge's existing LocalToCloud default route
+	// forwards it without bridge changes.
+	ConfigRequestTopic = "pt:j1/mt:rsp/rt:cloud/rn:backend-service/ad:telemetry-config"
+
+	// DefaultPollInterval is the fallback interval when the cloud response
+	// does not include next_update or on error.
+	DefaultPollInterval = 6 * time.Hour
 )
 
 // Event is the payload carried in the FIMP val field.
@@ -39,4 +57,11 @@ type Event struct {
 	Event  string         `json:"event"`
 	Domain string         `json:"domain,omitempty"`
 	Data   map[string]any `json:"data,omitempty"`
+}
+
+// ConfigResponse is the payload of evt.telemetry.config_report from the cloud.
+type ConfigResponse struct {
+	Enabled    bool     `json:"enabled"`
+	Suppressed []string `json:"suppressed"`
+	NextUpdate string   `json:"next_update"`
 }

--- a/telemetry/routing.go
+++ b/telemetry/routing.go
@@ -31,13 +31,27 @@ func RouteCmdSetValidity(svc fimptype.ServiceNameT, reporter Telemetry, options 
 	return config.RouteCmdConfigSetDuration(svc, SettingValidity, reporter.SetValidity, options...)
 }
 
+// RouteCmdGetSuppressed returns a routing for cmd.config.get_telemetry_suppressed
+// that replies with the current telemetry suppressed state.
+func RouteCmdGetSuppressed(svc fimptype.ServiceNameT, reporter Telemetry, options ...config.RoutingOption) *router.Routing {
+	return config.RouteCmdConfigGetBool(svc, SettingSuppressed, reporter.IsSuppressed, options...)
+}
+
+// RouteCmdSetSuppressed returns a routing for cmd.config.set_telemetry_suppressed
+// that toggles the telemetry suppressed state.
+func RouteCmdSetSuppressed(svc fimptype.ServiceNameT, reporter Telemetry, options ...config.RoutingOption) *router.Routing {
+	return config.RouteCmdConfigSetBool(svc, SettingSuppressed, reporter.SetSuppressed, options...)
+}
+
 // RoutingForTelemetry returns the get/set routings for the telemetry config
-// parameters (enabled, validity) bound to the given Telemetry instance.
+// parameters (enabled, validity, suppressed) bound to the given Telemetry instance.
 func RoutingForTelemetry(svc fimptype.ServiceNameT, reporter Telemetry, options ...config.RoutingOption) []*router.Routing {
 	return []*router.Routing{
 		RouteCmdGetEnabled(svc, reporter, options...),
 		RouteCmdSetEnabled(svc, reporter, options...),
 		RouteCmdGetValidity(svc, reporter, options...),
 		RouteCmdSetValidity(svc, reporter, options...),
+		RouteCmdGetSuppressed(svc, reporter, options...),
+		RouteCmdSetSuppressed(svc, reporter, options...),
 	}
 }

--- a/telemetry/store.go
+++ b/telemetry/store.go
@@ -11,9 +11,10 @@ import (
 // State is the persisted telemetry configuration. All fields are written
 // atomically by Store.Save so partial-update failures cannot occur.
 type State struct {
-	Enabled   bool
-	EnabledAt time.Time
-	Validity  time.Duration
+	Enabled    bool
+	EnabledAt  time.Time
+	Validity   time.Duration
+	Suppressed bool
 }
 
 // Store persists telemetry configuration so the enabled flag, the timestamp
@@ -86,6 +87,10 @@ func (s *defaultStore) Load() State {
 		st.Validity = DefaultValidity
 	}
 
+	if cfg.TelemetrySuppressed != nil {
+		st.Suppressed = *cfg.TelemetrySuppressed
+	}
+
 	return st
 }
 
@@ -98,6 +103,7 @@ func (s *defaultStore) Save(st State) error {
 	prevEnabled := cfg.TelemetryEnabled
 	prevEnabledAt := cfg.TelemetryEnabledAt
 	prevValidity := cfg.TelemetryValidity
+	prevSuppressed := cfg.TelemetrySuppressed
 
 	v := st.Enabled
 	cfg.TelemetryEnabled = &v
@@ -110,10 +116,14 @@ func (s *defaultStore) Save(st State) error {
 
 	cfg.TelemetryValidity = st.Validity.String()
 
+	sup := st.Suppressed
+	cfg.TelemetrySuppressed = &sup
+
 	if err := s.save(); err != nil {
 		cfg.TelemetryEnabled = prevEnabled
 		cfg.TelemetryEnabledAt = prevEnabledAt
 		cfg.TelemetryValidity = prevValidity
+		cfg.TelemetrySuppressed = prevSuppressed
 
 		return err
 	}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -154,10 +154,6 @@ type telemetryT struct {
 }
 
 func (r *telemetryT) Report(event, domain string, data map[string]any) error {
-	if event == "" {
-		return errors.New("telemetry: event name is required")
-	}
-
 	r.lock.Lock()
 	topic := r.topic
 	enabled := r.enabled
@@ -172,10 +168,6 @@ func (r *telemetryT) Report(event, domain string, data map[string]any) error {
 }
 
 func (r *telemetryT) ReportRequired(event, domain string, data map[string]any) error {
-	if event == "" {
-		return errors.New("telemetry: event name is required")
-	}
-
 	r.lock.Lock()
 	topic := r.topic
 	r.lock.Unlock()
@@ -184,6 +176,10 @@ func (r *telemetryT) ReportRequired(event, domain string, data map[string]any) e
 }
 
 func (r *telemetryT) publish(topic, event, domain string, data map[string]any) error {
+	if event == "" {
+		return errors.New("telemetry: event name is required")
+	}
+
 	msg := fimpgo.NewObjectMessage(MessageType, Service, &Event{
 		Event:  event,
 		Domain: domain,

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -14,8 +14,13 @@ import (
 // Telemetry emits telemetry events over MQTT to the cloud backend-service.
 type Telemetry interface {
 	// Report publishes an event with the given name, optional domain, and
-	// free-form data payload. Returns nil without publishing when disabled.
+	// free-form data payload. Returns nil without publishing when telemetry
+	// is disabled or the source is suppressed.
 	Report(event, domain string, data map[string]any) error
+	// ReportRequired publishes an event that always flows regardless of the
+	// enabled flag or suppressed state. Use for critical events such as
+	// device health transitions that must not be silenced.
+	ReportRequired(event, domain string, data map[string]any) error
 	// SetTargetTopic overrides the default target topic.
 	// Passing an empty string restores the default. The override is
 	// not persisted and resets to the default on restart.
@@ -34,6 +39,11 @@ type Telemetry interface {
 	Validity() time.Duration
 	// SetValidity updates the validity window. Must be positive.
 	SetValidity(validity time.Duration) error
+	// SetSuppressed marks this source as suppressed (true) or active (false).
+	// When suppressed, Report returns nil but ReportRequired still publishes.
+	SetSuppressed(suppressed bool) error
+	// IsSuppressed reports whether this source is currently suppressed.
+	IsSuppressed() bool
 }
 
 // New returns a Telemetry that publishes telemetry events as the given source.
@@ -59,12 +69,13 @@ func New(mqtt *fimpgo.MqttTransport, source string, store Store) (Telemetry, err
 	}
 
 	r := &telemetryT{
-		mqtt:     mqtt,
-		source:   fimptype.ResourceNameT(source),
-		store:    store,
-		topic:    Topic,
-		enabled:  st.Enabled,
-		validity: st.Validity,
+		mqtt:       mqtt,
+		source:     fimptype.ResourceNameT(source),
+		store:      store,
+		topic:      Topic,
+		enabled:    st.Enabled,
+		suppressed: st.Suppressed,
+		validity:   st.Validity,
 	}
 
 	if r.enabled { //nolint:nestif
@@ -133,12 +144,13 @@ type telemetryT struct {
 	source fimptype.ResourceNameT
 	store  Store
 
-	lock      sync.Mutex
-	topic     string
-	enabled   bool
-	validity  time.Duration
-	enabledAt time.Time
-	timer     *time.Timer
+	lock       sync.Mutex
+	topic      string
+	enabled    bool
+	suppressed bool
+	validity   time.Duration
+	enabledAt  time.Time
+	timer      *time.Timer
 }
 
 func (r *telemetryT) Report(event, domain string, data map[string]any) error {
@@ -149,12 +161,29 @@ func (r *telemetryT) Report(event, domain string, data map[string]any) error {
 	r.lock.Lock()
 	topic := r.topic
 	enabled := r.enabled
+	suppressed := r.suppressed
 	r.lock.Unlock()
 
-	if !enabled {
+	if !enabled || suppressed {
 		return nil
 	}
 
+	return r.publish(topic, event, domain, data)
+}
+
+func (r *telemetryT) ReportRequired(event, domain string, data map[string]any) error {
+	if event == "" {
+		return errors.New("telemetry: event name is required")
+	}
+
+	r.lock.Lock()
+	topic := r.topic
+	r.lock.Unlock()
+
+	return r.publish(topic, event, domain, data)
+}
+
+func (r *telemetryT) publish(topic, event, domain string, data map[string]any) error {
 	msg := fimpgo.NewObjectMessage(MessageType, Service, &Event{
 		Event:  event,
 		Domain: domain,
@@ -184,8 +213,9 @@ func (r *telemetryT) Enable(enabled bool) error {
 	defer r.lock.Unlock()
 
 	st := State{
-		Enabled:  enabled,
-		Validity: r.validity,
+		Enabled:    enabled,
+		Validity:   r.validity,
+		Suppressed: r.suppressed,
 	}
 
 	if enabled {
@@ -212,6 +242,33 @@ func (r *telemetryT) IsEnabled() bool {
 	defer r.lock.Unlock()
 
 	return r.enabled
+}
+
+func (r *telemetryT) SetSuppressed(suppressed bool) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	st := State{
+		Enabled:    r.enabled,
+		EnabledAt:  r.enabledAt,
+		Validity:   r.validity,
+		Suppressed: suppressed,
+	}
+
+	if err := r.store.Save(st); err != nil {
+		return fmt.Errorf("telemetry: persist suppressed: %w", err)
+	}
+
+	r.suppressed = suppressed
+
+	return nil
+}
+
+func (r *telemetryT) IsSuppressed() bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.suppressed
 }
 
 func (r *telemetryT) Validity() time.Duration {
@@ -251,9 +308,10 @@ func (r *telemetryT) SetValidity(validity time.Duration) error {
 	}
 
 	st := State{
-		Enabled:   newEnabled,
-		EnabledAt: newEnabledAt,
-		Validity:  validity,
+		Enabled:    newEnabled,
+		EnabledAt:  newEnabledAt,
+		Validity:   validity,
+		Suppressed: r.suppressed,
 	}
 
 	if err := r.store.Save(st); err != nil {
@@ -312,7 +370,7 @@ func (r *telemetryT) disableLocked(reason string) {
 	r.enabledAt = time.Time{}
 	r.timer = nil
 
-	st := State{Validity: r.validity}
+	st := State{Validity: r.validity, Suppressed: r.suppressed}
 
 	if err := r.store.Save(st); err != nil {
 		log.WithError(err).Errorf("[cliff] Telemetry: failed to persist disabled state")

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -18,15 +18,18 @@ import (
 )
 
 const (
-	testSource         = "core-energy-guard"
-	appTopic           = "pt:j1/mt:cmd/rt:app/rn:" + string(telemetry.Service) + "/ad:1"
-	appReportTopic     = "pt:j1/mt:evt/rt:app/rn:" + string(telemetry.Service) + "/ad:1"
-	cmdSetEnabledType  = "cmd.config.set_" + telemetry.SettingEnabled
-	cmdGetEnabledType  = "cmd.config.get_" + telemetry.SettingEnabled
-	evtEnabledReport   = "evt.config." + telemetry.SettingEnabled + "_report"
-	cmdSetValidityType = "cmd.config.set_" + telemetry.SettingValidity
-	cmdGetValidityType = "cmd.config.get_" + telemetry.SettingValidity
-	evtValidityReport  = "evt.config." + telemetry.SettingValidity + "_report"
+	testSource            = "core-energy-guard"
+	appTopic              = "pt:j1/mt:cmd/rt:app/rn:" + string(telemetry.Service) + "/ad:1"
+	appReportTopic        = "pt:j1/mt:evt/rt:app/rn:" + string(telemetry.Service) + "/ad:1"
+	cmdSetEnabledType     = "cmd.config.set_" + telemetry.SettingEnabled
+	cmdGetEnabledType     = "cmd.config.get_" + telemetry.SettingEnabled
+	evtEnabledReport      = "evt.config." + telemetry.SettingEnabled + "_report"
+	cmdSetValidityType    = "cmd.config.set_" + telemetry.SettingValidity
+	cmdGetValidityType    = "cmd.config.get_" + telemetry.SettingValidity
+	evtValidityReport     = "evt.config." + telemetry.SettingValidity + "_report"
+	cmdSetSuppressedType  = "cmd.config.set_" + telemetry.SettingSuppressed
+	cmdGetSuppressedType  = "cmd.config.get_" + telemetry.SettingSuppressed
+	evtSuppressedReport   = "evt.config." + telemetry.SettingSuppressed + "_report"
 )
 
 func TestNew_RejectsInvalidInput(t *testing.T) {
@@ -328,6 +331,163 @@ func TestReporter(t *testing.T) { //nolint:paralleltest
 						},
 						// No Expectations: timer disables the tel.
 					},
+					{
+						Name: "Re-enable for suppressed tests",
+						Callbacks: []suite.Callback{
+							func(t *testing.T) {
+								t.Helper()
+
+								require.NoError(t, tel.SetValidity(telemetry.DefaultValidity))
+								require.NoError(t, tel.Enable(true))
+							},
+						},
+					},
+					{
+						Name: "SetSuppressed(true) silences Report",
+						Callbacks: []suite.Callback{
+							func(t *testing.T) {
+								t.Helper()
+
+								require.NoError(t, tel.SetSuppressed(true))
+								assert.True(t, tel.IsSuppressed())
+
+								err := tel.Report("should_not_publish", "", nil)
+								assert.NoError(t, err)
+							},
+						},
+						// No Expectations: suppressed.
+					},
+					{
+						Name: "ReportRequired publishes when suppressed",
+						Callbacks: []suite.Callback{
+							func(t *testing.T) {
+								t.Helper()
+
+								assert.True(t, tel.IsSuppressed())
+
+								err := tel.ReportRequired("critical_event", "health", nil)
+								assert.NoError(t, err)
+							},
+						},
+						Expectations: []*suite.Expectation{
+							suite.NewExpectation(
+								router.ForTopic(telemetry.Topic),
+								router.ForType(telemetry.MessageType),
+								router.MessageVoterFn(func(msg *fimpgo.Message) bool {
+									var got telemetry.Event
+									if err := msg.Payload.GetObjectValue(&got); err != nil {
+										return false
+									}
+
+									return got.Event == "critical_event"
+								}),
+							),
+						},
+					},
+					{
+						Name: "ReportRequired with empty event name returns error",
+						Callbacks: []suite.Callback{
+							func(t *testing.T) {
+								t.Helper()
+
+								err := tel.ReportRequired("", "health", nil)
+								assert.Error(t, err)
+							},
+						},
+					},
+					{
+						Name: "SetSuppressed(false) restores Report",
+						Callbacks: []suite.Callback{
+							func(t *testing.T) {
+								t.Helper()
+
+								require.NoError(t, tel.SetSuppressed(false))
+								assert.False(t, tel.IsSuppressed())
+
+								err := tel.Report("after_unsuppress", "", nil)
+								assert.NoError(t, err)
+							},
+						},
+						Expectations: []*suite.Expectation{
+							suite.NewExpectation(
+								router.ForTopic(telemetry.Topic),
+								router.ForType(telemetry.MessageType),
+								router.MessageVoterFn(func(msg *fimpgo.Message) bool {
+									var got telemetry.Event
+									if err := msg.Payload.GetObjectValue(&got); err != nil {
+										return false
+									}
+
+									return got.Event == "after_unsuppress"
+								}),
+							),
+						},
+					},
+					{
+						Name: "ReportRequired publishes when disabled",
+						Callbacks: []suite.Callback{
+							func(t *testing.T) {
+								t.Helper()
+
+								require.NoError(t, tel.Enable(false))
+
+								err := tel.ReportRequired("critical_while_disabled", "", nil)
+								assert.NoError(t, err)
+							},
+						},
+						Expectations: []*suite.Expectation{
+							suite.NewExpectation(
+								router.ForTopic(telemetry.Topic),
+								router.ForType(telemetry.MessageType),
+								router.MessageVoterFn(func(msg *fimpgo.Message) bool {
+									var got telemetry.Event
+									if err := msg.Payload.GetObjectValue(&got); err != nil {
+										return false
+									}
+
+									return got.Event == "critical_while_disabled"
+								}),
+							),
+						},
+					},
+					{
+						Name: "Re-enable after ReportRequired disabled test",
+						Callbacks: []suite.Callback{
+							func(t *testing.T) {
+								t.Helper()
+
+								require.NoError(t, tel.Enable(true))
+							},
+						},
+					},
+					{
+						Name:    "cmd.config.set_telemetry_suppressed = true suppresses the source",
+						Command: suite.BoolMessage(appTopic, cmdSetSuppressedType, telemetry.Service, true),
+						Expectations: []*suite.Expectation{
+							suite.ExpectBool(appReportTopic, evtSuppressedReport, telemetry.Service, true),
+						},
+					},
+					{
+						Name:    "cmd.config.get_telemetry_suppressed reports current state",
+						Command: suite.NullMessage(appTopic, cmdGetSuppressedType, telemetry.Service),
+						Expectations: []*suite.Expectation{
+							suite.ExpectBool(appReportTopic, evtSuppressedReport, telemetry.Service, true),
+						},
+						Callbacks: []suite.Callback{
+							func(t *testing.T) {
+								t.Helper()
+
+								assert.True(t, tel.IsSuppressed())
+							},
+						},
+					},
+					{
+						Name:    "cmd.config.set_telemetry_suppressed = false restores the source",
+						Command: suite.BoolMessage(appTopic, cmdSetSuppressedType, telemetry.Service, false),
+						Expectations: []*suite.Expectation{
+							suite.ExpectBool(appReportTopic, evtSuppressedReport, telemetry.Service, false),
+						},
+					},
 				},
 			},
 		},
@@ -573,4 +733,75 @@ func TestDefaultStore_SaveFailure_RestoresConfig(t *testing.T) {
 	// Load must still return the original state.
 	st := store.Load()
 	assert.True(t, st.Enabled)
+}
+
+func TestSetSuppressed_SaveFailure_LeavesStateUnchanged(t *testing.T) {
+	t.Parallel()
+
+	store := &failStore{state: telemetry.State{
+		Enabled:  true,
+		Validity: telemetry.DefaultValidity,
+	}}
+
+	tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
+	require.NoError(t, err)
+	assert.False(t, tel.IsSuppressed())
+
+	store.saveErr = errors.New("disk full")
+	err = tel.SetSuppressed(true)
+	require.Error(t, err)
+
+	assert.False(t, tel.IsSuppressed(), "SetSuppressed must not change in-memory state on Save failure")
+}
+
+func TestEnable_PreservesSuppressedInStore(t *testing.T) {
+	t.Parallel()
+
+	store := &stubStore{state: telemetry.State{
+		Enabled:    true,
+		Suppressed: true,
+		Validity:   telemetry.DefaultValidity,
+	}}
+
+	tel, err := telemetry.New(&fimpgo.MqttTransport{}, testSource, store)
+	require.NoError(t, err)
+	assert.True(t, tel.IsSuppressed())
+
+	// Enable(true) must preserve the suppressed flag in the saved state.
+	store.saveCalls = 0
+
+	require.NoError(t, tel.Enable(true))
+	assert.True(t, store.state.Suppressed, "Enable must preserve Suppressed in persisted state")
+}
+
+func TestNewDefaultStore_SuppressedRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	d := &config.Default{}
+	store := telemetry.NewDefaultStore(func() *config.Default { return d }, func() error { return nil })
+
+	// Default: not suppressed.
+	st := store.Load()
+	assert.False(t, st.Suppressed, "unset suppressed should default to false")
+
+	// Save with suppressed=true.
+	require.NoError(t, store.Save(telemetry.State{
+		Enabled:    true,
+		Suppressed: true,
+		Validity:   telemetry.DefaultValidity,
+	}))
+
+	st = store.Load()
+	assert.True(t, st.Suppressed)
+	assert.NotNil(t, d.TelemetrySuppressed)
+	assert.True(t, *d.TelemetrySuppressed)
+
+	// Save with suppressed=false.
+	require.NoError(t, store.Save(telemetry.State{
+		Enabled:  true,
+		Validity: telemetry.DefaultValidity,
+	}))
+
+	st = store.Load()
+	assert.False(t, st.Suppressed)
 }


### PR DESCRIPTION
## Summary

- Add `ReportRequired()` for critical events that always flow regardless of enabled/suppressed state (e.g., device health transitions)
- Add suppressed sources support with blocklist semantics - cloud tells the hub which app sources to silence, new apps work by default without config changes
- Add `ConfigPull` service that periodically pulls telemetry config from the cloud (same pull-based pattern as energy-price-provider), replacing manual per-hub FIMP commands

## Design

- `Report()` returns nil when disabled OR suppressed; `ReportRequired()` ignores both
- Suppressed state is persisted in `State` and `config.Default`
- `ConfigPull` is a separate `root.Service` (opt-in via `WithServices()`), not integrated into the reporter
- Validity timer kept as safety net - if cloud stops responding, auto-disable still fires
- Config request uses `mt:rsp` topic so CloudBridge's existing LocalToCloud route forwards it

## Test plan

- [x] 38 tests total, all passing
- [x] ReportRequired publishes when disabled and when suppressed
- [x] Report returns nil when suppressed
- [x] SetSuppressed/IsSuppressed round-trip + FIMP routing
- [x] Enable preserves suppressed flag in persisted state
- [x] Save-failure test for SetSuppressed
- [x] ConfigPull applies config from mock cloud response
- [x] ConfigPull suppresses matching source, ignores non-matching
- [x] ConfigPull retries on error with fallback interval
- [x] ConfigPull Stop cancels pending timer
- [x] Past next_update uses fallback interval