### PR TITLE
Fix two open P2 findings from PR #197 review

### DIFF
--- a/app/check.go
+++ b/app/check.go
@@ -106,7 +106,8 @@ func (c *ConnectivityChecker) Check() error {
 }
 
 // CheckNow cancels any pending recheck delay and probes immediately. Use it when fresh
-// credentials must be validated right away, e.g. as the check callback of Authorize.
+// credentials must be validated right away, e.g. as the check callback of Authorize. The
+// failure counter is reset so a prior streak cannot trip MaxRechecks on the first probe.
 func (c *ConnectivityChecker) CheckNow() error {
 	c.checkMu.Lock()
 	defer c.checkMu.Unlock()
@@ -120,6 +121,7 @@ func (c *ConnectivityChecker) CheckNow() error {
 		c.timer = nil
 	}
 	c.cancelled = false
+	c.failures = 0
 	c.mu.Unlock()
 
 	c.check()

--- a/app/check_test.go
+++ b/app/check_test.go
@@ -73,20 +73,6 @@ func TestConnectivityChecker_Check(t *testing.T) { //nolint:funlen
 			wantConn:    lifecycle.ConnStateConnected,
 			wantReports: 1,
 		},
-		{
-			name:        "second consecutive failure disconnects",
-			probeErrs:   []error{nil, probeErr, probeErr},
-			wantAuth:    lifecycle.AuthStateAuthenticated,
-			wantConn:    lifecycle.ConnStateDisconnected,
-			wantReports: 2,
-		},
-		{
-			name:        "recovery after failure reconnects",
-			probeErrs:   []error{nil, probeErr, probeErr, nil},
-			wantAuth:    lifecycle.AuthStateAuthenticated,
-			wantConn:    lifecycle.ConnStateConnected,
-			wantReports: 3,
-		},
 	}
 
 	for _, tc := range testCases {
@@ -253,6 +239,30 @@ func TestConnectivityChecker_CheckNowProbesDespitePendingRecheck(t *testing.T) {
 	checker.Cancel()
 }
 
+func TestConnectivityChecker_CheckNowClearsPriorFailureStreak(t *testing.T) {
+	t.Parallel()
+
+	probe := func() error { return errors.New("probe err") }
+
+	lc := lifecycle.New(nil)
+	lc.SetConnState(lifecycle.ConnStateConnected)
+
+	reporter := &fakeReporter{}
+	checker := app.NewConnectivityChecker(probe, lc, reporter, app.CheckerConfig{
+		MaxRechecks:    1,
+		RecheckBackoff: backoff.New(time.Hour, time.Hour, time.Hour, 1, 1),
+	})
+
+	assert.NoError(t, checker.Check(), "a single background failure builds a streak but stays under MaxRechecks")
+
+	assert.NoError(t, checker.CheckNow())
+	assert.Equal(t, lifecycle.ConnStateConnected, lc.ConnectionState(),
+		"CheckNow resets the streak, so one failure on fresh credentials must not trip MaxRechecks")
+	assert.Equal(t, int32(0), reporter.reports.Load(), "no disconnection report should be published")
+
+	checker.Cancel()
+}
+
 // CheckNow takes checkMu before clearing the timer; run it against concurrent Check and
 // Cancel to guard that lock order against deadlock and data races (with -race).
 func TestConnectivityChecker_CheckNowConcurrentWithCheckAndCancel(t *testing.T) {
@@ -352,25 +362,32 @@ func TestConnectivityChecker_ConcurrentChecks(t *testing.T) {
 	checker.Cancel()
 }
 
-func TestConnectivityChecker_Recheck(t *testing.T) {
+func TestConnectivityChecker_DisconnectsAfterConsecutiveFailuresThenReconnects(t *testing.T) {
 	t.Parallel()
 
-	var calls atomic.Int32
+	var recovered atomic.Bool
 
 	probe := func() error {
-		calls.Add(1)
+		if recovered.Load() {
+			return nil
+		}
 
 		return errors.New("probe err")
 	}
 
-	checker := app.NewConnectivityChecker(probe, lifecycle.New(nil), nil, app.CheckerConfig{
+	lc := lifecycle.New(nil)
+	checker := app.NewConnectivityChecker(probe, lc, &fakeReporter{}, app.CheckerConfig{
+		MaxRechecks:    1,
 		RecheckBackoff: backoff.New(time.Millisecond, time.Millisecond, time.Millisecond, 1, 1),
 	})
 
 	assert.NoError(t, checker.Check())
+	assert.Eventually(t, func() bool { return lc.ConnectionState() == lifecycle.ConnStateDisconnected },
+		time.Second, 5*time.Millisecond, "more than MaxRechecks consecutive failures should report disconnection")
 
-	assert.Eventually(t, func() bool { return calls.Load() >= 2 }, time.Second, 5*time.Millisecond,
-		"scheduled recheck should re-run the probe")
+	recovered.Store(true)
+	assert.Eventually(t, func() bool { return lc.ConnectionState() == lifecycle.ConnStateConnected },
+		time.Second, 5*time.Millisecond, "a successful recheck should reconnect")
 
 	checker.Cancel()
 }

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -87,6 +87,7 @@ type Authenticator struct {
 
 	mu                sync.Mutex
 	unauthorizedSince time.Time
+	unauthorizedToken string
 }
 
 func NewAuthenticator(store CredentialsStore, exchanger TokenExchanger, cfg AuthenticatorConfig) *Authenticator {
@@ -123,8 +124,10 @@ func (a *Authenticator) AccessToken() (string, error) {
 
 		// A rejection streak that outlived the grace period concludes auth loss even while
 		// backoff suppresses new exchanges. unauthorizedSince is only set by a real 401/403,
-		// so a transient (non-auth) backoff is left alone to keep retrying.
-		if !a.unauthorizedSince.IsZero() && !a.withinUnauthorizedGrace() {
+		// so a transient (non-auth) backoff is left alone to keep retrying. The streak is tied
+		// to the rejected refresh token, so credentials replaced out-of-band are not concluded
+		// lost on a stale timestamp they never triggered.
+		if !a.unauthorizedSince.IsZero() && a.unauthorizedToken == creds.RefreshToken && !a.withinUnauthorizedGrace() {
 			a.authLost("refresh token rejected, grace elapsed during backoff")
 
 			return "", errors.New("refresh token rejected, re-login required")
@@ -137,10 +140,16 @@ func (a *Authenticator) AccessToken() (string, error) {
 	if err != nil {
 		a.cfg.Backoff.Fail()
 
-		if errors.Is(err, httpclient.ErrUnauthorized) && !a.withinUnauthorizedGrace() {
-			a.authLost(fmt.Sprintf("refresh token rejected: %v", err))
+		if errors.Is(err, httpclient.ErrUnauthorized) {
+			if a.unauthorizedSince.IsZero() {
+				a.unauthorizedToken = creds.RefreshToken
+			}
 
-			return "", err
+			if !a.withinUnauthorizedGrace() {
+				a.authLost(fmt.Sprintf("refresh token rejected: %v", err))
+
+				return "", err
+			}
 		}
 
 		// A transient refresh failure does not invalidate a token that is still valid.
@@ -154,6 +163,7 @@ func (a *Authenticator) AccessToken() (string, error) {
 	// The server accepted the refresh token, refuting any rejection streak regardless
 	// of whether persistence below succeeds.
 	a.unauthorizedSince = time.Time{}
+	a.unauthorizedToken = ""
 
 	newCreds := response.Credentials()
 	if newCreds.RefreshToken == "" || newCreds.RefreshToken == creds.RefreshToken {
@@ -187,6 +197,7 @@ func (a *Authenticator) authLost(reason string) {
 
 	a.cfg.Backoff.Reset()
 	a.unauthorizedSince = time.Time{}
+	a.unauthorizedToken = ""
 
 	if err := a.store.ClearCredentials(); err != nil {
 		log.Errorf("[auth] Clear credentials err: %v", err)

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -141,7 +141,11 @@ func (a *Authenticator) AccessToken() (string, error) {
 		a.cfg.Backoff.Fail()
 
 		if errors.Is(err, httpclient.ErrUnauthorized) {
-			if a.unauthorizedSince.IsZero() {
+			// A refresh token different from the one that started the streak gets its own grace
+			// window, so credentials replaced out-of-band are not concluded lost on the elapsed
+			// grace of a token they never shared.
+			if a.unauthorizedSince.IsZero() || a.unauthorizedToken != creds.RefreshToken {
+				a.unauthorizedSince = time.Time{}
 				a.unauthorizedToken = creds.RefreshToken
 			}
 

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -121,6 +121,15 @@ func (a *Authenticator) AccessToken() (string, error) {
 			return creds.AccessToken, nil
 		}
 
+		// A rejection streak that outlived the grace period concludes auth loss even while
+		// backoff suppresses new exchanges. unauthorizedSince is only set by a real 401/403,
+		// so a transient (non-auth) backoff is left alone to keep retrying.
+		if !a.unauthorizedSince.IsZero() && !a.withinUnauthorizedGrace() {
+			a.authLost("refresh token rejected, grace elapsed during backoff")
+
+			return "", errors.New("refresh token rejected, re-login required")
+		}
+
 		return "", errors.New("token refresh suspended by backoff")
 	}
 

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -360,4 +360,34 @@ func TestAuthenticator_AccessToken(t *testing.T) {
 		assert.True(t, store.creds.Empty(), "auth loss should clear credentials rather than stay suspended by backoff")
 		assert.Contains(t, lossReason, "grace elapsed during backoff")
 	})
+
+	t.Run("backoff auth loss ignores credentials replaced after the rejection", func(t *testing.T) {
+		t.Parallel()
+
+		creds := validCreds()
+		creds.ExpiresAt = time.Now().Add(-time.Minute)
+
+		store := &fakeStore{creds: creds}
+		a := auth.NewAuthenticator(store, &fakeExchanger{err: httpclient.ErrUnauthorized}, auth.AuthenticatorConfig{
+			UnauthorizedGrace: 50 * time.Millisecond,
+			Backoff:           backoff.NewTolerantFixed(0, time.Hour),
+		})
+
+		_, err := a.AccessToken()
+		assert.Error(t, err, "first 401 starts the grace window for the rejected refresh token")
+
+		// Re-authorization out-of-band: fresh credentials with a new refresh token, set
+		// directly on the store (e.g. a manual set-tokens command), bypassing the exchange.
+		fresh := validCreds()
+		fresh.RefreshToken = "refresh-2"
+		fresh.ExpiresAt = time.Now().Add(-time.Minute)
+		store.creds = fresh
+
+		time.Sleep(100 * time.Millisecond)
+
+		_, err = a.AccessToken()
+		assert.Error(t, err, "the replaced credentials still need a refresh that backoff suspends")
+		assert.False(t, store.creds.Empty(),
+			"a stale rejection streak from the old token must not clear the replaced credentials")
+	})
 }

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -390,4 +390,34 @@ func TestAuthenticator_AccessToken(t *testing.T) {
 		assert.False(t, store.creds.Empty(),
 			"a stale rejection streak from the old token must not clear the replaced credentials")
 	})
+
+	t.Run("exchange grace resets for credentials replaced after the rejection", func(t *testing.T) {
+		t.Parallel()
+
+		creds := validCreds()
+		creds.ExpiresAt = time.Now().Add(-time.Minute)
+
+		store := &fakeStore{creds: creds}
+		a := auth.NewAuthenticator(store, &fakeExchanger{err: httpclient.ErrUnauthorized}, auth.AuthenticatorConfig{
+			UnauthorizedGrace: 50 * time.Millisecond,
+			Backoff:           &fakeBackoff{},
+		})
+
+		_, err := a.AccessToken()
+		assert.Error(t, err, "first 401 on the original token starts the grace window")
+
+		time.Sleep(100 * time.Millisecond)
+
+		// Out-of-band replacement with a new refresh token that still needs a refresh; the
+		// exchange path (backoff not suppressing) must give it its own grace, not the elapsed one.
+		fresh := validCreds()
+		fresh.RefreshToken = "refresh-2"
+		fresh.ExpiresAt = time.Now().Add(-time.Minute)
+		store.creds = fresh
+
+		_, err = a.AccessToken()
+		assert.Error(t, err, "the replaced token still fails to exchange")
+		assert.False(t, store.creds.Empty(),
+			"the replaced token gets its own grace window rather than inheriting the old token's elapsed one")
+	})
 }

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -321,9 +321,11 @@ func TestAuthenticator_AccessToken(t *testing.T) {
 	t.Run("backoff suspends refresh attempts", func(t *testing.T) {
 		t.Parallel()
 
+		store := &fakeStore{creds: expiredCreds()}
 		exchanger := &fakeExchanger{err: errors.New("proxy down")}
-		a := auth.NewAuthenticator(&fakeStore{creds: expiredCreds()}, exchanger, auth.AuthenticatorConfig{
-			Backoff: backoff.NewStateful(time.Hour, time.Hour, time.Hour, 1, 1),
+		a := auth.NewAuthenticator(store, exchanger, auth.AuthenticatorConfig{
+			UnauthorizedGrace: time.Nanosecond,
+			Backoff:           backoff.NewStateful(time.Hour, time.Hour, time.Hour, 1, 1),
 		})
 
 		_, err := a.AccessToken()
@@ -331,5 +333,31 @@ func TestAuthenticator_AccessToken(t *testing.T) {
 		_, err = a.AccessToken()
 		assert.Error(t, err)
 		assert.Equal(t, 1, exchanger.calls, "second attempt should be suspended by backoff")
+		assert.False(t, store.creds.Empty(), "a transient (non-401) backoff must not conclude auth loss even past grace")
+	})
+
+	t.Run("backoff concludes auth loss once grace elapses", func(t *testing.T) {
+		t.Parallel()
+
+		creds := validCreds()
+		creds.ExpiresAt = time.Now().Add(-time.Minute)
+
+		store := &fakeStore{creds: creds}
+		lossReason := ""
+		a := auth.NewAuthenticator(store, &fakeExchanger{err: httpclient.ErrUnauthorized}, auth.AuthenticatorConfig{
+			UnauthorizedGrace: 50 * time.Millisecond,
+			Backoff:           backoff.NewTolerantFixed(0, time.Hour),
+			OnAuthLoss:        func(reason string) { lossReason = reason },
+		})
+
+		_, err := a.AccessToken()
+		assert.Error(t, err, "first 401 starts the grace window and the backoff streak")
+
+		time.Sleep(100 * time.Millisecond)
+
+		_, err = a.AccessToken()
+		assert.Error(t, err, "expired credentials must not linger once grace elapses under backoff")
+		assert.True(t, store.creds.Empty(), "auth loss should clear credentials rather than stay suspended by backoff")
+		assert.Contains(t, lossReason, "grace elapsed during backoff")
 	})
 }


### PR DESCRIPTION
Addresses the two remaining unresolved P2 findings from the #197 review, both on develop code that #198 did not touch.

- **auth: refresh backoff can delay auth loss past `UnauthorizedGrace`** ([#197 discussion_r3593595398](https://github.com/futurehomeno/cliffhanger/pull/197#discussion_r3593595398)). `AccessToken` now concludes auth loss inside the backoff branch when a real 401/403 streak has outlived the grace period, instead of returning "suspended by backoff" indefinitely. Guarded on `!unauthorizedSince.IsZero()` so a transient (non-auth) backoff keeps retrying.
- **app: CheckNow reuses stale failure history** ([#197 discussion_r3593595403](https://github.com/futurehomeno/cliffhanger/pull/197#discussion_r3593595403)). `CheckNow` resets the failure counter so a prior background streak cannot trip `MaxRechecks` on the first probe of freshly persisted credentials. Consecutive-failure accumulation is unchanged and now covered by a timer-driven test on the periodic `Check` path.

Verified: `go build`/`go vet` clean, `go test -race ./app/... ./auth/...` green, `golangci-lint run` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)