### PR TITLE
Add edge bundles, stream supervisor and secrets storage (wave 4)

### DIFF
--- a/bootstrap/edge.go
+++ b/bootstrap/edge.go
@@ -1,0 +1,57 @@
+package bootstrap
+
+import (
+	"time"
+
+	"github.com/futurehomeno/fimpgo/fimptype"
+
+	"github.com/futurehomeno/cliffhanger/adapter"
+	"github.com/futurehomeno/cliffhanger/app"
+	"github.com/futurehomeno/cliffhanger/lifecycle"
+	"github.com/futurehomeno/cliffhanger/router"
+	"github.com/futurehomeno/cliffhanger/storage"
+	"github.com/futurehomeno/cliffhanger/task"
+	"github.com/futurehomeno/cliffhanger/telemetry"
+)
+
+// EdgeRouting combines the standard edge adapter routing (default, app and adapter routes)
+// with domain-specific extras. excludeAllThings is forwarded to app.RouteApp: typically
+// ad.DestroyAllThings, or nil when the application destroys things in Uninstall itself.
+func EdgeRouting[C any](
+	serviceName fimptype.ServiceNameT,
+	configGetter func() any,
+	tel telemetry.Telemetry,
+	appLifecycle *lifecycle.Lifecycle,
+	configStorage storage.Storage[C],
+	configFactory func() C,
+	locker router.MessageHandlerLocker,
+	application app.App,
+	ad adapter.Adapter,
+	excludeAllThings func() error,
+	extras ...[]*router.Routing,
+) []*router.Routing {
+	routes := [][]*router.Routing{
+		DefaultRoute(serviceName, configGetter, tel),
+		app.RouteApp(serviceName, appLifecycle, configStorage, configFactory, locker, application, excludeAllThings),
+		adapter.RouteAdapter(ad),
+	}
+
+	return router.Combine(append(routes, extras...)...)
+}
+
+// EdgeTasks combines the standard edge adapter tasks (app and adapter tasks)
+// with domain-specific extras.
+func EdgeTasks(
+	application app.App,
+	appLifecycle *lifecycle.Lifecycle,
+	ad adapter.Adapter,
+	reportingInterval time.Duration,
+	extras ...[]*task.Task,
+) []*task.Task {
+	tasks := [][]*task.Task{
+		app.TaskApp(application, appLifecycle),
+		adapter.TaskAdapter(ad, reportingInterval),
+	}
+
+	return task.Combine(append(tasks, extras...)...)
+}

--- a/bootstrap/edge_test.go
+++ b/bootstrap/edge_test.go
@@ -1,0 +1,57 @@
+package bootstrap_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/futurehomeno/fimpgo/fimptype"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/bootstrap"
+	"github.com/futurehomeno/cliffhanger/lifecycle"
+	"github.com/futurehomeno/cliffhanger/manifest"
+	"github.com/futurehomeno/cliffhanger/storage"
+	mockedadapter "github.com/futurehomeno/cliffhanger/test/mocks/adapter"
+)
+
+type fakeApp struct{}
+
+func (a *fakeApp) GetManifest() (*manifest.Manifest, error) { return nil, nil }
+func (a *fakeApp) Configure(any) error                      { return nil }
+func (a *fakeApp) Uninstall() error                         { return nil }
+
+type testCfg struct{ Name string }
+
+func TestEdgeRouting(t *testing.T) {
+	t.Parallel()
+
+	cfg := &testCfg{}
+	s := storage.New(cfg, t.TempDir(), "config.json")
+
+	ad := mockedadapter.NewAdapter(t)
+	ad.On("Name").Return(fimptype.ResourceNameT("test"))
+
+	routes := bootstrap.EdgeRouting(
+		"test_service",
+		func() any { return cfg },
+		nil,
+		lifecycle.New(nil),
+		s,
+		func() *testCfg { return &testCfg{} },
+		nil,
+		&fakeApp{},
+		ad,
+		ad.DestroyAllThings,
+		nil,
+	)
+
+	assert.NotEmpty(t, routes)
+}
+
+func TestEdgeTasks(t *testing.T) {
+	t.Parallel()
+
+	tasks := bootstrap.EdgeTasks(&fakeApp{}, lifecycle.New(nil), mockedadapter.NewAdapter(t), time.Minute)
+
+	assert.NotEmpty(t, tasks)
+}

--- a/config/event.go
+++ b/config/event.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/futurehomeno/cliffhanger/event"
 	"github.com/futurehomeno/fimpgo/fimptype"
+
+	"github.com/futurehomeno/cliffhanger/event"
 )
 
 const (
@@ -20,6 +21,13 @@ func NewConfigurationChangeEvent(service fimptype.ServiceNameT, setting string) 
 type configurationChange struct {
 	Service fimptype.ServiceNameT
 	Setting string
+}
+
+// PublishConfigurationChanges publishes a configuration change event for every changed setting.
+func PublishConfigurationChanges(eventManager event.Manager, service fimptype.ServiceNameT, settings ...string) {
+	for _, setting := range settings {
+		eventManager.Publish(NewConfigurationChangeEvent(service, setting))
+	}
 }
 
 func WaitForConfigurationUpdate(service fimptype.ServiceNameT, setting string) event.Filter {

--- a/config/event_test.go
+++ b/config/event_test.go
@@ -1,0 +1,28 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/config"
+	"github.com/futurehomeno/cliffhanger/event"
+)
+
+func TestPublishConfigurationChanges(t *testing.T) {
+	t.Parallel()
+
+	manager := event.NewManager()
+	ch := manager.Subscribe("test", 5, config.WaitForConfigurationUpdate("srv", "interval"))
+
+	defer manager.Unsubscribe("test")
+
+	config.PublishConfigurationChanges(manager, "srv", "mode", "interval")
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		assert.Fail(t, "expected a configuration change event for the subscribed setting")
+	}
+}

--- a/storage/secrets_test.go
+++ b/storage/secrets_test.go
@@ -1,0 +1,50 @@
+package storage_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/storage"
+)
+
+type secrets struct {
+	AccessToken string
+}
+
+func TestNewSecrets_FileMode(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+
+	s := storage.NewSecrets(&secrets{AccessToken: "token"}, workDir, "secrets.json")
+	assert.NoError(t, s.Save())
+
+	info, err := os.Stat(filepath.Join(workDir, "data", "secrets.json"))
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+
+	assert.NoError(t, s.Load(), "load without data and defaults should not fail")
+}
+
+func TestNew_ConfigFileMode(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+
+	s := storage.New(&secrets{}, workDir, "config.json")
+	assert.NoError(t, s.Save())
+
+	info, err := os.Stat(filepath.Join(workDir, "data", "config.json"))
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+
+	assert.NoError(t, os.Chmod(filepath.Join(workDir, "data", "config.json"), 0o666)) //nolint:gosec
+	assert.NoError(t, s.Save())
+
+	info, err = os.Stat(filepath.Join(workDir, "data", "config.json"))
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm(), "save should tighten permissions of pre-existing files")
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -16,6 +16,9 @@ const (
 	dataDirectory     = "data"
 	defaultsDirectory = "defaults"
 	backupExtension   = ".bak"
+
+	configFileMode os.FileMode = 0o644
+	secretFileMode os.FileMode = 0o640
 )
 
 // Storage is an interface representing a service responsible for loading JSON configuration from provided location.
@@ -34,6 +37,30 @@ func New[T any](model T, workDir string, name string) Storage[T] {
 		backupPath:   filepath.Join(workDir, dataDirectory, name) + backupExtension,
 		defaultsPath: filepath.Join(workDir, defaultsDirectory, name),
 		model:        model,
+	}
+}
+
+// NewSecrets creates a storage service for credentials and other secrets, conventionally
+// data/secrets.json, written with 0640 permissions unlike the world-readable configuration
+// and without a defaults file.
+func NewSecrets[T any](model T, workDir string, name string) Storage[T] {
+	return &storage[T]{
+		lock:       &sync.Mutex{},
+		dataPath:   filepath.Join(workDir, dataDirectory, name),
+		backupPath: filepath.Join(workDir, dataDirectory, name) + backupExtension,
+		model:      model,
+		mode:       secretFileMode,
+	}
+}
+
+// NewCanonicalSecrets creates a secrets storage service following the canonical layout of core applications.
+func NewCanonicalSecrets[T any](model T, workDir string, name string) Storage[T] {
+	return &storage[T]{
+		lock:       &sync.Mutex{},
+		dataPath:   filepath.Join(workDir, name),
+		backupPath: filepath.Join(workDir, name) + backupExtension,
+		model:      model,
+		mode:       secretFileMode,
 	}
 }
 
@@ -75,6 +102,15 @@ type storage[T any] struct {
 	backupPath   string
 	defaultsPath string
 	model        T
+	mode         os.FileMode
+}
+
+func (s *storage[T]) fileMode() os.FileMode {
+	if s.mode == 0 {
+		return configFileMode
+	}
+
+	return s.mode
 }
 
 func (s *storage[T]) Model() T {
@@ -291,8 +327,13 @@ func (s *storage[T]) loadFile(path string) error {
 }
 
 func (s *storage[T]) writeFile(path string, data []byte) (err error) {
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0664) //nolint:gofumpt,gosec
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, s.fileMode()) //nolint:gosec
 	if err != nil {
+		return err
+	}
+
+	// Enforce permissions also on files created before this mode was configured, regardless of umask.
+	if err = file.Chmod(s.fileMode()); err != nil {
 		return err
 	}
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -332,11 +332,6 @@ func (s *storage[T]) writeFile(path string, data []byte) (err error) {
 		return err
 	}
 
-	// Enforce permissions also on files created before this mode was configured, regardless of umask.
-	if err = file.Chmod(s.fileMode()); err != nil {
-		return err
-	}
-
 	defer func() {
 		closeErr := file.Close()
 
@@ -347,6 +342,11 @@ func (s *storage[T]) writeFile(path string, data []byte) (err error) {
 
 		err = closeErr
 	}()
+
+	// Enforce permissions also on files created before this mode was configured, regardless of umask.
+	if err = file.Chmod(s.fileMode()); err != nil {
+		return err
+	}
 
 	if _, err = file.Write(data); err != nil {
 		return

--- a/stream/supervisor.go
+++ b/stream/supervisor.go
@@ -124,6 +124,11 @@ func (s *Supervisor) run(ctx context.Context, done chan struct{}) {
 		}
 
 		cancel()
+
+		// connCtx.Done may have won the select over its cancelled parent - do not dial again.
+		if ctx.Err() != nil {
+			return
+		}
 	}
 }
 

--- a/stream/supervisor.go
+++ b/stream/supervisor.go
@@ -65,10 +65,14 @@ func (s *Supervisor) Stop() error {
 
 	s.stop()
 	done := s.done
-	s.done = nil
 	s.mu.Unlock()
 
 	<-done
+
+	// Cleared only after the goroutine exited, so a concurrent Start cannot overlap connections.
+	s.mu.Lock()
+	s.done = nil
+	s.mu.Unlock()
 
 	return nil
 }

--- a/stream/supervisor.go
+++ b/stream/supervisor.go
@@ -1,0 +1,130 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/futurehomeno/cliffhanger/backoff"
+)
+
+// Connection dials and serves a streaming connection, blocking until the connection ends
+// or ctx is cancelled. It must call connected once the connection is established, resetting
+// the reconnection backoff. A nil error means a clean shutdown.
+type Connection func(ctx context.Context, connected func()) error
+
+// Supervisor keeps a single streaming connection alive, reconnecting with backoff and
+// implementing root.Service. Subscription registries and resubscription remain with the caller.
+type Supervisor struct {
+	connect Connection
+	backoff backoff.Stateful
+
+	mu      sync.Mutex
+	stop    context.CancelFunc
+	trigger context.CancelFunc
+	done    chan struct{}
+}
+
+// NewSupervisor creates a supervisor for the connection, using a default backoff if b is nil.
+func NewSupervisor(connect Connection, b backoff.Stateful) *Supervisor {
+	if b == nil {
+		b = backoff.NewStateful(10*time.Second, time.Minute, 5*time.Minute, 1, 3)
+	}
+
+	return &Supervisor{connect: connect, backoff: b}
+}
+
+func (s *Supervisor) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.done != nil {
+		return errors.New("stream: supervisor already started")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.stop = cancel
+	s.done = make(chan struct{})
+
+	go s.run(ctx, s.done)
+
+	return nil
+}
+
+func (s *Supervisor) Stop() error {
+	s.mu.Lock()
+
+	if s.done == nil {
+		s.mu.Unlock()
+
+		return nil
+	}
+
+	s.stop()
+	done := s.done
+	s.done = nil
+	s.mu.Unlock()
+
+	<-done
+
+	return nil
+}
+
+// TriggerReconnect drops the current connection or skips a pending backoff wait,
+// forcing an immediate reconnection, e.g. after credentials change.
+func (s *Supervisor) TriggerReconnect() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.done != nil && s.trigger != nil {
+		s.trigger()
+	}
+}
+
+func (s *Supervisor) run(ctx context.Context, done chan struct{}) {
+	defer close(done)
+
+	for {
+		connCtx, cancel := context.WithCancel(ctx)
+		s.setTrigger(cancel)
+
+		err := s.connect(connCtx, s.backoff.Reset)
+
+		if ctx.Err() != nil {
+			cancel()
+
+			return
+		}
+
+		delay := s.backoff.Next()
+		if err != nil {
+			log.Warnf("[stream] Connection err: %v, reconnecting in %s", err, delay)
+		} else {
+			log.Infof("[stream] Connection ended, reconnecting in %s", delay)
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			cancel()
+
+			return
+		case <-connCtx.Done():
+			// Triggered during the connection or the wait - reconnect immediately.
+			timer.Stop()
+		case <-timer.C:
+		}
+
+		cancel()
+	}
+}
+
+func (s *Supervisor) setTrigger(cancel context.CancelFunc) {
+	s.mu.Lock()
+	s.trigger = cancel
+	s.mu.Unlock()
+}

--- a/stream/supervisor_test.go
+++ b/stream/supervisor_test.go
@@ -1,0 +1,65 @@
+package stream_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/backoff"
+	"github.com/futurehomeno/cliffhanger/stream"
+)
+
+func TestSupervisor(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	connect := func(ctx context.Context, connected func()) error {
+		calls.Add(1)
+		connected()
+		<-ctx.Done()
+
+		return nil
+	}
+
+	s := stream.NewSupervisor(connect, backoff.NewStateful(time.Hour, time.Hour, time.Hour, 1, 1))
+
+	assert.NoError(t, s.Start())
+	assert.Error(t, s.Start(), "second start should fail")
+
+	assert.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, time.Millisecond)
+
+	s.TriggerReconnect()
+	assert.Eventually(t, func() bool { return calls.Load() == 2 }, time.Second, time.Millisecond,
+		"trigger should drop the connection and skip the backoff wait")
+
+	assert.NoError(t, s.Stop())
+	assert.NoError(t, s.Stop(), "stop should be idempotent")
+
+	total := calls.Load()
+	time.Sleep(20 * time.Millisecond)
+	assert.Equal(t, total, calls.Load(), "no reconnects after stop")
+}
+
+func TestSupervisor_ReconnectsAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	connect := func(context.Context, func()) error {
+		calls.Add(1)
+
+		return errors.New("connection err")
+	}
+
+	s := stream.NewSupervisor(connect, backoff.NewStateful(time.Millisecond, time.Millisecond, time.Millisecond, 1, 1))
+
+	assert.NoError(t, s.Start())
+	assert.Eventually(t, func() bool { return calls.Load() >= 3 }, time.Second, time.Millisecond,
+		"failed connections should be retried with backoff")
+	assert.NoError(t, s.Stop())
+}

--- a/stream/supervisor_test.go
+++ b/stream/supervisor_test.go
@@ -85,6 +85,26 @@ func TestSupervisor_StartDuringStop(t *testing.T) {
 	assert.NoError(t, s.Stop())
 }
 
+func TestSupervisor_StopDuringBackoffWait(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	connect := func(context.Context, func()) error {
+		calls.Add(1)
+
+		return errors.New("connection err")
+	}
+
+	s := stream.NewSupervisor(connect, backoff.NewStateful(time.Hour, time.Hour, time.Hour, 1, 1))
+
+	assert.NoError(t, s.Start())
+	assert.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, time.Millisecond)
+
+	assert.NoError(t, s.Stop())
+	assert.Equal(t, int32(1), calls.Load(), "stop during the backoff wait must not dial again")
+}
+
 func TestSupervisor_ReconnectsAfterFailure(t *testing.T) {
 	t.Parallel()
 

--- a/stream/supervisor_test.go
+++ b/stream/supervisor_test.go
@@ -45,6 +45,46 @@ func TestSupervisor(t *testing.T) {
 	assert.Equal(t, total, calls.Load(), "no reconnects after stop")
 }
 
+func TestSupervisor_StartDuringStop(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+
+	var calls atomic.Int32
+
+	connect := func(ctx context.Context, connected func()) error {
+		calls.Add(1)
+		connected()
+		<-ctx.Done()
+		<-release
+
+		return nil
+	}
+
+	s := stream.NewSupervisor(connect, backoff.NewStateful(time.Hour, time.Hour, time.Hour, 1, 1))
+
+	assert.NoError(t, s.Start())
+	assert.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, time.Millisecond)
+
+	stopped := make(chan struct{})
+
+	go func() {
+		assert.NoError(t, s.Stop())
+		close(stopped)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	assert.Error(t, s.Start(), "start must fail until the previous connection loop has fully exited")
+	assert.Equal(t, int32(1), calls.Load(), "no overlapping connection may be started")
+
+	close(release)
+	<-stopped
+
+	assert.NoError(t, s.Start(), "start should succeed after stop has completed")
+	assert.Eventually(t, func() bool { return calls.Load() == 2 }, time.Second, time.Millisecond)
+	assert.NoError(t, s.Stop())
+}
+
 func TestSupervisor_ReconnectsAfterFailure(t *testing.T) {
 	t.Parallel()
 

--- a/utils/timestamped.go
+++ b/utils/timestamped.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"sync"
+	"time"
+)
+
+// Timestamped is a concurrency-safe last-value holder rejecting out-of-order updates,
+// e.g. streamed observations arriving after a fresher poll. An update carrying a timestamp
+// equal to the held one wins, matching last-write-wins semantics of the source adapters.
+type Timestamped[T any] struct {
+	mu    sync.RWMutex
+	value T
+	ts    time.Time
+	set   bool
+}
+
+// Set stores the value unless a fresher one is already held, reporting whether it was stored.
+func (c *Timestamped[T]) Set(value T, ts time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.set && ts.Before(c.ts) {
+		return false
+	}
+
+	c.value, c.ts, c.set = value, ts, true
+
+	return true
+}
+
+// Get returns the held value and its timestamp, with false if nothing was stored yet.
+func (c *Timestamped[T]) Get() (T, time.Time, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.value, c.ts, c.set
+}

--- a/utils/timestamped_test.go
+++ b/utils/timestamped_test.go
@@ -1,0 +1,31 @@
+package utils_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/utils"
+)
+
+func TestTimestamped(t *testing.T) {
+	t.Parallel()
+
+	var c utils.Timestamped[int]
+
+	_, _, ok := c.Get()
+	assert.False(t, ok, "empty holder should report no value")
+
+	now := time.Now()
+
+	assert.True(t, c.Set(1, now))
+	assert.False(t, c.Set(2, now.Add(-time.Second)), "older value should be rejected")
+	assert.True(t, c.Set(3, now), "equal timestamp should win (last-write-wins)")
+	assert.True(t, c.Set(4, now.Add(time.Second)))
+
+	value, ts, ok := c.Get()
+	assert.True(t, ok)
+	assert.Equal(t, 4, value)
+	assert.Equal(t, now.Add(time.Second), ts)
+}


### PR DESCRIPTION
## Summary

Fourth wave of common blocks (independent of #185/#186/#187):

- **bootstrap.EdgeRouting / EdgeTasks** — the `DefaultRoute + RouteApp + RouteAdapter` and `TaskApp + TaskAdapter` wiring triples identical in every adapter, taking only domain extras. `excludeAllThings` stays a parameter — easee deliberately passes nil to avoid double-destroy on uninstall.
- **stream.Supervisor** — a reconnecting connection loop with stateful backoff, reset-on-successful-connect (matching tibber/easee/zaptec semantics via a `connected` callback), `TriggerReconnect` for credential changes, implementing `root.Service`. Scope note: this covers the outer dial/serve/backoff loop; the per-entity subscription registry + resubscribe machinery (duplicated between tibber and easee managers) is a candidate for a follow-up `stream.Registry`.
- **storage.NewSecrets / NewCanonicalSecrets** — separate `data/secrets.json` written with 0640 for tokens/passwords/API keys, while config files are now written 0644 (dropping the group-write bit) — both enforced with chmod on save so pre-existing files get tightened. Survey of all 7 apps confirmed the fit: OAuth credentials blobs (6 adapters), mill's LocalAPIKey and energy-guard's Influx credentials (currently unredacted in reports) all belong there; zaptec's encrypted username/password still work as ciphertext in the secrets file.
- **utils.Timestamped** — concurrency-safe last-value holder rejecting out-of-order updates (poll-vs-stream reconciliation), with easee's last-write-wins tie-break.
- **config.PublishConfigurationChanges** — per-setting configuration-change event fan-out (energy-guard pattern), publish-only.

## Testing

Unit tests for all new code including file-permission assertions; full `go test ./...`, `go vet`, `golangci-lint run` (0 issues) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)