### PR TITLE
Fix auth-loss event drop from PR #198 review

### DIFF
--- a/app/check.go
+++ b/app/check.go
@@ -220,12 +220,19 @@ func (c *ConnectivityChecker) rateLimitDelay(err error) time.Duration {
 func (c *ConnectivityChecker) apply(auth, conn lifecycle.State) {
 	changed := false
 
-	// Connection state goes first: the auth-loss watcher reacts to the auth event and
-	// must not report it together with an outdated connection state.
-	if c.lc.ConnectionState() != conn {
-		c.lc.SetConnState(conn)
+	// AuthStateLost triggers the auth-loss watcher, which reports the whole state bundle.
+	// Set both states atomically and emit once so it observes a consistent bundle and the
+	// trigger is not evicted from its buffer by a separate connection event.
+	if auth == lifecycle.AuthStateLost {
+		if c.lc.ConnectionState() != conn || c.lc.AuthState() != auth {
+			c.lc.SetConnAndAuthState(conn, auth)
 
-		changed = true
+			changed = true
+		}
+
+		c.report(changed)
+
+		return
 	}
 
 	if auth != "" && c.lc.AuthState() != auth {
@@ -234,6 +241,17 @@ func (c *ConnectivityChecker) apply(auth, conn lifecycle.State) {
 		changed = true
 	}
 
+	if c.lc.ConnectionState() != conn {
+		c.lc.SetConnState(conn)
+
+		changed = true
+	}
+
+	c.report(changed)
+}
+
+// report broadcasts node availability when a state change occurred.
+func (c *ConnectivityChecker) report(changed bool) {
 	if !changed || c.reporter == nil {
 		return
 	}

--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -208,6 +208,10 @@ func (l *Lifecycle) SetConnAndAuthState(connectionState, authState State) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 
+	if connectionState == l.connectionState && authState == l.authState {
+		return
+	}
+
 	l.connectionState = connectionState
 	l.authState = authState
 

--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -200,6 +200,20 @@ func (l *Lifecycle) SetConnState(connectionState State) {
 	l.emitStateChangeEvent(StateTypeConnState, connectionState, nil)
 }
 
+// SetConnAndAuthState sets the connection and auth states atomically and emits a single
+// auth-state event. Subscribers reacting to the auth event (e.g. the auth-loss watcher)
+// then read a consistent bundle, and the trigger cannot be evicted from their buffer by a
+// separate connection event.
+func (l *Lifecycle) SetConnAndAuthState(connectionState, authState State) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	l.connectionState = connectionState
+	l.authState = authState
+
+	l.emitStateChangeEvent(StateTypeAuthState, authState, nil)
+}
+
 func (l *Lifecycle) AppHealth() State {
 	l.lock.RLock()
 	defer l.lock.RUnlock()

--- a/lifecycle/lifecycle_test.go
+++ b/lifecycle/lifecycle_test.go
@@ -138,6 +138,27 @@ func TestSetAuthState_EmitsEvent(t *testing.T) {
 	assert.Equal(t, lifecycle.AuthStateAuthenticated, event.State)
 }
 
+func TestSetConnAndAuthState_EmitsSingleAuthEventWithBothStatesApplied(t *testing.T) {
+	t.Parallel()
+
+	l := lifecycle.New(nil)
+	l.SetAuthState(lifecycle.AuthStateAuthenticated)
+	l.SetConnState(lifecycle.ConnStateConnected)
+
+	ch := l.Subscribe("test", 5)
+
+	l.SetConnAndAuthState(lifecycle.ConnStateDisconnected, lifecycle.AuthStateLost)
+
+	event := <-ch
+	assert.Equal(t, lifecycle.StateTypeAuthState, event.Type, "a single auth event carries the transition")
+	assert.Equal(t, lifecycle.AuthStateLost, event.State)
+	assert.Equal(t, lifecycle.ConnStateDisconnected, l.ConnectionState(),
+		"both states are applied before the event, so an observer sees a consistent bundle")
+	assert.Equal(t, lifecycle.AuthStateLost, l.AuthState())
+
+	assert.Empty(t, ch, "no separate connection event competes for the subscriber buffer")
+}
+
 func TestSetConnectionState_EmitsEvent(t *testing.T) {
 	t.Parallel()
 

--- a/lifecycle/lifecycle_test.go
+++ b/lifecycle/lifecycle_test.go
@@ -159,6 +159,20 @@ func TestSetConnAndAuthState_EmitsSingleAuthEventWithBothStatesApplied(t *testin
 	assert.Empty(t, ch, "no separate connection event competes for the subscriber buffer")
 }
 
+func TestSetConnAndAuthState_NoEventWhenBothStatesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	l := lifecycle.New(nil)
+	l.SetConnState(lifecycle.ConnStateDisconnected)
+	l.SetAuthState(lifecycle.AuthStateLost)
+
+	ch := l.Subscribe("test", 5)
+
+	l.SetConnAndAuthState(lifecycle.ConnStateDisconnected, lifecycle.AuthStateLost)
+
+	assert.Empty(t, ch, "no event is emitted when neither state changes")
+}
+
 func TestSetConnectionState_EmitsEvent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Addresses the one confirmed finding from the review of #198.

**Auth-loss event can now be dropped under subscriber backpressure** (https://github.com/futurehomeno/cliffhanger/pull/198#discussion_r3590568677): the earlier fix for #197 reordered `apply` to set the connection state before the auth state. Since the auth-loss watcher ignores connection events, that extra conn event could evict the auth-loss trigger from the watcher's buffer under a burst, dropping the report entirely.

This replaces the ordering hack with `lifecycle.SetConnAndAuthState`, which sets both states under a single lock and emits **one** auth event. The watcher reads a consistent bundle (the original #197 stale-conn concern stays fixed) and the trigger is delivered as reliably as a single event — no competing conn event. Verified: the auth-loss watcher is the only consumer of the lifecycle event bus and nothing filters on connection events.

Covered by `TestSetConnAndAuthState_EmitsSingleAuthEventWithBothStatesApplied` and the existing `TestConnectivityChecker_AuthLossEventCarriesUpdatedConnState`.

The other five review findings were dismissed (three "breaking v1 API" complaints target symbols that were never released — absent from v1.2.10 — and have no consumers; two are P4 style notes the bot itself flagged as intentional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)