### PR TITLE
test: cover backoff-valid-token and repair-guard branches

### DIFF
--- a/app/check_test.go
+++ b/app/check_test.go
@@ -130,6 +130,23 @@ func TestConnectivityChecker_RepairsStrandedAppHealth(t *testing.T) {
 	assert.Equal(t, lifecycle.AuthStateAuthenticated, lc.AuthState())
 }
 
+func TestConnectivityChecker_RepairAppHealthLeavesRunningAppUntouched(t *testing.T) {
+	t.Parallel()
+
+	lc := lifecycle.New(nil)
+	lc.SetAppHealth(lifecycle.AppHealthRunning, nil)
+	// A running app that never lost its config must not be force-marked configured.
+	lc.SetConfigState(lifecycle.ConfigStateNotConfigured)
+
+	checker := app.NewConnectivityChecker(func() error { return nil }, lc, nil, app.CheckerConfig{})
+
+	assert.NoError(t, checker.Check())
+
+	assert.Equal(t, lifecycle.AppHealthRunning, lc.AppHealth())
+	assert.Equal(t, lifecycle.ConfigStateNotConfigured, lc.ConfigState(),
+		"an already-running app is left untouched, not re-configured by the repair guard")
+}
+
 func TestConnectivityChecker_CancelDiscardsInFlightProbe(t *testing.T) {
 	t.Parallel()
 
@@ -376,7 +393,10 @@ func TestConnectivityChecker_DisconnectsAfterConsecutiveFailuresThenReconnects(t
 	}
 
 	lc := lifecycle.New(nil)
-	checker := app.NewConnectivityChecker(probe, lc, &fakeReporter{}, app.CheckerConfig{
+	lc.SetAuthState(lifecycle.AuthStateAuthenticated)
+
+	reporter := &fakeReporter{}
+	checker := app.NewConnectivityChecker(probe, lc, reporter, app.CheckerConfig{
 		MaxRechecks:    1,
 		RecheckBackoff: backoff.New(time.Millisecond, time.Millisecond, time.Millisecond, 1, 1),
 	})
@@ -384,6 +404,9 @@ func TestConnectivityChecker_DisconnectsAfterConsecutiveFailuresThenReconnects(t
 	assert.NoError(t, checker.Check())
 	assert.Eventually(t, func() bool { return lc.ConnectionState() == lifecycle.ConnStateDisconnected },
 		time.Second, 5*time.Millisecond, "more than MaxRechecks consecutive failures should report disconnection")
+	assert.Equal(t, lifecycle.AuthStateAuthenticated, lc.AuthState(),
+		"a connectivity-only disconnect must not clear the auth state")
+	assert.Positive(t, reporter.reports.Load(), "the disconnection transition is reported")
 
 	recovered.Store(true)
 	assert.Eventually(t, func() bool { return lc.ConnectionState() == lifecycle.ConnStateConnected },

--- a/auth/authenticator_test.go
+++ b/auth/authenticator_test.go
@@ -420,4 +420,25 @@ func TestAuthenticator_AccessToken(t *testing.T) {
 		assert.False(t, store.creds.Empty(),
 			"the replaced token gets its own grace window rather than inheriting the old token's elapsed one")
 	})
+
+	t.Run("backoff returns a still valid token without refreshing", func(t *testing.T) {
+		t.Parallel()
+
+		b := backoff.NewStateful(time.Hour, time.Hour, time.Hour, 0, 0)
+		b.Fail() // prime the streak so Should() suppresses the refresh exchange
+
+		creds := validCreds()
+		creds.ExpiresAt = time.Now().Add(time.Minute) // inside RefreshLead but not yet expired
+
+		exchanger := &fakeExchanger{}
+		a := auth.NewAuthenticator(&fakeStore{creds: creds}, exchanger, auth.AuthenticatorConfig{
+			RefreshLead: 5 * time.Minute,
+			Backoff:     b,
+		})
+
+		token, err := a.AccessToken()
+		assert.NoError(t, err, "a still valid access token is returned while backoff suppresses the refresh")
+		assert.Equal(t, "access", token)
+		assert.Zero(t, exchanger.calls, "backoff must suppress the refresh exchange")
+	})
 }


### PR DESCRIPTION
Add tests for two previously-uncovered behavioral branches:
- auth: AccessToken returns a still-valid access token without an exchange when backoff is suppressing refreshes (AccessToken 97.5% -> 100%).
- app: repairAppHealth leaves an already-RUNNING app untouched instead of force-marking it configured (repairAppHealth 75% -> 100%).

Also restore the report-count and auth-untouched assertions on the timer-driven disconnect test that the earlier table-case removal dropped.