### PR TITLE
Add common blocks extracted from edge adapters

### DIFF
--- a/app/check.go
+++ b/app/check.go
@@ -1,0 +1,210 @@
+package app
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/futurehomeno/cliffhanger/backoff"
+	"github.com/futurehomeno/cliffhanger/httpclient"
+	"github.com/futurehomeno/cliffhanger/lifecycle"
+	"github.com/futurehomeno/cliffhanger/utils"
+)
+
+// ConnectivityReporter broadcasts availability of all things, e.g. evt.network.all_nodes_report.
+// It is satisfied by adapter.Adapter. Things reachable over a local transport keep reporting UP
+// through their own Connector.Connectivity() even when the third party API is down.
+type ConnectivityReporter interface {
+	SendConnectivityReport() error
+}
+
+// CheckerConfig configures the ConnectivityChecker recheck behavior.
+type CheckerConfig struct {
+	// Interval between periodic checks. 0 uses DefaultCheckInterval.
+	Interval time.Duration
+	// RecheckBackoff provides delays between rechecks following failed probes.
+	RecheckBackoff backoff.Backoff
+	// MaxRechecks is the number of consecutive probe failures tolerated before reporting disconnection.
+	MaxRechecks uint32
+	// RateLimitDelay is the recheck delay after a rate-limited probe without a Retry-After indication.
+	RateLimitDelay time.Duration
+}
+
+func (c *CheckerConfig) setDefaults() {
+	if c.RecheckBackoff == nil {
+		c.RecheckBackoff = backoff.New(time.Minute, 5*time.Minute, 15*time.Minute, 1, 2)
+	}
+
+	if c.MaxRechecks == 0 {
+		c.MaxRechecks = 1
+	}
+
+	if c.RateLimitDelay == 0 {
+		c.RateLimitDelay = 5 * time.Minute
+	}
+}
+
+// ConnectivityChecker implements CheckableApp by probing the third party API and mapping the
+// outcome onto lifecycle states. The probe should wrap httpclient.ErrUnauthorized on authorization
+// loss and httpclient.ErrTooManyRequests on rate limiting. Other errors are retried with backoff
+// and reported as disconnection only after more than MaxRechecks consecutive failures. On every
+// connectivity or authorization transition all nodes are reported via the ConnectivityReporter.
+type ConnectivityChecker struct {
+	cfg      CheckerConfig
+	probe    func() error
+	lc       *lifecycle.Lifecycle
+	reporter ConnectivityReporter
+	warnLog  utils.Throttle
+
+	mu       sync.Mutex
+	timer    *time.Timer
+	failures uint32
+}
+
+func NewConnectivityChecker(
+	probe func() error,
+	appLifecycle *lifecycle.Lifecycle,
+	reporter ConnectivityReporter,
+	cfg CheckerConfig,
+) *ConnectivityChecker {
+	cfg.setDefaults()
+
+	return &ConnectivityChecker{
+		cfg:      cfg,
+		probe:    probe,
+		lc:       appLifecycle,
+		reporter: reporter,
+	}
+}
+
+func (c *ConnectivityChecker) CheckInterval() time.Duration {
+	return c.cfg.Interval
+}
+
+func (c *ConnectivityChecker) Check() error {
+	err := c.probe()
+	if err == nil {
+		c.Cancel()
+		c.apply(lifecycle.AuthStateAuthenticated, lifecycle.ConnStateConnected)
+
+		return nil
+	}
+
+	if errors.Is(err, httpclient.ErrUnauthorized) {
+		c.Cancel()
+		c.apply(lifecycle.AuthStateLost, lifecycle.ConnStateDisconnected)
+
+		return nil
+	}
+
+	// A rate limit does not mean connectivity is lost, so the connectivity state is left untouched.
+	if errors.Is(err, httpclient.ErrTooManyRequests) {
+		c.Cancel()
+		c.schedule(c.rateLimitDelay(err))
+
+		return nil
+	}
+
+	c.warnLog.Do(err.Error(), func() { log.Warnf("[app] Check probe err: %v", err) })
+
+	failures := c.fail()
+	if failures > c.cfg.MaxRechecks {
+		c.apply("", lifecycle.ConnStateDisconnected)
+	}
+
+	c.schedule(c.cfg.RecheckBackoff.Delay(failures))
+
+	return nil
+}
+
+// Cancel stops a pending recheck and clears the failure counter; call it on logout and reset.
+func (c *ConnectivityChecker) Cancel() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.failures = 0
+	c.warnLog.Reset()
+
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+}
+
+// rateLimitDelay honors a server-requested Retry-After delay if it exceeds the configured one.
+func (c *ConnectivityChecker) rateLimitDelay(err error) time.Duration {
+	delay := c.cfg.RateLimitDelay
+
+	var rateLimitErr *httpclient.TooManyRequestsError
+	if errors.As(err, &rateLimitErr) && rateLimitErr.RetryAfter > delay {
+		return rateLimitErr.RetryAfter
+	}
+
+	return delay
+}
+
+// apply sets the provided lifecycle states (empty auth leaves it untouched) and
+// broadcasts node availability if any of them changed.
+func (c *ConnectivityChecker) apply(auth, conn lifecycle.State) {
+	changed := false
+
+	if auth != "" && c.lc.AuthState() != auth {
+		c.lc.SetAuthState(auth)
+
+		changed = true
+	}
+
+	if c.lc.ConnectionState() != conn {
+		c.lc.SetConnState(conn)
+
+		changed = true
+	}
+
+	if !changed || c.reporter == nil {
+		return
+	}
+
+	if err := c.reporter.SendConnectivityReport(); err != nil {
+		log.Errorf("[app] Send connectivity report err: %v", err)
+	}
+}
+
+// schedule sets a one-shot recheck, skipped if one is already pending.
+func (c *ConnectivityChecker) schedule(delay time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.timer != nil {
+		return
+	}
+
+	log.Infof("[app] Check failed, retrying in %s", delay)
+
+	// The callback compares timer identity to detect a Cancel that raced its firing.
+	var timer *time.Timer
+
+	timer = time.AfterFunc(delay, func() {
+		c.mu.Lock()
+		if c.timer != timer {
+			c.mu.Unlock()
+
+			return
+		}
+		c.timer = nil
+		c.mu.Unlock()
+
+		_ = c.Check()
+	})
+	c.timer = timer
+}
+
+func (c *ConnectivityChecker) fail() uint32 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.failures++
+
+	return c.failures
+}

--- a/app/check.go
+++ b/app/check.go
@@ -61,9 +61,10 @@ type ConnectivityChecker struct {
 	// checkMu serializes Check so overlapping periodic and recheck probes cannot interleave state changes.
 	checkMu sync.Mutex
 
-	mu       sync.Mutex
-	timer    *time.Timer
-	failures uint32
+	mu        sync.Mutex
+	timer     *time.Timer
+	failures  uint32
+	cancelled bool
 }
 
 func NewConnectivityChecker(
@@ -102,7 +103,17 @@ func (c *ConnectivityChecker) Check() error {
 
 // check performs the probe and applies its outcome; the caller must hold checkMu.
 func (c *ConnectivityChecker) check() {
+	c.mu.Lock()
+	c.cancelled = false
+	c.mu.Unlock()
+
 	err := c.probe()
+
+	// A Cancel during the probe (logout or reset) makes its result stale, so it is discarded.
+	if c.stale() {
+		return
+	}
+
 	if err == nil {
 		c.Cancel()
 		c.apply(lifecycle.AuthStateAuthenticated, lifecycle.ConnStateConnected)
@@ -136,11 +147,13 @@ func (c *ConnectivityChecker) check() {
 	c.schedule(c.cfg.RecheckBackoff.Delay(failures))
 }
 
-// Cancel stops a pending recheck and clears the failure counter; call it on logout and reset.
+// Cancel stops a pending recheck, discards the result of an in-flight probe and
+// clears the failure counter; call it on logout and reset.
 func (c *ConnectivityChecker) Cancel() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.cancelled = true
 	c.failures = 0
 	c.warnLog.Reset()
 
@@ -171,16 +184,21 @@ func (c *ConnectivityChecker) pending() bool {
 	return c.timer != nil
 }
 
-// rateLimitDelay honors a server-requested Retry-After delay if it exceeds the configured one.
-func (c *ConnectivityChecker) rateLimitDelay(err error) time.Duration {
-	delay := c.cfg.RateLimitDelay
+func (c *ConnectivityChecker) stale() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
+	return c.cancelled
+}
+
+// rateLimitDelay honors a server-requested Retry-After delay, falling back to the configured one.
+func (c *ConnectivityChecker) rateLimitDelay(err error) time.Duration {
 	var rateLimitErr *httpclient.TooManyRequestsError
-	if errors.As(err, &rateLimitErr) && rateLimitErr.RetryAfter > delay {
+	if errors.As(err, &rateLimitErr) && rateLimitErr.RetryAfter > 0 {
 		return rateLimitErr.RetryAfter
 	}
 
-	return delay
+	return c.cfg.RateLimitDelay
 }
 
 // apply sets the provided lifecycle states (empty auth leaves it untouched) and

--- a/app/check.go
+++ b/app/check.go
@@ -58,6 +58,9 @@ type ConnectivityChecker struct {
 	reporter ConnectivityReporter
 	warnLog  utils.Throttle
 
+	// checkMu serializes Check so overlapping periodic and recheck probes cannot interleave state changes.
+	checkMu sync.Mutex
+
 	mu       sync.Mutex
 	timer    *time.Timer
 	failures uint32
@@ -84,20 +87,35 @@ func (c *ConnectivityChecker) CheckInterval() time.Duration {
 }
 
 func (c *ConnectivityChecker) Check() error {
+	c.checkMu.Lock()
+	defer c.checkMu.Unlock()
+
+	// A pending recheck honors its backoff or Retry-After delay, so the periodic probe is skipped.
+	if c.pending() {
+		return nil
+	}
+
+	c.check()
+
+	return nil
+}
+
+// check performs the probe and applies its outcome; the caller must hold checkMu.
+func (c *ConnectivityChecker) check() {
 	err := c.probe()
 	if err == nil {
 		c.Cancel()
 		c.apply(lifecycle.AuthStateAuthenticated, lifecycle.ConnStateConnected)
 		c.repairAppHealth()
 
-		return nil
+		return
 	}
 
 	if errors.Is(err, httpclient.ErrUnauthorized) {
 		c.Cancel()
 		c.apply(lifecycle.AuthStateLost, lifecycle.ConnStateDisconnected)
 
-		return nil
+		return
 	}
 
 	// A rate limit does not mean connectivity is lost, so the connectivity state is left untouched.
@@ -105,7 +123,7 @@ func (c *ConnectivityChecker) Check() error {
 		c.Cancel()
 		c.schedule(c.rateLimitDelay(err))
 
-		return nil
+		return
 	}
 
 	c.warnLog.Do(err.Error(), func() { log.Warnf("[app] Check probe err: %v", err) })
@@ -116,8 +134,6 @@ func (c *ConnectivityChecker) Check() error {
 	}
 
 	c.schedule(c.cfg.RecheckBackoff.Delay(failures))
-
-	return nil
 }
 
 // Cancel stops a pending recheck and clears the failure counter; call it on logout and reset.
@@ -146,6 +162,13 @@ func (c *ConnectivityChecker) repairAppHealth() {
 
 	c.lc.SetAppHealth(lifecycle.AppHealthRunning, nil)
 	c.lc.SetConfigState(lifecycle.ConfigStateConfigured)
+}
+
+func (c *ConnectivityChecker) pending() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.timer != nil
 }
 
 // rateLimitDelay honors a server-requested Retry-After delay if it exceeds the configured one.
@@ -201,6 +224,11 @@ func (c *ConnectivityChecker) schedule(delay time.Duration) {
 	var timer *time.Timer
 
 	timer = time.AfterFunc(delay, func() {
+		// checkMu is taken before clearing the timer so a periodic Check cannot
+		// slip into the gap and probe back-to-back with this recheck.
+		c.checkMu.Lock()
+		defer c.checkMu.Unlock()
+
 		c.mu.Lock()
 		if c.timer != timer {
 			c.mu.Unlock()
@@ -210,7 +238,7 @@ func (c *ConnectivityChecker) schedule(delay time.Duration) {
 		c.timer = nil
 		c.mu.Unlock()
 
-		_ = c.Check()
+		c.check()
 	})
 	c.timer = timer
 }

--- a/app/check.go
+++ b/app/check.go
@@ -88,6 +88,7 @@ func (c *ConnectivityChecker) Check() error {
 	if err == nil {
 		c.Cancel()
 		c.apply(lifecycle.AuthStateAuthenticated, lifecycle.ConnStateConnected)
+		c.repairAppHealth()
 
 		return nil
 	}
@@ -131,6 +132,20 @@ func (c *ConnectivityChecker) Cancel() {
 		c.timer.Stop()
 		c.timer = nil
 	}
+}
+
+// repairAppHealth restores the running and configured states after a successful probe.
+// A transient failure during authorization may have left the app NOT_CONFIGURED, and the
+// periodic check task does not run while the app is not RUNNING (task.WhenAppIsRunning),
+// so a successful recheck is the only opportunity to repair that state. A successful
+// probe proves valid credentials, which is what configured means for these adapters.
+func (c *ConnectivityChecker) repairAppHealth() {
+	if c.lc.AppHealth() == lifecycle.AppHealthRunning {
+		return
+	}
+
+	c.lc.SetAppHealth(lifecycle.AppHealthRunning, nil)
+	c.lc.SetConfigState(lifecycle.ConfigStateConfigured)
 }
 
 // rateLimitDelay honors a server-requested Retry-After delay if it exceeds the configured one.

--- a/app/check_test.go
+++ b/app/check_test.go
@@ -3,6 +3,7 @@ package app_test
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -111,7 +112,7 @@ func TestConnectivityChecker_Check(t *testing.T) { //nolint:funlen
 			})
 
 			for range errs {
-				assert.NoError(t, checker.Check())
+				assert.NoError(t, checker.CheckNow())
 			}
 
 			checker.Cancel()
@@ -141,6 +142,67 @@ func TestConnectivityChecker_RepairsStrandedAppHealth(t *testing.T) {
 	assert.Equal(t, lifecycle.ConfigStateConfigured, lc.ConfigState())
 	assert.Equal(t, lifecycle.ConnStateConnected, lc.ConnectionState())
 	assert.Equal(t, lifecycle.AuthStateAuthenticated, lc.AuthState())
+}
+
+func TestConnectivityChecker_PendingRecheckSkipsPeriodicProbe(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	probe := func() error {
+		calls.Add(1)
+
+		return errors.New("probe err")
+	}
+
+	checker := app.NewConnectivityChecker(probe, lifecycle.New(nil), nil, app.CheckerConfig{
+		RecheckBackoff: backoff.New(time.Hour, time.Hour, time.Hour, 1, 1),
+	})
+
+	assert.NoError(t, checker.Check())
+	assert.NoError(t, checker.Check())
+	assert.Equal(t, int32(1), calls.Load(), "periodic probe should be skipped while a recheck is pending")
+
+	checker.Cancel()
+
+	assert.NoError(t, checker.Check())
+	assert.Equal(t, int32(2), calls.Load(), "probe should resume once the pending recheck is canceled")
+}
+
+func TestConnectivityChecker_ConcurrentChecks(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	probe := func() error {
+		if calls.Add(1)%2 == 0 {
+			return errors.New("probe err")
+		}
+
+		return nil
+	}
+
+	checker := app.NewConnectivityChecker(probe, lifecycle.New(nil), &fakeReporter{}, app.CheckerConfig{
+		RecheckBackoff: backoff.New(time.Hour, time.Hour, time.Hour, 1, 1),
+	})
+
+	var wg sync.WaitGroup
+
+	for range 8 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			assert.NoError(t, checker.Check())
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Positive(t, calls.Load())
+
+	checker.Cancel()
 }
 
 func TestConnectivityChecker_Recheck(t *testing.T) {

--- a/app/check_test.go
+++ b/app/check_test.go
@@ -1,0 +1,147 @@
+package app_test
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/app"
+	"github.com/futurehomeno/cliffhanger/backoff"
+	"github.com/futurehomeno/cliffhanger/httpclient"
+	"github.com/futurehomeno/cliffhanger/lifecycle"
+)
+
+type fakeReporter struct {
+	reports atomic.Int32
+}
+
+func (r *fakeReporter) SendConnectivityReport() error {
+	r.reports.Add(1)
+
+	return nil
+}
+
+func TestConnectivityChecker_Check(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	probeErr := errors.New("probe err")
+
+	testCases := []struct {
+		name        string
+		probeErrs   []error
+		wantAuth    lifecycle.State
+		wantConn    lifecycle.State
+		wantReports int32
+	}{
+		{
+			name:        "success marks authenticated and connected",
+			probeErrs:   []error{nil},
+			wantAuth:    lifecycle.AuthStateAuthenticated,
+			wantConn:    lifecycle.ConnStateConnected,
+			wantReports: 1,
+		},
+		{
+			name:        "unauthorized marks auth lost and disconnected",
+			probeErrs:   []error{fmt.Errorf("wrap: %w", httpclient.ErrUnauthorized)},
+			wantAuth:    lifecycle.AuthStateLost,
+			wantConn:    lifecycle.ConnStateDisconnected,
+			wantReports: 1,
+		},
+		{
+			name:        "rate limit leaves states untouched",
+			probeErrs:   []error{nil, httpclient.ErrTooManyRequests},
+			wantAuth:    lifecycle.AuthStateAuthenticated,
+			wantConn:    lifecycle.ConnStateConnected,
+			wantReports: 1,
+		},
+		{
+			name:        "rate limit with retry-after leaves states untouched",
+			probeErrs:   []error{nil, &httpclient.TooManyRequestsError{RetryAfter: time.Hour}},
+			wantAuth:    lifecycle.AuthStateAuthenticated,
+			wantConn:    lifecycle.ConnStateConnected,
+			wantReports: 1,
+		},
+		{
+			name:        "single transient failure does not disconnect",
+			probeErrs:   []error{nil, probeErr},
+			wantAuth:    lifecycle.AuthStateAuthenticated,
+			wantConn:    lifecycle.ConnStateConnected,
+			wantReports: 1,
+		},
+		{
+			name:        "second consecutive failure disconnects",
+			probeErrs:   []error{nil, probeErr, probeErr},
+			wantAuth:    lifecycle.AuthStateAuthenticated,
+			wantConn:    lifecycle.ConnStateDisconnected,
+			wantReports: 2,
+		},
+		{
+			name:        "recovery after failure reconnects",
+			probeErrs:   []error{nil, probeErr, probeErr, nil},
+			wantAuth:    lifecycle.AuthStateAuthenticated,
+			wantConn:    lifecycle.ConnStateConnected,
+			wantReports: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			errs := tc.probeErrs
+			call := 0
+			probe := func() error {
+				err := errs[call]
+				call++
+
+				return err
+			}
+
+			lc := lifecycle.New(nil)
+			reporter := &fakeReporter{}
+
+			checker := app.NewConnectivityChecker(probe, lc, reporter, app.CheckerConfig{
+				// An hour-long recheck delay ensures scheduled rechecks never fire within the test.
+				RecheckBackoff: backoff.New(time.Hour, time.Hour, time.Hour, 1, 1),
+				RateLimitDelay: time.Hour,
+			})
+
+			for range errs {
+				assert.NoError(t, checker.Check())
+			}
+
+			checker.Cancel()
+
+			assert.Equal(t, tc.wantAuth, lc.AuthState())
+			assert.Equal(t, tc.wantConn, lc.ConnectionState())
+			assert.Equal(t, tc.wantReports, reporter.reports.Load())
+		})
+	}
+}
+
+func TestConnectivityChecker_Recheck(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	probe := func() error {
+		calls.Add(1)
+
+		return errors.New("probe err")
+	}
+
+	checker := app.NewConnectivityChecker(probe, lifecycle.New(nil), nil, app.CheckerConfig{
+		RecheckBackoff: backoff.New(time.Millisecond, time.Millisecond, time.Millisecond, 1, 1),
+	})
+
+	assert.NoError(t, checker.Check())
+
+	assert.Eventually(t, func() bool { return calls.Load() >= 2 }, time.Second, 5*time.Millisecond,
+		"scheduled recheck should re-run the probe")
+
+	checker.Cancel()
+}

--- a/app/check_test.go
+++ b/app/check_test.go
@@ -123,6 +123,26 @@ func TestConnectivityChecker_Check(t *testing.T) { //nolint:funlen
 	}
 }
 
+func TestConnectivityChecker_RepairsStrandedAppHealth(t *testing.T) {
+	t.Parallel()
+
+	lc := lifecycle.New(nil)
+	// A transient failure during authorization strands the app in NOT_CONFIGURED;
+	// the periodic check task does not run in this state, so the successful
+	// recheck must repair the app health, not just connectivity.
+	lc.SetAppHealth(lifecycle.AppHealthNotConfigured, nil)
+	lc.SetConfigState(lifecycle.ConfigStateNotConfigured)
+
+	checker := app.NewConnectivityChecker(func() error { return nil }, lc, nil, app.CheckerConfig{})
+
+	assert.NoError(t, checker.Check())
+
+	assert.Equal(t, lifecycle.AppHealthRunning, lc.AppHealth())
+	assert.Equal(t, lifecycle.ConfigStateConfigured, lc.ConfigState())
+	assert.Equal(t, lifecycle.ConnStateConnected, lc.ConnectionState())
+	assert.Equal(t, lifecycle.AuthStateAuthenticated, lc.AuthState())
+}
+
 func TestConnectivityChecker_Recheck(t *testing.T) {
 	t.Parallel()
 

--- a/app/check_test.go
+++ b/app/check_test.go
@@ -144,6 +144,68 @@ func TestConnectivityChecker_RepairsStrandedAppHealth(t *testing.T) {
 	assert.Equal(t, lifecycle.AuthStateAuthenticated, lc.AuthState())
 }
 
+func TestConnectivityChecker_CancelDiscardsInFlightProbe(t *testing.T) {
+	t.Parallel()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	probe := func() error {
+		close(entered)
+		<-release
+
+		return nil
+	}
+
+	lc := lifecycle.New(nil)
+	reporter := &fakeReporter{}
+	checker := app.NewConnectivityChecker(probe, lc, reporter, app.CheckerConfig{})
+
+	wantAuth, wantConn := lc.AuthState(), lc.ConnectionState()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		assert.NoError(t, checker.Check())
+	}()
+
+	<-entered
+	checker.Cancel()
+	close(release)
+	<-done
+
+	assert.Equal(t, wantAuth, lc.AuthState(), "stale probe result should not change the auth state")
+	assert.Equal(t, wantConn, lc.ConnectionState(), "stale probe result should not change the connectivity state")
+	assert.Equal(t, int32(0), reporter.reports.Load())
+}
+
+func TestConnectivityChecker_ShortRetryAfterHonored(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	probe := func() error {
+		if calls.Add(1) == 1 {
+			return &httpclient.TooManyRequestsError{RetryAfter: time.Millisecond}
+		}
+
+		return nil
+	}
+
+	checker := app.NewConnectivityChecker(probe, lifecycle.New(nil), nil, app.CheckerConfig{
+		RateLimitDelay: time.Hour,
+	})
+
+	assert.NoError(t, checker.Check())
+
+	assert.Eventually(t, func() bool { return calls.Load() >= 2 }, time.Second, 5*time.Millisecond,
+		"recheck should honor a server Retry-After shorter than the configured fallback delay")
+
+	checker.Cancel()
+}
+
 func TestConnectivityChecker_PendingRecheckSkipsPeriodicProbe(t *testing.T) {
 	t.Parallel()
 

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -1,0 +1,14 @@
+package app
+
+// CheckNow fires a pending recheck immediately, or performs a regular check if none is pending.
+// It lets tests drive consecutive probes deterministically in place of the recheck timer.
+func (c *ConnectivityChecker) CheckNow() error {
+	c.mu.Lock()
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+	c.mu.Unlock()
+
+	return c.Check()
+}

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"errors"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+var jwtParser = jwt.NewParser()
+
+// TokenExpirationDate returns the expiration date (UTC) of the JWT token without verifying its signature.
+func TokenExpirationDate(jwtToken string) (time.Time, error) {
+	var claims jwt.RegisteredClaims
+
+	_, _, err := jwtParser.ParseUnverified(jwtToken, &claims)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if claims.ExpiresAt == nil {
+		return time.Time{}, errors.New("no expiration date found in the token")
+	}
+
+	return claims.ExpiresAt.UTC(), nil
+}

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -1,0 +1,35 @@
+package auth_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/auth"
+)
+
+func TestTokenExpirationDate(t *testing.T) {
+	t.Parallel()
+
+	expiry := time.Now().Add(time.Hour).Truncate(time.Second).UTC()
+
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(expiry),
+	}).SignedString([]byte("secret"))
+	assert.NoError(t, err)
+
+	got, err := auth.TokenExpirationDate(token)
+	assert.NoError(t, err)
+	assert.Equal(t, expiry, got)
+
+	noExpiry, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{}).SignedString([]byte("secret"))
+	assert.NoError(t, err)
+
+	_, err = auth.TokenExpirationDate(noExpiry)
+	assert.Error(t, err)
+
+	_, err = auth.TokenExpirationDate("not-a-token")
+	assert.Error(t, err)
+}

--- a/backoff/presets.go
+++ b/backoff/presets.go
@@ -1,0 +1,9 @@
+package backoff
+
+import "time"
+
+// NewTolerantFixed returns a stateful backoff applying no delay for the first tolerance
+// consecutive failures (absorbing transient blips) and a fixed delay afterwards.
+func NewTolerantFixed(tolerance uint32, delay time.Duration) Stateful {
+	return NewStateful(0, delay, delay, tolerance, tolerance)
+}

--- a/backoff/presets_test.go
+++ b/backoff/presets_test.go
@@ -1,0 +1,24 @@
+package backoff_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/backoff"
+)
+
+func TestNewTolerantFixed(t *testing.T) {
+	t.Parallel()
+
+	b := backoff.NewTolerantFixed(2, 5*time.Minute)
+
+	assert.Equal(t, time.Duration(0), b.Next(), "first failure should not be delayed")
+	assert.Equal(t, time.Duration(0), b.Next(), "second failure should not be delayed")
+	assert.Equal(t, 5*time.Minute, b.Next(), "third failure should be delayed")
+	assert.Equal(t, 5*time.Minute, b.Next(), "further failures should keep the fixed delay")
+
+	b.Reset()
+	assert.Equal(t, time.Duration(0), b.Next(), "reset should restore tolerance")
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ retract v1.19.0 // bad release, pushed by mistake
 
 require (
 	github.com/futurehomeno/fimpgo v1.17.1
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/mitchellh/mapstructure v1.5.0
@@ -22,7 +23,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/eclipse/paho.mqtt.golang v1.5.1 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/tidwall/btree v1.8.1/go.mod h1:jBbTdUWhSZClZWoDg54VnvV7/54modSOzDN7VX
 github.com/tidwall/buntdb v1.3.2 h1:qd+IpdEGs0pZci37G4jF51+fSKlkuUTMXuHhXL1AkKg=
 github.com/tidwall/buntdb v1.3.2/go.mod h1:lZZrZUWzlyDJKlLQ6DKAy53LnG7m5kHyrEHvvcDmBpU=
 github.com/tidwall/gjson v1.12.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
-github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.19.0 h1:xwxm7n691Uf3u5OFjzngavjGTh55KX5q/9w9xHW88JU=
 github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=
 github.com/tidwall/grect v0.1.4 h1:dA3oIgNgWdSspFzn1kS4S/RDpZFLrIxAZOdJKjYapOg=
@@ -65,8 +63,6 @@ github.com/tidwall/tinyqueue v0.1.1 h1:SpNEvEggbpyN5DIReaJ2/1ndroY8iyEGxPYxoSaym
 github.com/tidwall/tinyqueue v0.1.1/go.mod h1:O/QNHwrnjqr6IHItYrzoHAKYhBkLI67Q096fQP5zMYw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
-golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
 golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
@@ -74,8 +70,6 @@ golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/httpclient/builder.go
+++ b/httpclient/builder.go
@@ -1,0 +1,63 @@
+package httpclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+// RequestBuilder builds an HTTP request with optional JSON body and headers.
+type RequestBuilder struct {
+	method  string
+	url     string
+	body    any
+	headers map[string]string
+}
+
+func NewRequest(method, url string) *RequestBuilder {
+	return &RequestBuilder{
+		method:  method,
+		url:     url,
+		headers: make(map[string]string),
+	}
+}
+
+// WithJSONBody sets the request body to the JSON encoding of v and the Content-Type header accordingly.
+func (b *RequestBuilder) WithJSONBody(v any) *RequestBuilder {
+	b.body = v
+	b.headers["Content-Type"] = "application/json"
+
+	return b
+}
+
+func (b *RequestBuilder) WithHeader(key, value string) *RequestBuilder {
+	b.headers[key] = value
+
+	return b
+}
+
+func (b *RequestBuilder) Build(ctx context.Context) (*http.Request, error) {
+	var body io.Reader
+
+	if b.body != nil {
+		data, err := json.Marshal(b.body)
+		if err != nil {
+			return nil, err
+		}
+
+		body = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, b.method, b.url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	for key, value := range b.headers {
+		req.Header.Set(key, value)
+	}
+
+	return req, nil
+}

--- a/httpclient/errors.go
+++ b/httpclient/errors.go
@@ -58,12 +58,24 @@ func ErrorFromResponse(resp *http.Response) error {
 	return ErrorFromStatus(resp.StatusCode)
 }
 
-// RetryAfter returns the delay the server asks for via the Retry-After header (seconds), or 0.
+// RetryAfter returns the delay the server asks for via the Retry-After header
+// (delta-seconds or HTTP-date form), or 0.
 func RetryAfter(resp *http.Response) time.Duration {
-	secs, err := strconv.Atoi(resp.Header.Get("Retry-After"))
-	if err != nil || secs <= 0 {
-		return 0
+	header := resp.Header.Get("Retry-After")
+
+	if secs, err := strconv.Atoi(header); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+
+		return time.Duration(secs) * time.Second
 	}
 
-	return time.Duration(secs) * time.Second
+	if date, err := http.ParseTime(header); err == nil {
+		if delay := time.Until(date); delay > 0 {
+			return delay
+		}
+	}
+
+	return 0
 }

--- a/httpclient/errors.go
+++ b/httpclient/errors.go
@@ -1,0 +1,69 @@
+package httpclient
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+var (
+	// ErrUnauthorized is returned when the API responds with 401 or 403.
+	ErrUnauthorized = errors.New("unauthorized")
+	// ErrNotFound is returned when the API responds with 404.
+	ErrNotFound = errors.New("not found")
+	// ErrTooManyRequests is returned when the API responds with 429.
+	ErrTooManyRequests = errors.New("too many requests")
+)
+
+// TooManyRequestsError carries the server-requested Retry-After delay.
+// It matches ErrTooManyRequests with errors.Is.
+type TooManyRequestsError struct {
+	RetryAfter time.Duration
+}
+
+func (e *TooManyRequestsError) Error() string {
+	return ErrTooManyRequests.Error()
+}
+
+func (e *TooManyRequestsError) Is(target error) bool {
+	return target == ErrTooManyRequests
+}
+
+// ErrorFromStatus maps an HTTP status code to a shared sentinel error.
+// It returns nil for success codes and a generic error for other failures.
+func ErrorFromStatus(statusCode int) error {
+	switch {
+	case statusCode < http.StatusMultipleChoices:
+		return nil
+	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden:
+		return ErrUnauthorized
+	case statusCode == http.StatusNotFound:
+		return ErrNotFound
+	case statusCode == http.StatusTooManyRequests:
+		return ErrTooManyRequests
+	default:
+		return fmt.Errorf("unexpected response status: %d", statusCode)
+	}
+}
+
+// ErrorFromResponse maps the response status like ErrorFromStatus, carrying
+// the Retry-After delay in a TooManyRequestsError when rate limited.
+func ErrorFromResponse(resp *http.Response) error {
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return &TooManyRequestsError{RetryAfter: RetryAfter(resp)}
+	}
+
+	return ErrorFromStatus(resp.StatusCode)
+}
+
+// RetryAfter returns the delay the server asks for via the Retry-After header (seconds), or 0.
+func RetryAfter(resp *http.Response) time.Duration {
+	secs, err := strconv.Atoi(resp.Header.Get("Retry-After"))
+	if err != nil || secs <= 0 {
+		return 0
+	}
+
+	return time.Duration(secs) * time.Second
+}

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -76,4 +76,12 @@ func TestRetryAfter(t *testing.T) {
 
 	resp.Header.Set("Retry-After", "invalid")
 	assert.Equal(t, time.Duration(0), httpclient.RetryAfter(resp))
+
+	resp.Header.Set("Retry-After", time.Now().Add(2*time.Minute).UTC().Format(http.TimeFormat))
+	delay := httpclient.RetryAfter(resp)
+	assert.Greater(t, delay, time.Minute)
+	assert.LessOrEqual(t, delay, 2*time.Minute)
+
+	resp.Header.Set("Retry-After", time.Now().Add(-time.Minute).UTC().Format(http.TimeFormat))
+	assert.Equal(t, time.Duration(0), httpclient.RetryAfter(resp))
 }

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -1,0 +1,79 @@
+package httpclient_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/httpclient"
+)
+
+func TestRequestBuilder(t *testing.T) {
+	t.Parallel()
+
+	req, err := httpclient.NewRequest(http.MethodPost, "https://example.com/api").
+		WithJSONBody(map[string]string{"key": "value"}).
+		WithHeader("Authorization", "Bearer token").
+		Build(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodPost, req.Method)
+	assert.Equal(t, "https://example.com/api", req.URL.String())
+	assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
+	assert.Equal(t, "Bearer token", req.Header.Get("Authorization"))
+
+	body, err := io.ReadAll(req.Body)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"key":"value"}`, string(body))
+
+	req, err = httpclient.NewRequest(http.MethodGet, "https://example.com").Build(context.Background())
+	assert.NoError(t, err)
+	assert.Nil(t, req.Body)
+}
+
+func TestErrorFromStatus(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, httpclient.ErrorFromStatus(http.StatusOK))
+	assert.NoError(t, httpclient.ErrorFromStatus(http.StatusNoContent))
+	assert.ErrorIs(t, httpclient.ErrorFromStatus(http.StatusUnauthorized), httpclient.ErrUnauthorized)
+	assert.ErrorIs(t, httpclient.ErrorFromStatus(http.StatusForbidden), httpclient.ErrUnauthorized)
+	assert.ErrorIs(t, httpclient.ErrorFromStatus(http.StatusNotFound), httpclient.ErrNotFound)
+	assert.ErrorIs(t, httpclient.ErrorFromStatus(http.StatusTooManyRequests), httpclient.ErrTooManyRequests)
+	assert.Error(t, httpclient.ErrorFromStatus(http.StatusBadGateway))
+}
+
+func TestErrorFromResponse(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}}
+	resp.Header.Set("Retry-After", "30")
+
+	err := httpclient.ErrorFromResponse(resp)
+	assert.ErrorIs(t, err, httpclient.ErrTooManyRequests)
+
+	var rateLimitErr *httpclient.TooManyRequestsError
+
+	assert.ErrorAs(t, err, &rateLimitErr)
+	assert.Equal(t, 30*time.Second, rateLimitErr.RetryAfter)
+
+	assert.NoError(t, httpclient.ErrorFromResponse(&http.Response{StatusCode: http.StatusOK}))
+	assert.ErrorIs(t, httpclient.ErrorFromResponse(&http.Response{StatusCode: http.StatusForbidden}), httpclient.ErrUnauthorized)
+}
+
+func TestRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{Header: http.Header{}}
+	assert.Equal(t, time.Duration(0), httpclient.RetryAfter(resp))
+
+	resp.Header.Set("Retry-After", "30")
+	assert.Equal(t, 30*time.Second, httpclient.RetryAfter(resp))
+
+	resp.Header.Set("Retry-After", "invalid")
+	assert.Equal(t, time.Duration(0), httpclient.RetryAfter(resp))
+}

--- a/root/app_test.go
+++ b/root/app_test.go
@@ -102,7 +102,9 @@ func TestApp_Reset(t *testing.T) { //nolint:paralleltest
 				Setup: suite.ServiceSetup(func(t *testing.T) (service suite.Service, mocks []suite.Mock) {
 					t.Helper()
 
-					mqtt := suite.DefaultMQTT("root_app", "", "", "")
+					// A distinct client ID keeps a late auto-reconnect of the previous test's
+					// client from taking over this session mid-subscribe.
+					mqtt := suite.DefaultMQTT("root_app_reset", "", "", "")
 
 					resetter := mockedroot.NewResetter(t).MockReset(nil)
 

--- a/router/stats.go
+++ b/router/stats.go
@@ -1,0 +1,33 @@
+package router
+
+import (
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// DefaultLogStats returns a stats callback logging incoming and outgoing FIMP messages.
+// Values of incoming messages whose interface matches one of the provided prefixes
+// (e.g. "cmd.auth.") are redacted, as they may carry plaintext credentials.
+func DefaultLogStats(redactedInterfacePrefixes ...string) func(Stats) {
+	return func(stats Stats) {
+		if stats.InputMessage != nil && stats.InputMessage.Payload != nil && log.IsLevelEnabled(log.InfoLevel) {
+			payload := stats.InputMessage.Payload
+			value := payload.Value
+
+			for _, prefix := range redactedInterfacePrefixes {
+				if strings.HasPrefix(payload.Interface, prefix) {
+					value = "***"
+
+					break
+				}
+			}
+
+			log.Infof("FIMP %s -> %s %s %v", payload.Source, payload.Service, payload.Interface, value)
+		}
+
+		if stats.OutputMessage != nil && stats.OutputMessage.Payload != nil && log.IsLevelEnabled(log.DebugLevel) {
+			log.Debugf("FIMP <- %s %s", stats.OutputMessage.Payload.Service, stats.OutputMessage.Payload.Interface)
+		}
+	}
+}

--- a/router/stats_test.go
+++ b/router/stats_test.go
@@ -1,0 +1,50 @@
+package router_test
+
+import (
+	"testing"
+
+	"github.com/futurehomeno/fimpgo"
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/router"
+)
+
+func TestDefaultLogStats(t *testing.T) {
+	hook := test.NewGlobal()
+	defer hook.Reset()
+
+	log.SetLevel(log.DebugLevel)
+
+	logStats := router.DefaultLogStats("cmd.auth.")
+
+	logStats(router.Stats{}) // must not panic on empty stats
+
+	logStats(router.Stats{
+		InputMessage: &fimpgo.Message{Payload: &fimpgo.FimpMessage{
+			Interface: "cmd.auth.login",
+			Service:   "test",
+			Value:     "secret-password",
+		}},
+	})
+
+	logStats(router.Stats{
+		InputMessage: &fimpgo.Message{Payload: &fimpgo.FimpMessage{
+			Interface: "cmd.binary.set",
+			Service:   "test",
+			Value:     true,
+		}},
+		OutputMessage: &fimpgo.Message{Payload: &fimpgo.FimpMessage{
+			Interface: "evt.binary.report",
+			Service:   "test",
+		}},
+	})
+
+	entries := hook.AllEntries()
+	assert.Len(t, entries, 3)
+	assert.Contains(t, entries[0].Message, "***")
+	assert.NotContains(t, entries[0].Message, "secret-password")
+	assert.Contains(t, entries[1].Message, "true")
+	assert.Contains(t, entries[2].Message, "evt.binary.report")
+}

--- a/utils/throttle.go
+++ b/utils/throttle.go
@@ -1,0 +1,31 @@
+package utils
+
+import "sync"
+
+// Throttle collapses runs of an identical message into a single emission: Do runs
+// emit only when key differs from the previous call, so a persistent error (e.g. a
+// revoked token repeated on every retry) is logged once instead of forever.
+type Throttle struct {
+	mu   sync.Mutex
+	last string
+}
+
+// Do invokes emit unless key matches the last key passed to Do.
+func (t *Throttle) Do(key string, emit func()) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if key == t.last {
+		return
+	}
+
+	t.last = key
+	emit()
+}
+
+// Reset forgets the last key so the next Do always emits.
+func (t *Throttle) Reset() {
+	t.mu.Lock()
+	t.last = ""
+	t.mu.Unlock()
+}

--- a/utils/throttle_test.go
+++ b/utils/throttle_test.go
@@ -1,0 +1,29 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/utils"
+)
+
+func TestThrottle(t *testing.T) {
+	t.Parallel()
+
+	var throttle utils.Throttle
+
+	emitted := 0
+	emit := func() { emitted++ }
+
+	throttle.Do("a", emit)
+	throttle.Do("a", emit)
+	assert.Equal(t, 1, emitted, "repeated key should emit once")
+
+	throttle.Do("b", emit)
+	assert.Equal(t, 2, emitted, "new key should emit")
+
+	throttle.Reset()
+	throttle.Do("b", emit)
+	assert.Equal(t, 3, emitted, "reset should allow the same key to emit again")
+}


### PR DESCRIPTION
- app.ConnectivityChecker: configurable check/recheck with backoff, rate-limit handling and all-nodes connectivity reporting on state transitions
- httpclient: request builder, status->sentinel errors, Retry-After support
- auth.TokenExpirationDate, backoff.NewTolerantFixed, utils.Throttle, router.DefaultLogStats with credential redaction