### PR TITLE
Fix PR #189 review findings: fd leak and Stop/Start race

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -332,11 +332,6 @@ func (s *storage[T]) writeFile(path string, data []byte) (err error) {
 		return err
 	}
 
-	// Enforce permissions also on files created before this mode was configured, regardless of umask.
-	if err = file.Chmod(s.fileMode()); err != nil {
-		return err
-	}
-
 	defer func() {
 		closeErr := file.Close()
 
@@ -347,6 +342,11 @@ func (s *storage[T]) writeFile(path string, data []byte) (err error) {
 
 		err = closeErr
 	}()
+
+	// Enforce permissions also on files created before this mode was configured, regardless of umask.
+	if err = file.Chmod(s.fileMode()); err != nil {
+		return err
+	}
 
 	if _, err = file.Write(data); err != nil {
 		return

--- a/stream/supervisor.go
+++ b/stream/supervisor.go
@@ -65,10 +65,14 @@ func (s *Supervisor) Stop() error {
 
 	s.stop()
 	done := s.done
-	s.done = nil
 	s.mu.Unlock()
 
 	<-done
+
+	// Cleared only after the goroutine exited, so a concurrent Start cannot overlap connections.
+	s.mu.Lock()
+	s.done = nil
+	s.mu.Unlock()
 
 	return nil
 }

--- a/stream/supervisor_test.go
+++ b/stream/supervisor_test.go
@@ -45,6 +45,46 @@ func TestSupervisor(t *testing.T) {
 	assert.Equal(t, total, calls.Load(), "no reconnects after stop")
 }
 
+func TestSupervisor_StartDuringStop(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+
+	var calls atomic.Int32
+
+	connect := func(ctx context.Context, connected func()) error {
+		calls.Add(1)
+		connected()
+		<-ctx.Done()
+		<-release
+
+		return nil
+	}
+
+	s := stream.NewSupervisor(connect, backoff.NewStateful(time.Hour, time.Hour, time.Hour, 1, 1))
+
+	assert.NoError(t, s.Start())
+	assert.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, time.Millisecond)
+
+	stopped := make(chan struct{})
+
+	go func() {
+		assert.NoError(t, s.Stop())
+		close(stopped)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	assert.Error(t, s.Start(), "start must fail until the previous connection loop has fully exited")
+	assert.Equal(t, int32(1), calls.Load(), "no overlapping connection may be started")
+
+	close(release)
+	<-stopped
+
+	assert.NoError(t, s.Start(), "start should succeed after stop has completed")
+	assert.Eventually(t, func() bool { return calls.Load() == 2 }, time.Second, time.Millisecond)
+	assert.NoError(t, s.Stop())
+}
+
 func TestSupervisor_ReconnectsAfterFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes for confirmed findings from the review of #189:

- **File descriptor leak when Chmod fails** (https://github.com/futurehomeno/cliffhanger/pull/189#discussion_r3582841288): the `defer file.Close()` is now registered immediately after `OpenFile`, before the `Chmod` call, so an early return no longer leaks the handle.
- **Stop marks the supervisor stopped before shutdown finishes** (https://github.com/futurehomeno/cliffhanger/pull/189#discussion_r3582841296): `s.done` is now cleared only after the connection loop has fully exited, so a concurrent `Start()` cannot launch an overlapping connection. Covered by the new `TestSupervisor_StartDuringStop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)