### PR TITLE
Preserve RefreshExpiresAt when refresh token is carried over

### DIFF
--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -144,7 +144,7 @@ func (a *Authenticator) AccessToken() (string, error) {
 	a.unauthorizedSince = time.Time{}
 
 	newCreds := response.Credentials()
-	if newCreds.RefreshToken == "" {
+	if newCreds.RefreshToken == "" || newCreds.RefreshToken == creds.RefreshToken {
 		newCreds.RefreshToken = creds.RefreshToken
 		newCreds.RefreshExpiresAt = creds.RefreshExpiresAt
 	}

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -146,6 +146,7 @@ func (a *Authenticator) AccessToken() (string, error) {
 	newCreds := response.Credentials()
 	if newCreds.RefreshToken == "" {
 		newCreds.RefreshToken = creds.RefreshToken
+		newCreds.RefreshExpiresAt = creds.RefreshExpiresAt
 	}
 
 	if err := a.store.SetCredentials(newCreds); err != nil {

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -88,6 +88,37 @@ func TestAuthenticator_AccessToken(t *testing.T) {
 		assert.True(t, store.creds.ExpiresAt.After(time.Now()))
 	})
 
+	t.Run("refresh without rotated token preserves refresh expiry", func(t *testing.T) {
+		t.Parallel()
+
+		creds := expiredCreds()
+		creds.RefreshExpiresAt = time.Now().Add(time.Hour)
+
+		store := &fakeStore{creds: creds}
+		exchanger := &fakeExchanger{response: &auth.OAuth2TokenResponse{AccessToken: "fresh", ExpiresIn: 3600}}
+		a := auth.NewAuthenticator(store, exchanger, auth.AuthenticatorConfig{})
+
+		_, err := a.AccessToken()
+		assert.NoError(t, err)
+		assert.Equal(t, creds.RefreshExpiresAt, store.creds.RefreshExpiresAt, "carried over refresh token should keep its expiry")
+	})
+
+	t.Run("refresh with rotated token clears refresh expiry", func(t *testing.T) {
+		t.Parallel()
+
+		creds := expiredCreds()
+		creds.RefreshExpiresAt = time.Now().Add(time.Hour)
+
+		store := &fakeStore{creds: creds}
+		exchanger := &fakeExchanger{response: &auth.OAuth2TokenResponse{AccessToken: "fresh", RefreshToken: "rotated", ExpiresIn: 3600}}
+		a := auth.NewAuthenticator(store, exchanger, auth.AuthenticatorConfig{})
+
+		_, err := a.AccessToken()
+		assert.NoError(t, err)
+		assert.Equal(t, "rotated", store.creds.RefreshToken)
+		assert.True(t, store.creds.RefreshExpiresAt.IsZero(), "rotated refresh token must not inherit the old expiry")
+	})
+
 	t.Run("rejected refresh token clears credentials and reports auth loss", func(t *testing.T) {
 		t.Parallel()
 

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -103,6 +103,21 @@ func TestAuthenticator_AccessToken(t *testing.T) {
 		assert.Equal(t, creds.RefreshExpiresAt, store.creds.RefreshExpiresAt, "carried over refresh token should keep its expiry")
 	})
 
+	t.Run("refresh returning same token preserves refresh expiry", func(t *testing.T) {
+		t.Parallel()
+
+		creds := expiredCreds()
+		creds.RefreshExpiresAt = time.Now().Add(time.Hour)
+
+		store := &fakeStore{creds: creds}
+		exchanger := &fakeExchanger{response: &auth.OAuth2TokenResponse{AccessToken: "fresh", RefreshToken: creds.RefreshToken, ExpiresIn: 3600}}
+		a := auth.NewAuthenticator(store, exchanger, auth.AuthenticatorConfig{})
+
+		_, err := a.AccessToken()
+		assert.NoError(t, err)
+		assert.Equal(t, creds.RefreshExpiresAt, store.creds.RefreshExpiresAt, "explicitly returned same token is a carry-over and should keep its expiry")
+	})
+
 	t.Run("refresh with rotated token clears refresh expiry", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Fixes the P2 finding from the review of #187: a successful refresh discarded `RefreshExpiresAt`, permanently disarming the local doomed-refresh short-circuit (https://github.com/futurehomeno/cliffhanger/pull/187#discussion_r3582723448).

The expiry is preserved only when the refresh token itself is carried over; a rotated refresh token must not inherit the old expiry, or a stale timestamp would later trigger a spurious forced re-login. Covered by two new test cases in `auth/authenticator_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)