### PR TITLE
Document that OnAuthLoss runs under the Authenticator lock

### DIFF
--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -58,8 +58,9 @@ type AuthenticatorConfig struct {
 	RefreshLead time.Duration
 	// Backoff spaces retries of failed refresh attempts.
 	Backoff backoff.Stateful
-	// OnAuthLoss is invoked when the refresh token is rejected and credentials are cleared,
-	// e.g. to mark the lifecycle auth state as lost and publish a logout event.
+	// OnAuthLoss is invoked when authorization is lost — the refresh token is rejected or
+	// has locally expired — and credentials are cleared, e.g. to mark the lifecycle auth
+	// state as lost and publish a logout event.
 	// It runs with the internal lock held, so it must not call back into the Authenticator.
 	OnAuthLoss func(reason string)
 	// UnauthorizedGrace tolerates rejected refresh attempts for this long before concluding

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -60,6 +60,7 @@ type AuthenticatorConfig struct {
 	Backoff backoff.Stateful
 	// OnAuthLoss is invoked when the refresh token is rejected and credentials are cleared,
 	// e.g. to mark the lifecycle auth state as lost and publish a logout event.
+	// It runs with the internal lock held, so it must not call back into the Authenticator.
 	OnAuthLoss func(reason string)
 	// UnauthorizedGrace tolerates rejected refresh attempts for this long before concluding
 	// authorization loss, for APIs known to return spurious rejections on valid tokens.


### PR DESCRIPTION
Fixes the P3 finding from the final review of #187 (https://github.com/futurehomeno/cliffhanger/pull/187#discussion_r3590285358): `OnAuthLoss` is invoked from `authLost()` while `AccessToken()` holds `a.mu`, and Go's mutex is not reentrant, so a callback that re-enters the Authenticator would deadlock. Documented as a one-line constraint on the field — no runtime change.

#187 was merged before this note could land; the other finding from that review (stale backoff/grace state in `authLost`) was already fixed in #193 and is in `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)