### PR TITLE
Add lifecycle bundles, app flows and generic config service (wave 2)

### DIFF
--- a/app/flow.go
+++ b/app/flow.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/futurehomeno/cliffhanger/lifecycle"
+)
+
+// ThingDestroyer destroys all things of an application. It is satisfied by adapter.Adapter.
+type ThingDestroyer interface {
+	DestroyAllThings() error
+}
+
+// Reset destroys all things, resets the configuration and marks the application as not
+// configured. Optional teardown hooks run first, e.g. to cancel checks or close connections.
+func Reset(appLifecycle *lifecycle.Lifecycle, things ThingDestroyer, resetConfig func() error, teardown ...func()) error {
+	for _, fn := range teardown {
+		fn()
+	}
+
+	if err := things.DestroyAllThings(); err != nil {
+		return fmt.Errorf("destroy things: %w", err)
+	}
+
+	if err := resetConfig(); err != nil {
+		return fmt.Errorf("reset configuration: %w", err)
+	}
+
+	appLifecycle.MarkNotConfigured()
+
+	return nil
+}
+
+// Logout clears credentials and marks the application as not configured.
+// Optional teardown hooks run first, e.g. to cancel checks or close connections.
+func Logout(appLifecycle *lifecycle.Lifecycle, clearCredentials func() error, teardown ...func()) error {
+	for _, fn := range teardown {
+		fn()
+	}
+
+	if err := clearCredentials(); err != nil {
+		return fmt.Errorf("clear credentials: %w", err)
+	}
+
+	appLifecycle.MarkNotConfigured()
+
+	return nil
+}
+
+// Authorize persists new credentials and promotes the application to running if the
+// subsequent check confirms connectivity. Check failures are reported through
+// lifecycle states rather than an error, matching CheckableApp semantics.
+func Authorize(appLifecycle *lifecycle.Lifecycle, persistCredentials, check func() error) error {
+	if err := persistCredentials(); err != nil {
+		return fmt.Errorf("persist credentials: %w", err)
+	}
+
+	if err := check(); err != nil {
+		return err
+	}
+
+	if appLifecycle.ConnectionState() == lifecycle.ConnStateConnected {
+		appLifecycle.MarkRunning()
+	}
+
+	return nil
+}
+
+// ConfigModel casts the model provided to Configure to the application configuration type.
+func ConfigModel[T any](model any) (T, error) {
+	cfg, ok := model.(T)
+	if !ok {
+		return cfg, fmt.Errorf("expected configuration model of type %T, got %T", cfg, model)
+	}
+
+	return cfg, nil
+}

--- a/app/flow.go
+++ b/app/flow.go
@@ -48,8 +48,9 @@ func Logout(appLifecycle *lifecycle.Lifecycle, clearCredentials func() error, te
 }
 
 // Authorize persists new credentials and promotes the application to running if the
-// subsequent check confirms connectivity. Check failures are reported through
-// lifecycle states rather than an error, matching CheckableApp semantics.
+// subsequent check confirms connectivity. Connectivity failures are reported through
+// lifecycle states set by check itself, matching CheckableApp semantics; an error
+// returned by check is a hard failure that aborts promotion and is propagated.
 func Authorize(appLifecycle *lifecycle.Lifecycle, persistCredentials, check func() error) error {
 	if err := persistCredentials(); err != nil {
 		return fmt.Errorf("persist credentials: %w", err)

--- a/app/flow_test.go
+++ b/app/flow_test.go
@@ -1,0 +1,107 @@
+package app_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/app"
+	"github.com/futurehomeno/cliffhanger/lifecycle"
+)
+
+type fakeDestroyer struct {
+	err    error
+	called bool
+}
+
+func (d *fakeDestroyer) DestroyAllThings() error {
+	d.called = true
+
+	return d.err
+}
+
+func TestReset(t *testing.T) {
+	t.Parallel()
+
+	lc := lifecycle.New(nil)
+	lc.MarkRunning()
+
+	destroyer := &fakeDestroyer{}
+	tornDown := false
+	resetCalled := false
+
+	err := app.Reset(lc, destroyer, func() error { resetCalled = true; return nil }, func() { tornDown = true })
+
+	assert.NoError(t, err)
+	assert.True(t, tornDown)
+	assert.True(t, destroyer.called)
+	assert.True(t, resetCalled)
+	assert.Equal(t, lifecycle.AppHealthNotConfigured, lc.AppHealth())
+
+	lc.MarkRunning()
+
+	err = app.Reset(lc, &fakeDestroyer{err: errors.New("destroy err")}, func() error { return nil })
+
+	assert.Error(t, err)
+	assert.Equal(t, lifecycle.AppHealthRunning, lc.AppHealth(), "states should be left untouched on failure")
+}
+
+func TestLogout(t *testing.T) {
+	t.Parallel()
+
+	lc := lifecycle.New(nil)
+	lc.MarkRunning()
+
+	err := app.Logout(lc, func() error { return nil })
+
+	assert.NoError(t, err)
+	assert.Equal(t, lifecycle.AuthStateNotAuthenticated, lc.AuthState())
+
+	lc.MarkRunning()
+
+	err = app.Logout(lc, func() error { return errors.New("clear err") })
+
+	assert.Error(t, err)
+	assert.Equal(t, lifecycle.AuthStateAuthenticated, lc.AuthState())
+}
+
+func TestAuthorize(t *testing.T) {
+	t.Parallel()
+
+	lc := lifecycle.New(nil)
+
+	err := app.Authorize(lc, func() error { return errors.New("persist err") }, func() error { return nil })
+	assert.Error(t, err)
+
+	err = app.Authorize(lc, func() error { return nil }, func() error {
+		lc.SetConnState(lifecycle.ConnStateDisconnected)
+
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.NotEqual(t, lifecycle.AppHealthRunning, lc.AppHealth(), "should not promote when check left the app disconnected")
+
+	err = app.Authorize(lc, func() error { return nil }, func() error {
+		lc.SetConnState(lifecycle.ConnStateConnected)
+
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, lifecycle.AppHealthRunning, lc.AppHealth())
+	assert.Equal(t, lifecycle.ConfigStateConfigured, lc.ConfigState())
+}
+
+func TestConfigModel(t *testing.T) {
+	t.Parallel()
+
+	type cfg struct{ Name string }
+
+	got, err := app.ConfigModel[*cfg](any(&cfg{Name: "test"}))
+	assert.NoError(t, err)
+	assert.Equal(t, "test", got.Name)
+
+	_, err = app.ConfigModel[*cfg](any("wrong type"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected configuration model")
+}

--- a/app/flow_test.go
+++ b/app/flow_test.go
@@ -82,6 +82,10 @@ func TestAuthorize(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEqual(t, lifecycle.AppHealthRunning, lc.AppHealth(), "should not promote when check left the app disconnected")
 
+	err = app.Authorize(lc, func() error { return nil }, func() error { return errors.New("check err") })
+	assert.Error(t, err, "hard check failure should be propagated")
+	assert.NotEqual(t, lifecycle.AppHealthRunning, lc.AppHealth())
+
 	err = app.Authorize(lc, func() error { return nil }, func() error {
 		lc.SetConnState(lifecycle.ConnStateConnected)
 

--- a/config/backoff.go
+++ b/config/backoff.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"github.com/futurehomeno/cliffhanger/backoff"
+)
+
+// BackoffConfig is a backoff specification persisted as part of application configuration.
+type BackoffConfig struct {
+	Initial       string `json:"initial"`
+	Repeated      string `json:"repeated"`
+	Final         string `json:"final"`
+	InitialCount  uint32 `json:"initial_count"`
+	RepeatedCount uint32 `json:"repeated_count"`
+}
+
+// Stateful builds a stateful backoff from the configuration, falling back to def for
+// unset or unparsable durations and zero counts.
+func (c BackoffConfig) Stateful(def BackoffConfig) backoff.Stateful {
+	initialCount, repeatedCount := c.InitialCount, c.RepeatedCount
+	if initialCount == 0 {
+		initialCount = def.InitialCount
+	}
+
+	if repeatedCount == 0 {
+		repeatedCount = def.RepeatedCount
+	}
+
+	return backoff.NewStateful(
+		parseDurationOr(c.Initial, parseDurationOr(def.Initial, 0)),
+		parseDurationOr(c.Repeated, parseDurationOr(def.Repeated, 0)),
+		parseDurationOr(c.Final, parseDurationOr(def.Final, 0)),
+		initialCount,
+		repeatedCount,
+	)
+}

--- a/config/service.go
+++ b/config/service.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"sync"
+	"time"
+
+	"github.com/futurehomeno/cliffhanger/storage"
+)
+
+// Service is a generic thread-safe configuration service base for applications.
+// The configuration model must embed Default, exposed through the defaults accessor.
+// The optional redact function strips credentials for public reporting, satisfying app.PublicModeler.
+type Service[C any] struct {
+	storage.Storage[C]
+
+	lock         sync.RWMutex
+	defaultStore *DefaultStore
+	redact       func(C) any
+}
+
+func NewService[C any](s storage.Storage[C], defaults func(C) *Default, redact func(C) any) *Service[C] {
+	return &Service[C]{
+		Storage:      s,
+		defaultStore: NewDefaultStoreFromStorage(s, defaults),
+		redact:       redact,
+	}
+}
+
+// Update applies fn to the model under lock, stamps the configuration time and saves.
+func (s *Service[C]) Update(fn func(model C)) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	fn(s.Model())
+	s.defaultStore.accessor().SetConfiguredAt(time.Now())
+
+	return s.Save()
+}
+
+// Persist applies fn to the model under lock and saves without stamping the configuration
+// time, for caches and internal state that are not user configuration.
+func (s *Service[C]) Persist(fn func(model C)) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	fn(s.Model())
+
+	return s.Save()
+}
+
+// Reset restores the configuration to defaults under lock.
+func (s *Service[C]) Reset() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.Storage.Reset()
+}
+
+// Migrate runs migrations under lock and saves the model if any step was applied.
+func (s *Service[C]) Migrate(migrations ...Migration) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	applied, err := s.defaultStore.accessor().Migrate(migrations...)
+	if err != nil {
+		return err
+	}
+
+	if applied == 0 {
+		return nil
+	}
+
+	return s.Save()
+}
+
+// DefaultStore exposes the embedded Default settings, as required by the app builders.
+func (s *Service[C]) DefaultStore() *DefaultStore {
+	return s.defaultStore
+}
+
+// PublicModel returns the redacted configuration for public reporting, or the full model
+// if no redact function was provided.
+func (s *Service[C]) PublicModel() any {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	if s.redact == nil {
+		return s.Model()
+	}
+
+	return s.redact(s.Model())
+}
+
+// Get reads a setting from the model under read lock.
+func Get[C, V any](s *Service[C], get func(model C) V) V {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return get(s.Model())
+}
+
+// GetDuration reads a duration setting persisted as string, falling back to def when unset or invalid.
+func GetDuration[C any](s *Service[C], get func(model C) string, def time.Duration) time.Duration {
+	return parseDurationOr(Get(s, get), def)
+}
+
+func parseDurationOr(s string, def time.Duration) time.Duration {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return def
+	}
+
+	return d
+}

--- a/config/service.go
+++ b/config/service.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"sync"
 	"time"
 
 	"github.com/futurehomeno/cliffhanger/storage"
@@ -10,10 +9,12 @@ import (
 // Service is a generic thread-safe configuration service base for applications.
 // The configuration model must embed Default, exposed through the defaults accessor.
 // The optional redact function strips credentials for public reporting, satisfying app.PublicModeler.
+// Service shares the DefaultStore lock, since both mutate the same underlying model.
+// The lock is not reentrant: callbacks passed to Update, Persist and Migrate must not
+// call back into Service or DefaultStore methods.
 type Service[C any] struct {
 	storage.Storage[C]
 
-	lock         sync.RWMutex
 	defaultStore *DefaultStore
 	redact       func(C) any
 }
@@ -28,8 +29,8 @@ func NewService[C any](s storage.Storage[C], defaults func(C) *Default, redact f
 
 // Update applies fn to the model under lock, stamps the configuration time and saves.
 func (s *Service[C]) Update(fn func(model C)) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.defaultStore.lock.Lock()
+	defer s.defaultStore.lock.Unlock()
 
 	fn(s.Model())
 	s.defaultStore.accessor().SetConfiguredAt(time.Now())
@@ -40,8 +41,8 @@ func (s *Service[C]) Update(fn func(model C)) error {
 // Persist applies fn to the model under lock and saves without stamping the configuration
 // time, for caches and internal state that are not user configuration.
 func (s *Service[C]) Persist(fn func(model C)) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.defaultStore.lock.Lock()
+	defer s.defaultStore.lock.Unlock()
 
 	fn(s.Model())
 
@@ -50,16 +51,16 @@ func (s *Service[C]) Persist(fn func(model C)) error {
 
 // Reset restores the configuration to defaults under lock.
 func (s *Service[C]) Reset() error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.defaultStore.lock.Lock()
+	defer s.defaultStore.lock.Unlock()
 
 	return s.Storage.Reset()
 }
 
 // Migrate runs migrations under lock and saves the model if any step was applied.
 func (s *Service[C]) Migrate(migrations ...Migration) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.defaultStore.lock.Lock()
+	defer s.defaultStore.lock.Unlock()
 
 	applied, err := s.defaultStore.accessor().Migrate(migrations...)
 	if err != nil {
@@ -81,8 +82,8 @@ func (s *Service[C]) DefaultStore() *DefaultStore {
 // PublicModel returns the redacted configuration for public reporting, or the full model
 // if no redact function was provided.
 func (s *Service[C]) PublicModel() any {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	s.defaultStore.lock.RLock()
+	defer s.defaultStore.lock.RUnlock()
 
 	if s.redact == nil {
 		return s.Model()
@@ -93,8 +94,8 @@ func (s *Service[C]) PublicModel() any {
 
 // Get reads a setting from the model under read lock.
 func Get[C, V any](s *Service[C], get func(model C) V) V {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	s.defaultStore.lock.RLock()
+	defer s.defaultStore.lock.RUnlock()
 
 	return get(s.Model())
 }

--- a/config/service.go
+++ b/config/service.go
@@ -92,7 +92,9 @@ func (s *Service[C]) PublicModel() any {
 	return s.redact(s.Model())
 }
 
-// Get reads a setting from the model under read lock.
+// Get reads a setting from the model under read lock. The accessor should return
+// a value type or a copy: a returned reference type aliases the live model after
+// the lock is released.
 func Get[C, V any](s *Service[C], get func(model C) V) V {
 	s.defaultStore.lock.RLock()
 	defer s.defaultStore.lock.RUnlock()

--- a/config/service_test.go
+++ b/config/service_test.go
@@ -1,0 +1,134 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/config"
+	"github.com/futurehomeno/cliffhanger/storage"
+)
+
+type testConfig struct {
+	config.Default
+
+	Name     string
+	Secret   string
+	Interval string
+}
+
+func newTestService(t *testing.T) *config.Service[*testConfig] {
+	t.Helper()
+
+	s := storage.New(&testConfig{}, t.TempDir(), "config.json")
+
+	return config.NewService(s, func(c *testConfig) *config.Default { return &c.Default }, nil)
+}
+
+func TestService_Update(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestService(t)
+
+	err := srv.Update(func(c *testConfig) { c.Name = "test" })
+
+	assert.NoError(t, err)
+	assert.Equal(t, "test", config.Get(srv, func(c *testConfig) string { return c.Name }))
+	assert.NotEmpty(t, srv.Model().ConfiguredAt, "update should stamp the configuration time")
+}
+
+func TestService_Persist(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestService(t)
+
+	err := srv.Persist(func(c *testConfig) { c.Name = "cache" })
+
+	assert.NoError(t, err)
+	assert.Equal(t, "cache", srv.Model().Name)
+	assert.Empty(t, srv.Model().ConfiguredAt, "persist should not stamp the configuration time")
+}
+
+func TestService_PublicModel(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestService(t)
+	assert.NoError(t, srv.Update(func(c *testConfig) { c.Secret = "credentials" }))
+	assert.Equal(t, srv.Model(), srv.PublicModel(), "no redactor should expose the full model")
+
+	s := storage.New(&testConfig{}, t.TempDir(), "config.json")
+	redacting := config.NewService(s, func(c *testConfig) *config.Default { return &c.Default },
+		func(c *testConfig) any { public := *c; public.Secret = ""; return &public })
+
+	assert.NoError(t, redacting.Update(func(c *testConfig) { c.Secret = "credentials" }))
+
+	public, ok := redacting.PublicModel().(*testConfig)
+	assert.True(t, ok)
+	assert.Empty(t, public.Secret)
+	assert.Equal(t, "credentials", redacting.Model().Secret)
+}
+
+func TestService_GetDuration(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestService(t)
+
+	get := func(c *testConfig) string { return c.Interval }
+
+	assert.Equal(t, time.Minute, config.GetDuration(srv, get, time.Minute), "unset value should fall back to default")
+
+	assert.NoError(t, srv.Update(func(c *testConfig) { c.Interval = "30s" }))
+	assert.Equal(t, 30*time.Second, config.GetDuration(srv, get, time.Minute))
+
+	assert.NoError(t, srv.Update(func(c *testConfig) { c.Interval = "invalid" }))
+	assert.Equal(t, time.Minute, config.GetDuration(srv, get, time.Minute), "invalid value should fall back to default")
+}
+
+func TestService_Migrate(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestService(t)
+
+	migrated := 0
+	migration := config.Migration{From: 0, To: 1, Do: func() error { migrated++; return nil }}
+
+	assert.NoError(t, srv.Migrate(migration))
+	assert.Equal(t, 1, migrated)
+	assert.Equal(t, 1, srv.Model().ConfigVersion)
+
+	assert.NoError(t, srv.Migrate(migration))
+	assert.Equal(t, 1, migrated, "already applied migration should not run again")
+}
+
+func TestService_DefaultStore(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestService(t)
+
+	assert.NoError(t, srv.DefaultStore().SetLevel("debug"))
+	assert.Equal(t, "debug", srv.Model().LogLevel)
+}
+
+func TestBackoffConfig_Stateful(t *testing.T) {
+	t.Parallel()
+
+	b := config.BackoffConfig{
+		Initial:       "1s",
+		Repeated:      "2s",
+		Final:         "3s",
+		InitialCount:  1,
+		RepeatedCount: 1,
+	}.Stateful(config.BackoffConfig{})
+
+	assert.Equal(t, time.Second, b.Next())
+	assert.Equal(t, 2*time.Second, b.Next())
+	assert.Equal(t, 3*time.Second, b.Next())
+
+	def := config.BackoffConfig{Initial: "1m", Repeated: "5m", Final: "10m", InitialCount: 1, RepeatedCount: 1}
+	fallback := config.BackoffConfig{Initial: "invalid"}.Stateful(def)
+
+	assert.Equal(t, time.Minute, fallback.Next(), "unset or unparsable config should fall back to defaults")
+	assert.Equal(t, 5*time.Minute, fallback.Next())
+	assert.Equal(t, 10*time.Minute, fallback.Next())
+}

--- a/config/service_test.go
+++ b/config/service_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -108,6 +109,32 @@ func TestService_DefaultStore(t *testing.T) {
 
 	assert.NoError(t, srv.DefaultStore().SetLevel("debug"))
 	assert.Equal(t, "debug", srv.Model().LogLevel)
+}
+
+func TestService_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestService(t)
+
+	var wg sync.WaitGroup
+
+	for range 20 {
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+
+			assert.NoError(t, srv.Update(func(c *testConfig) { c.Name = "test" }))
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			assert.NoError(t, srv.DefaultStore().SetLevel("debug"))
+		}()
+	}
+
+	wg.Wait()
 }
 
 func TestBackoffConfig_Stateful(t *testing.T) {

--- a/lifecycle/marks.go
+++ b/lifecycle/marks.go
@@ -1,0 +1,25 @@
+package lifecycle
+
+// MarkNotConfigured sets the state bundle of an unconfigured application,
+// as done on uninstall, reset and logout.
+func (l *Lifecycle) MarkNotConfigured() {
+	l.SetAppHealth(AppHealthNotConfigured, nil)
+	l.SetConfigState(ConfigStateNotConfigured)
+	l.SetConnState(ConnStateDisconnected)
+	l.SetAuthState(AuthStateNotAuthenticated)
+}
+
+// MarkRunning sets the state bundle of a configured, authenticated and connected application.
+func (l *Lifecycle) MarkRunning() {
+	l.SetAppHealth(AppHealthRunning, nil)
+	l.SetConfigState(ConfigStateConfigured)
+	l.SetConnState(ConnStateConnected)
+	l.SetAuthState(AuthStateAuthenticated)
+}
+
+// MarkAuthLost sets the state bundle of an application that lost authorization to its
+// third party API, which for cloud adapters also means connectivity is lost.
+func (l *Lifecycle) MarkAuthLost() {
+	l.SetAuthState(AuthStateLost)
+	l.SetConnState(ConnStateDisconnected)
+}

--- a/lifecycle/marks.go
+++ b/lifecycle/marks.go
@@ -1,5 +1,8 @@
 package lifecycle
 
+// The Mark* bundles target cloud adapters with authentication. Applications keeping
+// auth or connectivity at AuthStateNA/ConnStateNA should set states individually instead.
+
 // MarkNotConfigured sets the state bundle of an unconfigured application,
 // as done on uninstall, reset and logout.
 func (l *Lifecycle) MarkNotConfigured() {

--- a/lifecycle/marks_test.go
+++ b/lifecycle/marks_test.go
@@ -1,0 +1,32 @@
+package lifecycle_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/lifecycle"
+)
+
+func TestLifecycle_Marks(t *testing.T) {
+	t.Parallel()
+
+	lc := lifecycle.New(nil)
+
+	lc.MarkRunning()
+	assert.Equal(t, lifecycle.AppHealthRunning, lc.AppHealth())
+	assert.Equal(t, lifecycle.ConfigStateConfigured, lc.ConfigState())
+	assert.Equal(t, lifecycle.ConnStateConnected, lc.ConnectionState())
+	assert.Equal(t, lifecycle.AuthStateAuthenticated, lc.AuthState())
+
+	lc.MarkAuthLost()
+	assert.Equal(t, lifecycle.AuthStateLost, lc.AuthState())
+	assert.Equal(t, lifecycle.ConnStateDisconnected, lc.ConnectionState())
+	assert.Equal(t, lifecycle.AppHealthRunning, lc.AppHealth(), "auth loss should not change app health")
+
+	lc.MarkNotConfigured()
+	assert.Equal(t, lifecycle.AppHealthNotConfigured, lc.AppHealth())
+	assert.Equal(t, lifecycle.ConfigStateNotConfigured, lc.ConfigState())
+	assert.Equal(t, lifecycle.ConnStateDisconnected, lc.ConnectionState())
+	assert.Equal(t, lifecycle.AuthStateNotAuthenticated, lc.AuthState())
+}


### PR DESCRIPTION
## Summary

Second wave of common blocks extracted from the edge adapters (independent of #185):

- **lifecycle.MarkNotConfigured / MarkRunning / MarkAuthLost** — the 4-setter state quartets copy-pasted at ~12 call sites per adapter across Reset/Logout/Uninstall/Login/Initialize.
- **app.Reset / app.Logout / app.Authorize** — the shared flows: teardown hooks → destroy things / clear credentials → state bundle; Authorize promotes to running only when the subsequent check confirms connectivity. **app.ConfigModel[T]** replaces the `model.(*config.Config)` type-assert boilerplate in every Configure().
- **config.Service[C]** — generic locked config-service base over `storage.Storage[C]`: `Update` (stamps ConfiguredAt), `Persist` (no stamp, for caches), `Migrate`, cached `DefaultStore()`, `PublicModel()` credential redaction plugging into the existing `app.PublicModeler` contract, and `config.Get`/`GetDuration` accessors. Replaces the 15–25 hand-written locked getter/setter pairs per adapter.
- **config.BackoffConfig** — persisted backoff spec with defaults fallback (duplicated in easee/mill/tibber/energy-guard).

## Testing

Unit tests for all new code; `go vet`, `go build`, `golangci-lint run` (0 issues) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)