### PR TITLE
Fix PR #186 review findings

### DIFF
--- a/app/flow.go
+++ b/app/flow.go
@@ -48,8 +48,9 @@ func Logout(appLifecycle *lifecycle.Lifecycle, clearCredentials func() error, te
 }
 
 // Authorize persists new credentials and promotes the application to running if the
-// subsequent check confirms connectivity. Check failures are reported through
-// lifecycle states rather than an error, matching CheckableApp semantics.
+// subsequent check confirms connectivity. Connectivity failures are reported through
+// lifecycle states set by check itself, matching CheckableApp semantics; an error
+// returned by check is a hard failure that aborts promotion and is propagated.
 func Authorize(appLifecycle *lifecycle.Lifecycle, persistCredentials, check func() error) error {
 	if err := persistCredentials(); err != nil {
 		return fmt.Errorf("persist credentials: %w", err)

--- a/app/flow_test.go
+++ b/app/flow_test.go
@@ -82,6 +82,10 @@ func TestAuthorize(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEqual(t, lifecycle.AppHealthRunning, lc.AppHealth(), "should not promote when check left the app disconnected")
 
+	err = app.Authorize(lc, func() error { return nil }, func() error { return errors.New("check err") })
+	assert.Error(t, err, "hard check failure should be propagated")
+	assert.NotEqual(t, lifecycle.AppHealthRunning, lc.AppHealth())
+
 	err = app.Authorize(lc, func() error { return nil }, func() error {
 		lc.SetConnState(lifecycle.ConnStateConnected)
 

--- a/config/service.go
+++ b/config/service.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"sync"
 	"time"
 
 	"github.com/futurehomeno/cliffhanger/storage"
@@ -10,10 +9,10 @@ import (
 // Service is a generic thread-safe configuration service base for applications.
 // The configuration model must embed Default, exposed through the defaults accessor.
 // The optional redact function strips credentials for public reporting, satisfying app.PublicModeler.
+// Service shares the DefaultStore lock, since both mutate the same underlying model.
 type Service[C any] struct {
 	storage.Storage[C]
 
-	lock         sync.RWMutex
 	defaultStore *DefaultStore
 	redact       func(C) any
 }
@@ -28,8 +27,8 @@ func NewService[C any](s storage.Storage[C], defaults func(C) *Default, redact f
 
 // Update applies fn to the model under lock, stamps the configuration time and saves.
 func (s *Service[C]) Update(fn func(model C)) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.defaultStore.lock.Lock()
+	defer s.defaultStore.lock.Unlock()
 
 	fn(s.Model())
 	s.defaultStore.accessor().SetConfiguredAt(time.Now())
@@ -40,8 +39,8 @@ func (s *Service[C]) Update(fn func(model C)) error {
 // Persist applies fn to the model under lock and saves without stamping the configuration
 // time, for caches and internal state that are not user configuration.
 func (s *Service[C]) Persist(fn func(model C)) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.defaultStore.lock.Lock()
+	defer s.defaultStore.lock.Unlock()
 
 	fn(s.Model())
 
@@ -50,16 +49,16 @@ func (s *Service[C]) Persist(fn func(model C)) error {
 
 // Reset restores the configuration to defaults under lock.
 func (s *Service[C]) Reset() error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.defaultStore.lock.Lock()
+	defer s.defaultStore.lock.Unlock()
 
 	return s.Storage.Reset()
 }
 
 // Migrate runs migrations under lock and saves the model if any step was applied.
 func (s *Service[C]) Migrate(migrations ...Migration) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	s.defaultStore.lock.Lock()
+	defer s.defaultStore.lock.Unlock()
 
 	applied, err := s.defaultStore.accessor().Migrate(migrations...)
 	if err != nil {
@@ -81,8 +80,8 @@ func (s *Service[C]) DefaultStore() *DefaultStore {
 // PublicModel returns the redacted configuration for public reporting, or the full model
 // if no redact function was provided.
 func (s *Service[C]) PublicModel() any {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	s.defaultStore.lock.RLock()
+	defer s.defaultStore.lock.RUnlock()
 
 	if s.redact == nil {
 		return s.Model()
@@ -93,8 +92,8 @@ func (s *Service[C]) PublicModel() any {
 
 // Get reads a setting from the model under read lock.
 func Get[C, V any](s *Service[C], get func(model C) V) V {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	s.defaultStore.lock.RLock()
+	defer s.defaultStore.lock.RUnlock()
 
 	return get(s.Model())
 }

--- a/config/service.go
+++ b/config/service.go
@@ -10,6 +10,8 @@ import (
 // The configuration model must embed Default, exposed through the defaults accessor.
 // The optional redact function strips credentials for public reporting, satisfying app.PublicModeler.
 // Service shares the DefaultStore lock, since both mutate the same underlying model.
+// The lock is not reentrant: callbacks passed to Update, Persist and Migrate must not
+// call back into Service or DefaultStore methods.
 type Service[C any] struct {
 	storage.Storage[C]
 

--- a/config/service_test.go
+++ b/config/service_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -108,6 +109,32 @@ func TestService_DefaultStore(t *testing.T) {
 
 	assert.NoError(t, srv.DefaultStore().SetLevel("debug"))
 	assert.Equal(t, "debug", srv.Model().LogLevel)
+}
+
+func TestService_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestService(t)
+
+	var wg sync.WaitGroup
+
+	for range 20 {
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+
+			assert.NoError(t, srv.Update(func(c *testConfig) { c.Name = "test" }))
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			assert.NoError(t, srv.DefaultStore().SetLevel("debug"))
+		}()
+	}
+
+	wg.Wait()
 }
 
 func TestBackoffConfig_Stateful(t *testing.T) {

--- a/lifecycle/marks.go
+++ b/lifecycle/marks.go
@@ -1,5 +1,8 @@
 package lifecycle
 
+// The Mark* bundles target cloud adapters with authentication. Applications keeping
+// auth or connectivity at AuthStateNA/ConnStateNA should set states individually instead.
+
 // MarkNotConfigured sets the state bundle of an unconfigured application,
 // as done on uninstall, reset and logout.
 func (l *Lifecycle) MarkNotConfigured() {


### PR DESCRIPTION
Addresses review findings from #186:

- https://github.com/futurehomeno/cliffhanger/pull/186#discussion_r3582726378 — `Service` now shares the `DefaultStore` lock, removing the dual-lock data race on the shared model (covered by `TestService_ConcurrentAccess` under `-race`).
- https://github.com/futurehomeno/cliffhanger/pull/186#discussion_r3582726392 — reworded the `Authorize` docstring to state that connectivity failures go through lifecycle states while a check error is a hard failure that is propagated; added a test pinning the propagation.
- https://github.com/futurehomeno/cliffhanger/pull/186#discussion_r3582726416 — documented that the `Mark*` bundles target cloud adapters with authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)