### PR TITLE
Fix bearer leak on cross-host redirects and dead token retries

### DIFF
--- a/auth/client.go
+++ b/auth/client.go
@@ -104,6 +104,9 @@ func (c *proxyClient) getToken(request any, url string) (*OAuth2TokenResponse, e
 	for i := 0; i <= c.cfg.Retry; i++ {
 		var response *OAuth2TokenResponse
 
+		// Each attempt drains the body, so it must be replaced before sending.
+		r.Body = io.NopCloser(bytes.NewReader(requestData))
+
 		response, err = c.requestToken(r)
 		if err == nil {
 			return response, nil

--- a/auth/client_test.go
+++ b/auth/client_test.go
@@ -1,0 +1,44 @@
+package auth_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/auth"
+)
+
+func TestProxyClient_RetryResendsBody(t *testing.T) {
+	t.Parallel()
+
+	var bodies []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+
+		bodies = append(bodies, string(b))
+		if len(bodies) == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+
+			return
+		}
+
+		_, err = w.Write([]byte(`{"access_token":"token","expires_in":3600}`))
+		assert.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	client := auth.NewProxyClient(&auth.ProxyClientConfig{URL: srv.URL, Retry: 1, RetryDelay: time.Millisecond})
+
+	response, err := client.ExchangeRefreshToken("refresh")
+	assert.NoError(t, err)
+	assert.Equal(t, "token", response.AccessToken)
+	assert.Len(t, bodies, 2)
+	assert.NotEmpty(t, bodies[0])
+	assert.Equal(t, bodies[0], bodies[1], "retry must resend the full request body")
+}

--- a/auth/transport.go
+++ b/auth/transport.go
@@ -20,6 +20,21 @@ type Transport struct {
 }
 
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	// The bearer must not leak to another host on a redirect hop.
+	first := req
+	for first.Response != nil {
+		first = first.Response.Request
+	}
+
+	if first.URL.Host != req.URL.Host {
+		return base.RoundTrip(req)
+	}
+
 	token, err := t.Source.AccessToken()
 	if err != nil {
 		return nil, err
@@ -29,11 +44,6 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	clone.Header = req.Header.Clone()
 	clone.Header.Set("Authorization", "Bearer "+token)
 	req = &clone
-
-	base := t.Base
-	if base == nil {
-		base = http.DefaultTransport
-	}
 
 	resp, err := base.RoundTrip(req)
 	if err == nil && resp.StatusCode == http.StatusUnauthorized && t.OnUnauthorized != nil {

--- a/auth/transport.go
+++ b/auth/transport.go
@@ -25,13 +25,13 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		base = http.DefaultTransport
 	}
 
-	// The bearer must not leak to another host on a redirect hop.
+	// The bearer must not leak to another host or onto plaintext on a redirect hop.
 	first := req
 	for first.Response != nil {
 		first = first.Response.Request
 	}
 
-	if first.URL.Host != req.URL.Host {
+	if first.URL.Host != req.URL.Host || (first.URL.Scheme == "https" && req.URL.Scheme != "https") {
 		return base.RoundTrip(req)
 	}
 

--- a/auth/transport_test.go
+++ b/auth/transport_test.go
@@ -89,3 +89,36 @@ func TestTransport_Redirects(t *testing.T) {
 	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, "Bearer token", sameAuth, "bearer should survive a same host redirect")
 }
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// A same-host scheme downgrade cannot be reproduced with httptest servers, as they
+// always differ in port, so the redirect hop is built by hand.
+func TestTransport_SchemeDowngrade(t *testing.T) {
+	t.Parallel()
+
+	gotAuth := "unset"
+	transport := &auth.Transport{
+		Source: staticToken("token"),
+		Base: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			gotAuth = r.Header.Get("Authorization")
+
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+		}),
+	}
+
+	first, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.example.com/a", nil)
+	assert.NoError(t, err)
+
+	hop, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://api.example.com/a", nil)
+	assert.NoError(t, err)
+
+	hop.Response = &http.Response{Request: first}
+
+	resp, err := transport.RoundTrip(hop)
+	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+	assert.Empty(t, gotAuth, "bearer must not be sent over plaintext after a scheme downgrade")
+}

--- a/auth/transport_test.go
+++ b/auth/transport_test.go
@@ -48,3 +48,44 @@ func TestTransport(t *testing.T) {
 	assert.NoError(t, resp.Body.Close())
 	assert.Equal(t, 1, unauthorized)
 }
+
+func TestTransport_Redirects(t *testing.T) {
+	t.Parallel()
+
+	otherAuth := "unset"
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		otherAuth = r.Header.Get("Authorization")
+	}))
+	defer other.Close()
+
+	sameAuth := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/cross":
+			http.Redirect(w, r, other.URL, http.StatusFound)
+		case "/same":
+			http.Redirect(w, r, "/target", http.StatusFound)
+		default:
+			sameAuth = r.Header.Get("Authorization")
+		}
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: &auth.Transport{Source: staticToken("token")}}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/cross", nil)
+	assert.NoError(t, err)
+
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+	assert.Empty(t, otherAuth, "bearer must not leak to another host on a redirect")
+
+	req, err = http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/same", nil)
+	assert.NoError(t, err)
+
+	resp, err = client.Do(req)
+	assert.NoError(t, err)
+	assert.NoError(t, resp.Body.Close())
+	assert.Equal(t, "Bearer token", sameAuth, "bearer should survive a same host redirect")
+}


### PR DESCRIPTION
Fixes both findings from the round-4 review of #187:

- **P1** — `Transport.RoundTrip` runs per redirect hop and re-attached the bearer to any host, defeating net/http's cross-host `Authorization` stripping (https://github.com/futurehomeno/cliffhanger/pull/187#discussion_r3587168230). Fixed without new API surface: the `req.Response` chain identifies redirect hops, and the token is not attached when the hop's host differs from the original request's host. Covered by `TestTransport_Redirects` (cross-host and same-host cases).
- **P2** (pre-existing, body-only finding in https://github.com/futurehomeno/cliffhanger/pull/187#pullrequestreview-4703996403) — the token request was built once, so every retry sent a drained body and failed client-side. The body is now replaced before each attempt. Covered by `TestProxyClient_RetryResendsBody`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)