### PR TITLE
Add port_to_cliffhanger_1.2 and _1.3 skills

### DIFF
--- a/.claude/skills/port_to_cliffhanger_1.2/SKILL.md
+++ b/.claude/skills/port_to_cliffhanger_1.2/SKILL.md
@@ -8,10 +8,11 @@ description: Port a Futurehome edge adapter (legacy fimpgo or cliffhanger v0.x) 
 Read [references/porting-manual.md](references/porting-manual.md) first — it contains the full
 architecture, package structure, template table, and code patterns. This file is the procedure.
 
-Reference projects live in `~/proj/go/`: edge-mill-adapter (primary template),
-edge-sensibo-adapter (tooling/packaging golden copy), edge-zaptec-adapter (packaging migration +
-adapter.json migration), edge-sonos/easee (push transports), edge-netatmo (OAuth).
-Cliffhanger source: `~/go/pkg/mod/github.com/futurehomeno/cliffhanger@v1.2.10/`.
+Reference projects are the sibling `edge-*-adapter` repos in this workspace (here, `~/proj/go/`;
+adjust to wherever they're checked out): edge-mill-adapter (primary template), edge-sensibo-adapter
+(tooling/packaging golden copy), edge-zaptec-adapter (packaging migration + adapter.json migration),
+edge-sonos/easee (push transports), edge-netatmo (OAuth). Cliffhanger source is in the Go module
+cache (`$(go env GOMODCACHE)/github.com/futurehomeno/cliffhanger@v1.2.10/`).
 
 ## Procedure
 
@@ -65,8 +66,9 @@ Cliffhanger source: `~/go/pkg/mod/github.com/futurehomeno/cliffhanger@v1.2.10/`.
 9. **Verify**: `go vet ./...`, `golangci-lint run`, `make test`, `make build-arm`, `make deb-arm`.
    Delete dead legacy packages. Update README, app-manifest.json, defaults/config.json.
 
-10. **Finish with `/improve_logs`**: invoke the improve_logs skill on the ported code so all log
-    statements follow the logging conventions (wrap-then-log-once, [component] prefixes, levels).
+10. **Review logs**: if the `improve_logs` skill is available, invoke it on the ported code;
+    otherwise review log statements by hand for the conventions (wrap-then-log-once,
+    [component] prefixes, appropriate levels).
 
 ## Output expectations
 

--- a/.claude/skills/port_to_cliffhanger_1.2/SKILL.md
+++ b/.claude/skills/port_to_cliffhanger_1.2/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: port_to_cliffhanger_1.2
+description: Port a Futurehome edge adapter (legacy fimpgo or cliffhanger v0.x) to cliffhanger v1.2.10, or build a new adapter on it. Use when asked to port/migrate an edge adapter to cliffhanger, modernize an adapter, or align an adapter with the mill/sensibo/zaptec architecture (futurehome packaging, unified Makefile/CI, mockery tests).
+---
+
+# Port an edge adapter to cliffhanger v1.2.10
+
+Read [references/porting-manual.md](references/porting-manual.md) first — it contains the full
+architecture, package structure, template table, and code patterns. This file is the procedure.
+
+Reference projects live in `~/proj/go/`: edge-mill-adapter (primary template),
+edge-sensibo-adapter (tooling/packaging golden copy), edge-zaptec-adapter (packaging migration +
+adapter.json migration), edge-sonos/easee (push transports), edge-netatmo (OAuth).
+Cliffhanger source: `~/go/pkg/mod/github.com/futurehomeno/cliffhanger@v1.2.10/`.
+
+## Procedure
+
+1. **Survey the legacy adapter.** Record: FIMP services + interfaces emitted, exact device
+   addresses (`sv:<svc>/ad:<id>`), config file shape and location, auth flow, polling interval,
+   packaging paths (`/opt/thingsplex/...`?), quirks (unit scaling, clamps, rate limits).
+   **FIMP messages must stay wire-compatible** (manual §14): same resource name (`rn:`), same
+   service names, same service addresses (via `ThingSeed.CustomAddress`), same interfaces and
+   value types — diff legacy vs ported inclusion reports and evt messages to prove it.
+
+2. **Check vendor API conformity.** Find the vendor's public API docs (and OpenAPI spec if
+   published). Compare with what the legacy code calls; note auth model, units, rate limits.
+   Decide: keep the existing auth architecture (e.g. Futurehome proxy) unless told otherwise.
+   If the vendor offers an async channel (LAN API, websocket, SignalR, AMQP, UPnP), prefer it
+   over polling, with a slow REST poll as reconciliation.
+
+3. **Decisions before coding** (confirm with the user if ambiguous): thing granularity
+   (device vs room), service set, prefab thing vs generic assembly, polling default
+   (**floor 60 s for REST cloud polling**), what legacy config fields map to.
+
+4. **Scaffold** per manual §1–§2: `main.go`, `cmd/{root,factory,testing}.go`,
+   `internal/{app,config,routing,tasks,adapter,<vendor>}`. Copy the shape from mill; keep
+   `go.mod` at cliffhanger v1.2.10 and the Go version used by the reference projects.
+
+5. **Implement in order**: config (+ legacy migration, manual §8; the 0→1 migration must
+   forcefully set `LogLevel = "info"` and `LogFormat = "budzik"`) → API client + auth →
+   controller + thing factory → app (Check per manual §3) → routing → tasks.
+   Reporting: `cache.ReportAtLeastEvery(time.Hour)` for variable values (setpoint, mode,
+   temperature, meter); static parameters are never reported periodically.
+
+6. **Tooling** (manual §12): copy sensibo's Makefile + go.yml, add mill's `check-mocks`/`broker`
+   targets, netatmo/sonos `.golangci.yaml`, mill's `.mockery.yaml`; substitute app name, module
+   path, version. Coverage gate 75% in `make test`, aim > 80%. Never SHA-pin actions.
+
+7. **Packaging** (manual §13): futurehome layout (`/usr/bin`, `/var/lib/futurehome`,
+   `/usr/share/futurehome`, `/var/log/futurehome`), zaptec's maintainer scripts + `migrate.sh`
+   adapted to the app (path sed rules for the legacy config).
+   **Gitignore trap**: a bare `<app>` ignore pattern (for the built binary) also swallows every
+   packaging path containing `/<app>/` (`usr/lib/futurehome/<app>/migrate.sh`, `usr/share/.../defaults/`)
+   — the local `deb-arm` still builds, so it ships silently broken. Anchor binary ignores
+   (`/<app>`, `src/<app>`) and verify `git ls-files package/` matches the on-disk tree.
+
+8. **Tests**: `make generate-mocks`; unit tests for controller/config/app/routing against mocks;
+   e2e FIMP round trips with local mosquitto (`make broker`). Iterate until every package clears
+   the 75% gate and total is > 80%.
+   **Goroutine lifecycle in ported engines**: legacy restart paths often re-enter Init and
+   re-spawn worker/ticker goroutines with no shutdown, leaking one per stop/start cycle.
+   When porting, guard spawns (sync.Once) or give loops a stop channel closed in Stop(),
+   and order side effects so a failed Start doesn't leave tickers/transports running.
+
+9. **Verify**: `go vet ./...`, `golangci-lint run`, `make test`, `make build-arm`, `make deb-arm`.
+   Delete dead legacy packages. Update README, app-manifest.json, defaults/config.json.
+
+10. **Finish with `/improve_logs`**: invoke the improve_logs skill on the ported code so all log
+    statements follow the logging conventions (wrap-then-log-once, [component] prefixes, levels).
+
+## Output expectations
+
+- A working adapter on cliffhanger v1.2.10 with the manual's package structure.
+- Legacy users upgrade seamlessly: same FIMP addresses, migrated config/state, packaging
+  migration from /opt/thingsplex.
+- CI green: build, lint (golangci-lint v2 + staticcheck), tests with coverage gate.

--- a/.claude/skills/port_to_cliffhanger_1.2/references/porting-manual.md
+++ b/.claude/skills/port_to_cliffhanger_1.2/references/porting-manual.md
@@ -417,3 +417,94 @@ before release.
 - `.githooks/pre-commit` + `make init` to install it.
 - Don't SHA-pin GitHub Actions; use major version tags.
 - Delete dead legacy code after the port (old router/poller/processor packages).
+
+## 17. Review-hardening checklist (learned from the kind-owl hub-service port)
+
+These are the issues an automated reviewer flags round after round on a port. Fix them
+up front — most are one-liners that are cheaper to get right than to re-review.
+
+**Diff against the LATEST prod branch, not the fork base.** The single biggest source of
+regressions: the port was cut from an old `master` while prod had moved on (`develop`,
+tagged `v1.8.3`). Everything downstream — a missing feature (`cmd.timeline.delete`), a
+dropped guard (`if cmd == "set"`), a reordered timer (clear the pending flag *before* the
+callback, not after) — traced to not diffing the domain logic line-by-line against the
+newest shipped version. Before coding: `git log <forkbase>..<latest-prod>` for the feature
+list, then `git diff <latest-prod> -- <domain files>` and reconcile every behavioral line.
+A behavior-preserving port preserves *prod's* behavior, not the fork base's.
+
+**Core/hub service (no edge things), builder + lifecycle.** For a hub-internal service
+(no device inclusion, e.g. a notification/timeline service): `root.NewCoreAppBuilder()`,
+which *forbids* `WithLifecycle` (precedent: `fhbutler_nextgen/src/cmd/root.go`). Because
+`app.RouteApp`/`app.TaskApp` require a lifecycle, hand-roll the app routes with
+`router.NewRouting(router.NewMessageHandler(...), router.ForService(...), router.ForType(...))`
+for `cmd.app.get_manifest`, `cmd.app.get_state`, and **`cmd.app.uninstall`** — wire every
+app method you implement (a `Uninstall()` that wipes state but is never routed is dead code),
+and advertise each as an `in`/`out` interface in the manifest.
+
+**The router runs 5 concurrent workers by default** (`router.go` `concurrency: 5`). Any
+mutable state a handler touches is racy without a lock: config setters (do the whole
+read-modify-write in one critical section — snapshotting under a read lock then writing
+under a separate write lock is a TOCTOU that loses updates), and any timer/flag read by a
+handler. Run the affected packages with `-race` and add a regression test that drives the
+concurrent path.
+
+**Config service correctness:**
+- Setters roll the model back on `Save()` failure — otherwise `get_report` shows the new
+  value while the pipeline keeps the old one. `old := *m; change(m); if Save() fails { *m = old; return err }`.
+- Migration `Do()` **returns the error** on a real (non-ENOENT) legacy read/parse failure so
+  `config_version` does not advance — cliffhanger only writes `To` into `ConfigVersion` when
+  `Do()` returns nil, so the import retries next boot instead of silently losing settings.
+- Startup stays **fail-soft** on a migration error (log, boot with the shipped defaults —
+  which must be the correct standard config: right topics, subscriptions, thresholds). Do
+  *not* `log.Fatal` — crash-looping a hub service over a config edge is worse than degraded.
+
+**Upgrade preserves the legacy config file.** If the *old* package shipped its config as
+package content (e.g. `/var/lib/futurehome/<app>/config.json`) and the new package no longer
+ships that path, dpkg deletes it during unpack — before first-boot migration reads it.
+`preinst upgrade` copies it to `config.json.pre-upgrade`; `postinst configure` moves it back
+before the service starts. (This is on top of §13's thingsplex `migrate.sh`.)
+
+**Packaging `Depends`.** Don't drop runtime `Depends:` (e.g. `influxdb (>= 1.7)`) from the
+generated `control` — `postinst` starts the dependency under `set -e`, so a missing
+declaration half-configures the package on a clean host. Verify with `dpkg-deb -f <deb> Depends`.
+
+**Destructive commands: authorize on the topic, not the payload.** A delete/reset command
+must validate the MQTT **topic** it arrived on (`message.Topic ==
+"pt:j1/mt:cmd/rt:app/rn:<svc>/ad:1"`), not the payload's `Service` field (the sender controls
+that). Thread `message.Topic` from routing into the handler. Validate any injected id
+(numeric `event_id` before an InfluxQL `DELETE`) and escape identifiers/values.
+
+**Storage: use the configured DB name**, not a hardcoded literal, in create/delete/retention
+queries — or a non-default `DbName` creates one database while reads/writes target another.
+
+**Async-backend wiring (websocket/SignalR/etc.):**
+- A `Start()` that retries `connect()` in an infinite loop never returns an error — that
+  error branch is dead; don't fail app boot on it (the service must come up and keep retrying).
+- On a fetch error, **skip the cache push** — sending an empty/zero-value result clobbers the
+  in-memory cache. Make `warmup()`/`handleStatus()` share one `refresh(component)` helper that
+  returns early on error.
+
+**Panic guard.** A shared `recover()` helper re-panics with the **original value**
+(`panic(r)`), not a fixed sentinel string — preserves the chain for crash reporters.
+
+**CI / tooling gotchas (these each cost a review round):**
+- The mock-generating job needs the private-module setup too (`git config insteadOf` with the
+  token + `go env -w GOPRIVATE=...`) — without it `mockery` can't load private deps
+  (`invalid package name`).
+- Verify committed mocks with `git status --porcelain -- <mocks dir>` (catches new *untracked*
+  files), not `git diff --exit-code` (misses them) — in **both** CI and the `check-mocks`
+  Makefile target.
+- Coverage-gate profile filtering: exclude `_test\.go` and `/mocks/` precisely; a bare
+  `grep -v test` / `grep -v mock` also drops production files whose path contains those
+  substrings (e.g. `cmd/testing.go`), silently weakening the gate.
+- `.githooks/pre-commit` is **check-only** (`gofmt -l` → fail), never mutate-then-abort:
+  `gofmt -w` + a commented-out `git add` lets unformatted blobs through on the retry (the
+  index still holds them). Filter files with `grep '\.go$'` (escaped dot).
+
+**testdata parity.** The config `make run` uses (`./testdata`) must mirror `defaults/` for
+behaviorally-significant fields (e.g. `legacyEvents`) — an empty list there means manual runs
+never exercise the flows the port is supposed to preserve.
+
+**Logs last:** review logs (invoke `improve_logs` if available, § finish step) — `[component]` prefixes, wrap-then-log-once,
+no swallowed errors, budzik format. Reviewers flag every `WithError`, every silently-dropped
+`err`, and every leftover debug string.

--- a/.claude/skills/port_to_cliffhanger_1.2/references/porting-manual.md
+++ b/.claude/skills/port_to_cliffhanger_1.2/references/porting-manual.md
@@ -1,0 +1,419 @@
+# Porting a Futurehome edge adapter to cliffhanger v1.2.10
+
+Manual for migrating legacy edge adapters (hand-rolled fimpgo routing or cliffhanger v0.x) to the
+cliffhanger v1.2.10 framework, and for building new adapters on it. Distilled from:
+`edge-mill-adapter` (cloud thermostat + LAN fallback — best overall template),
+`edge-sensibo-adapter` (multi-service climate things, modern packaging + CI),
+`edge-sonos-adapter` (UPnP push), `edge-easee-adapter` (SignalR push),
+`edge-zaptec-adapter` (AMQP push, packaging migration reference), `edge-netatmo-adapter` (OAuth).
+
+## 0. Pick your templates
+
+| Concern | Copy from |
+|---|---|
+| Overall skeleton (cmd/, internal/, app, tasks, routing) | mill |
+| Multi-service / capability-driven things | sensibo |
+| Makefile + packaging (futurehome layout, staging build) | sensibo (zaptec equivalent) |
+| go.yml CI workflow | sensibo (release needs test+linter, first-release-safe changelog) |
+| .golangci.yaml | netatmo or sonos (fullest: includes paralleltest/tparallel) |
+| .mockery.yaml | mill (has `issue-845-fix`, `resolve-type-alias`) |
+| Debian maintainer scripts + migrate.sh | zaptec (best documented; sensibo equivalent) |
+| Async push transport | easee (SignalR), sonos (UPnP/GENA), zaptec (AMQP), mill (LAN REST fallback) |
+| Adapter-state (adapter.json) migration | zaptec `src/internal/migration/` |
+
+Do NOT use `core-energy-guard` as a template — it is a core service, not an edge adapter.
+Easee lags at cliffhanger v1.2.7; use it only for the SignalR pattern.
+
+## 1. Package structure
+
+```
+Makefile                      # unified style, see §12
+VERSION file only if legacy scripts need it; version lives in Makefile + git tags
+.github/workflows/go.yml
+.githooks/pre-commit          # gofmt guard
+package/debian/               # futurehome layout, see §13
+scripts/coverage_gate.awk     # or coverage-gate.sh
+src/
+  main.go                     # thin: cmd.Execute(PackageName, Version)
+  go.mod                      # module github.com/futurehomeno/edge-<name>-adapter, cliffhanger v1.2.10
+  .golangci.yaml
+  .mockery.yaml
+  cmd/
+    root.go                   # Execute() + Build() -> root.NewEdgeAppBuilder()
+    factory.go                # serviceContainer: lazy get*() singletons (hand-rolled DI)
+    testing.go                # bootstrap helpers for e2e tests
+  internal/
+    app/app.go                # cliffhanger app.App implementation (§3)
+    config/config.go          # Config + thread-safe Service + Migrate() (§8)
+    routing/routing.go        # router.Combine(...) table + LogStats (§10)
+    tasks/tasks.go            # task.Combine(...) periodic tasks (§5)
+    adapter/thing.go          # ThingFactory (§4)
+    <vendor>/                 # domain: client.go, auth.go, controller.go, model
+    model/                    # DTOs if not in <vendor>/
+    migration/                # legacy config/adapter.json migration if porting (§8)
+    test/mocks/               # mockery output; test/fakes/ hand-written
+```
+
+One package = one concern. The `<vendor>` package owns the API client and the `Controller`
+(device driver implementing service interfaces). `adapter` assembles things from services.
+
+## 2. Bootstrap
+
+`main.go`:
+
+```go
+var Version = "unknown"; var PackageName = "<name>"
+func main() { cmd.Execute(PackageName, Version) }
+```
+
+`cmd/root.go` — `Execute` loads config (`bootstrap.GetConfigurationDirectory()`), calls `Build`,
+`app.Run()`. The builder:
+
+```go
+root.NewEdgeAppBuilder().
+    WithMQTT(getMQTT(cfg)).
+    WithServiceDiscovery(routing.ResourceName, discovery.ResourceTypeAd, packageName, "1", version).
+    WithLifecycle(getLifecycle()).
+    WithTelemetry(getTelemetry(cfg)).
+    WithTopicSubscription(
+        router.TopicPatternAdapter(routing.ResourceName, fimptype.MsgTypeCmd),
+        router.TopicPatternDevice(routing.ResourceName, fimptype.MsgTypeCmd),
+    ).
+    WithRouterOptions(router.WithStatsCallback(routing.LogStats)).
+    WithRouting(newRouting(cfg)...).
+    WithTask(newTasks(cfg)...).
+    WithServices(/* push transport managers, event listeners — root.Service */).
+    Build()
+```
+
+`cmd/factory.go` — package-level `services = &serviceContainer{}` with lazy singletons:
+- `getConfigStorage()` → `storage.New(config.New(workDir), workDir, "config.json")`
+- `getLifecycle()` → `lifecycle.New(getConfigService().DefaultStore())`
+- `getAdapter()` → `cliffAdapter.NewState(workDir)` + `cliffAdapter.NewAdapter(mqtt, eventManager, thingFactory, state, routing.ResourceName, "1")`
+
+Async transports (SignalR/UPnP/AMQP managers) are registered via `WithServices(...)` so their
+`Start()/Stop()` follow the app lifecycle.
+
+## 3. The app package — lifecycle and Check()
+
+Implement and assert the interfaces you need (cliffhanger `app/app.go`):
+
+```go
+var (
+    _ app.App              = (*Application)(nil)   // GetManifest, Configure, Uninstall
+    _ app.InitializableApp = (*Application)(nil)   // Initialize
+    _ app.CheckableApp     = (*Application)(nil)   // Check, CheckInterval
+    _ app.LogginableApp    = (*Application)(nil)   // Login (note spelling)
+    _ app.LogoutableApp    = (*Application)(nil)   // Logout
+    // app.AuthorizableApp for cmd.auth.set_tokens, app.ResettableApp for factory reset
+)
+```
+
+`RouteApp` picks these up by type assertion — never hand-write `cmd.auth.*` handlers.
+
+**Check()** (mill `app.go:198` is the canonical state machine):
+1. No credentials → `SetConnState(Disconnected)`, return.
+2. Probe the cloud with a cheap real call.
+3. 401 → drop token, `SetAuthState(AuthStateLost)`, `SetConnState(Disconnected)`.
+4. 429/transient → stay `Connected` (or schedule a 5-min recheck before flipping — mill
+   `scheduleRecheck`); avoids hour-long false outages since `CheckInterval()` is typically 1h.
+5. Success → `Authenticated` + `Connected`, then self-heal: reconcile registered things vs the
+   device list (`EnsureThings`).
+
+**Initialize()**: `adapter.InitializeThings()`, set lifecycle from stored credentials
+(none → NotConfigured/NotAuthenticated/Disconnected; present → Configured/Authenticated/
+Connected/Running), then an initial `Check()`.
+
+**Configure(model any)**: type-assert `*config.Config`, apply changes (may re-run
+`EnsureThings`), `SetConfigState(Configured)`, `SetAppHealth(Running, nil)`.
+
+## 4. Adapter and ThingFactory — creating/destroying devices
+
+Implement `adapter.ThingFactory` (single `Create` method); the adapter owns destruction.
+
+```go
+func (f *thingFactory) Create(ad adapter.Adapter, publisher adapter.Publisher, ts adapter.ThingState) (adapter.Thing, error) {
+    var info model.Info
+    ts.Info(&info)                        // persisted per-thing info from the seed
+    controller := vendor.NewController(...)
+    cfg := &thing.ThermostatConfig{
+        ThingConfig: &adapter.ThingConfig{Connector: controller, InclusionReport: f.inclusionReport(...)},
+        ThermostatConfig: &thermostat.Config{Specification: ..., Controller: controller,
+            ReportingStrategy: cache.ReportAtLeastEvery(time.Hour)},
+        SensorTempConfig: &numericsensor.Config{...Reporter: controller...},
+        MeterElecConfig:  &numericmeter.Config{...Reporter: controller...},
+    }
+    return thing.NewThermostat(publisher, ts, cfg), nil
+}
+```
+
+Use a prefab thing (`thing.NewThermostat`, `thing.NewChargepoint`, ...) when it fits; otherwise
+assemble `[]adapter.Service` and call `adapter.NewThing(...)` (sensibo pattern).
+
+**Create/destroy = seeds + EnsureThings**: build `adapter.ThingSeeds`
+(`ThingSeed{ID, Info, CustomAddress}`) from the device list and call `adapter.EnsureThings(seeds)`
+— it creates missing things and destroys removed ones, emitting inclusion/exclusion reports.
+**`CustomAddress` must reproduce the legacy FIMP address** so devices survive the upgrade without
+re-inclusion. Other methods: `InitializeThings`, `Things`, `ThingByID`, `CreateThing`,
+`DestroyThingByID`, `DestroyAllThings` (pass as `RouteApp`'s exclude-all callback + use in
+`Uninstall`). If service topology can change in place, checksum it and rebuild the thing
+(sensibo `reconcile.go`).
+
+## 5. Polling and async transports
+
+`internal/tasks/tasks.go`:
+
+```go
+return task.Combine[[]*task.Task](
+    app.TaskApp(application, appLifecycle),                      // runs Check() every CheckInterval
+    cliffAdapter.TaskAdapter(adapter, cfg.GetPollingInterval()),
+    thing.TaskThermostat(adapter, cfg.GetPollingInterval(), task.WhenAppIsConnected(appLifecycle)),
+)
+```
+
+Rules:
+- **REST cloud polling must be ≥ 60 s.** Enforce a floor in `Config.GetPollingInterval()`.
+  Respect vendor rate limits (HTTP 429/402) — back off, don't tighten the loop.
+- **Prefer an async channel over polling if the vendor offers one**: LAN REST (mill),
+  UPnP/GENA events (sonos), SignalR (easee), AMQP (zaptec), webhooks, MQTT. Wire it as a
+  `root.Service` manager + per-thing `adapter.Connector.Connect(thing)` registering a handler
+  that calls `svc.Send...Report(false)`. Keep a slow REST poll as reconciliation.
+- Gate tasks with `task.Voter`s so polling stops when disconnected (custom voters for
+  "connected OR locally reachable", mill `whenConnectedOrLocal`).
+
+## 6. Reporting strategy
+
+Cliffhanger `adapter/cache` strategies, set per service via `Config.ReportingStrategy`:
+- `cache.ReportOnChangeOnly()` — only on change.
+- `cache.ReportAtLeastEvery(time.Hour)` — on change, plus an hourly heartbeat. **This is the
+  default for variable values**: thermostat mode, setpoint, sensor temperature, meter readings.
+- Static/slow parameters (settings, supported ranges, max setpoint) are NOT reported
+  periodically — they live in the inclusion report / extended config report and are re-sent only
+  on change (forced inclusion report) or on explicit `cmd.*.get_report`.
+
+Every `Send...Report(force bool)` consults the strategy when `force=false` (polling, push
+handlers); `force=true` bypasses it (explicit get_report commands, post-inclusion sync).
+Suppress sensor jitter in the controller before the cache (mill `ambientReportDelta = 0.3`).
+
+## 7. Services — climate device assembly
+
+Controller implements the service interfaces (one struct, several roles):
+
+```go
+var (
+    _ thermostat.Controller  = (*Controller)(nil)  // SetThermostatMode/Setpoint, *Report()
+    _ numericsensor.Reporter = (*Controller)(nil)  // NumericSensorReport(unit)
+    _ numericmeter.Reporter  = (*Controller)(nil)  // MeterReport(unit)
+    _ adapter.Connector      = (*Controller)(nil)  // Connectivity(), Ping()
+)
+```
+
+Specs (mill):
+
+```go
+thermostat.Specification(name, adapterAddr, thingAddr, groups,
+    []string{"off", "heat"}, []string{"heat"}, []string{"idle", "heat"})
+numericsensor.Specification(name, adapterAddr, numericsensor.SensorTemp, thingAddr, groups,
+    []string{numericsensor.UnitC})
+numericmeter.Specification(numericmeter.MeterElec, name, adapterAddr, thingAddr, groups,
+    []numericmeter.Unit{numericmeter.UnitW, numericmeter.UnitKWh})
+```
+
+Clamp setpoints to the vendor's range in `SetThermostatSetpoint`. Preserve legacy group/channel
+suffixes (`ch_0`...) for hub-upgrade compatibility.
+
+## 8. Config — model, service, migrations
+
+```go
+type Config struct {
+    config.Default                      // MQTT, LogLevel, WorkDir, ConfiguredAt
+    PollingInterval string      `json:"pollingInterval"`
+    Credentials     Credentials `json:"credentials"`
+    ...
+}
+func New(workDir string) *Config { return &Config{Default: config.NewDefault(workDir)} }
+func Factory() *Config           { return &Config{} }   // for RouteApp
+```
+
+`Service` embeds `storage.Storage[*Config]` + `sync.RWMutex`; every setter stamps
+`ConfiguredAt` and `Save()`s. Provide `DefaultStore()`, `GetPublicConfig()` (credentials
+stripped), and `Migrate()`.
+
+**Migrating legacy config/state files.** Old adapters persist different shapes
+(`data/config.json` with flat fields, `data.json`, no `adapter.json` at all). The port must read
+the old files once and translate:
+- `config.json`: map legacy fields (e.g. `poll_time_min: "5"` minutes → `pollingInterval: "5m"`,
+  legacy token fields → `credentials`), drop cached API state. Use cliffhanger versioned
+  migrations: `m.Migrate(config.Migration{From: 0, To: 1, Do: func() error {...}})` — the 0→1
+  migration MUST forcefully set `m.LogLevel = "info"` and `m.LogFormat = "budzik"` (mill
+  `config.go` Migrate is the reference) — or a
+  custom unmarshal of the legacy shape when fields moved (sensibo migrates a legacy bearer-key
+  file into `credentials.accessToken`; netatmo `MigrateClientID`).
+- `adapter.json` (thing registry): legacy adapters that hand-published inclusion reports have no
+  adapter.json — recreate things via `EnsureThings` with `CustomAddress` = the legacy service
+  address so FIMP addresses (and therefore the hub's device registry) are preserved. Adapters
+  with an old-format adapter.json need a rewrite pass like zaptec
+  `internal/migration/adapterstate.go` (`MigrateAdapterState(workDir)` re-keys thing records,
+  returns an old→new mapping fed to `MigrateSelectedDevices`).
+- Absolute paths inside migrated config are rewritten by packaging's `migrate.sh` (§13), not in Go.
+
+## 9. Auth patterns
+
+- **Username/password → JWT + refresh** (mill `internal/mill/auth.go`): `Authenticator` caches
+  the token, refreshes on expiry with `backoff.NewStateful`, forces app logout on refresh
+  failure/401 (`AuthStateLost` + push notification).
+- **OAuth authorization-code** (netatmo): tokens arrive via `cmd.auth.set_tokens`
+  (implement `app.AuthorizableApp`); store `AccessToken/RefreshToken/ExpiresAt` in config.
+- **Hub-proxied auth** (legacy adax pattern): device API called through the Futurehome proxy
+  (`auth.ProxyURL(env)` + hub token from `hub.NewTokenLoader`); only a one-time vendor call to
+  bind the account. No refresh logic needed on the hub.
+- **Plain API key** (sensibo): `credentials.accessToken` used directly.
+
+Always: credentials live in the persisted config, stripped by `GetPublicConfig`, cleared by
+`Logout`/`Uninstall`. `LogStats` masks `cmd.auth.*` payloads out of logs.
+
+## 10. Routing
+
+```go
+return router.Combine(
+    bootstrap.DefaultRoute(ServiceName, cfgSrv.GetPublicConfig, tel),
+    []*router.Routing{
+        cliffConfig.RouteCmdConfigGetDuration(ServiceName, "polling_interval", cfgSrv.GetPollingInterval),
+        cliffConfig.RouteCmdConfigSetDuration(ServiceName, "polling_interval", cfgSrv.SetPollingInterval),
+        // Get/Set String, Bool, StringMap variants for each app setting
+    },
+    app.RouteApp(ServiceName, appLifecycle, cfgSrv, config.Factory, locker, application, adapter.DestroyAllThings),
+    cliffAdapter.RouteAdapter(adapter),
+    thing.RouteThermostat(adapter),          // per-service routes for each service used
+)
+```
+
+`locker := router.NewMessageHandlerLocker()` serializes config mutations. `RouteApp`
+auto-provides `cmd.app.get_state/get_manifest/uninstall`, `cmd.config.get_extended_report/
+extended_set`, and `cmd.auth.login/logout/set_tokens` from the interfaces the app implements.
+
+## 11. Tests
+
+- **mockery v2.53.5**, config in `src/.mockery.yaml` (mill's is the model):
+
+```yaml
+with-expecter: true
+disable-version-string: true
+issue-845-fix: true
+resolve-type-alias: false
+dir: "internal/test/mocks/{{.PackageName}}"
+mockname: "{{.InterfaceName}}"
+outpkg: "mock{{.PackageName}}"
+filename: "{{.InterfaceName}}.go"
+packages:
+  github.com/futurehomeno/edge-<name>-adapter/internal/<vendor>:
+    interfaces: { Client: }
+  github.com/futurehomeno/cliffhanger/adapter:
+    interfaces: { Adapter:, ThingState:, Publisher: }
+```
+
+  Mock both project interfaces and consumed cliffhanger interfaces. `make generate-mocks`.
+- Unit-test the controller against a mocked client; e2e-test FIMP round trips via
+  `cmd/testing.go` bootstrap + a local mosquitto broker (port 11883, `make broker`).
+- **Coverage: target > 80%, hard gate at 75% per package** enforced by `make test`
+  (`scripts/coverage_gate.awk`, dedups `-coverpkg` blocks by position; skips the main package).
+  CI has no separate threshold — the Makefile gate is the gate.
+
+## 12. Tooling — unified Makefile / go.yml / golangci
+
+**Makefile** (sensibo base + mill's `check-mocks`/`broker`): targets `build-local`, `build-arm`
+(GOARM=6), `build-linux-amd64`, `lint`, `generate-mocks`, `check-mocks`, `broker`, `test`
+(with coverage gate), `configure`, `package-deb` (staging from `git ls-files` so untracked files
+never ship), `deb-arm`, `run`, `upload/deploy/install`. Common ldflags:
+`-ldflags="-s -w -X main.Version=$(VERSION) -X main.PackageName=$(APP_NAME)"`.
+`COVERAGE_THRESHOLD := 75`, `MQTT_PORT := 11883`.
+
+**go.yml** (sensibo's): jobs `setup → build → linter → test → release`; Go `1.26`
+(`actions/setup-go@v5`); mockery installed and mocks shared as artifact; lint =
+`golangci/golangci-lint-action@v7` (v2.12.2) + `staticcheck@latest`; test spins
+`eclipse-mosquitto:2` on 11883 then `make test`; release on `v*` tags with
+`softprops/action-gh-release@v2` (never SHA-pin actions — major tags only), `needs: [test,
+linter]`, first-release-safe changelog. `GOPRIVATE=github.com/futurehomeno/*` + insteadOf with
+`GH_OAUTH_TOKEN`.
+
+**.golangci.yaml**: v2 config from netatmo/sonos (includes `paralleltest`/`tparallel`,
+gofumpt/gci with `prefix(github.com/futurehomeno/edge-<name>-adapter)`, test-file exclusions).
+
+Substitute per project: `APP_NAME`, module path (golangci prefix, mockery package keys,
+coverage-gate module skip string), `VERSION`, artifact/deb names, systemd unit, container name.
+
+## 13. Packaging — thingsplex → futurehome migration
+
+Legacy layout: `/opt/thingsplex/<app>/` (binary + data + defaults), logs
+`/var/log/thingsplex/<app>`. New layout (zaptec/sensibo):
+
+```
+/usr/bin/<app>                              binary
+/usr/lib/futurehome/<app>/migrate.sh        one-time state migration (run via fh-drop)
+/usr/lib/systemd/system/<app>.service       ExecStart=/usr/bin/<app> -c /var/lib/futurehome/<app>
+/usr/share/futurehome/<app>/defaults/       read-only defaults (dpkg-owned)
+/var/lib/futurehome/<app>/defaults          symlink -> /usr/share/futurehome/<app>/defaults
+/var/lib/futurehome/<app>/data              state + credentials (0750, postinst-created)
+/var/log/futurehome/<app>/                  logs
+```
+
+- `control`: `Depends: fh-drop`; maintainer `Futurehome AS <dev@futurehome.no>`.
+- `preinst`: stop service; on upgrade remove old real `defaults` dir so dpkg can unpack the symlink.
+- `postinst configure`: create `futurehome` group + `<app>` system user → dirs → ownership →
+  `fh-drop <app> /usr/lib/futurehome/<app>/migrate.sh` → enable+start service.
+- `migrate.sh`: if new `data/` absent and `/opt/thingsplex/<app>/data` exists, copy via temp dir +
+  `sync -f` + atomic `mv`; `sed`-rewrite absolute paths in `config.json`
+  (`/opt/thingsplex/<app>` → `/var/lib/futurehome/<app>`, log dir likewise); best-effort log copy.
+  Never deletes the old tree (downgrade-safe). `umask 027`, refuses to run as root.
+- `prerm/postrm`: stop/disable on remove; delete data+logs only on purge.
+- FIMP identity (resource name, topics `pt:j1/.../rt:ad/rn:<app>/ad:1`) is unchanged by this —
+  it is purely a filesystem/packaging move.
+
+## 14. FIMP compatibility — hard requirement
+
+The port must be wire-compatible with the legacy adapter. The hub's device registry, flows and
+apps key on these identifiers — changing any of them breaks every existing installation:
+
+- **Resource name** (`rn:<name>` in topics, `WithServiceDiscovery` resource) — keep identical.
+- **Service names** (`thermostat`, `sensor_temp`, `meter_elec`, ...) — same set, same names.
+- **Service addresses** (`/rt:dev/rn:<name>/ad:1/sv:<svc>/ad:<id>`) — preserve the legacy `<id>`
+  via `ThingSeed.CustomAddress`.
+- **Interfaces + value types** (`cmd.setpoint.set` str_map, `evt.sensor.report` float, units,
+  props like `sup_modes`) — the new inclusion report must be a superset of the legacy one.
+- Groups/channels (`ch_0`), `ManufacturerId`/`ProductHash` — keep legacy values.
+
+Verify by diffing a captured legacy inclusion report + evt messages against the ported ones
+before release.
+
+## 15. Porting checklist
+
+1. Map the legacy adapter: services + FIMP addresses emitted, config file shape, auth flow,
+   polling interval, packaging paths. Record legacy addresses — they must survive.
+2. Verify FIMP compatibility plan per §14 (resource name, service names, addresses, interfaces).
+3. Check the vendor's public API docs for conformity (endpoints, auth, units, rate limits).
+4. Scaffold from mill: `main.go`, `cmd/{root,factory,testing}.go`,
+   `internal/{app,config,routing,tasks,adapter,<vendor>}`.
+5. Config package + legacy config migration (§8).
+6. API client + auth in `internal/<vendor>` (context-aware, typed errors for 401/429).
+7. Controller implementing the service interfaces; ThingFactory; `EnsureThings` with
+   `CustomAddress` preserving legacy addresses.
+8. App: Configure/Initialize/Check/Login(or SetTokens)/Logout/Uninstall.
+9. Routing + tasks; polling floor ≥60s; `ReportAtLeastEvery(time.Hour)` on variable values.
+10. Tooling: Makefile, go.yml, .golangci.yaml, .mockery.yaml, coverage gate, pre-commit hook.
+11. Packaging: futurehome layout + migrate.sh + maintainer scripts.
+12. Tests: mocks, controller/app/config/routing tests, e2e; coverage >80% (gate 75%).
+13. Update app-manifest.json (auth block, settings), defaults/config.json, README.
+14. Verify: `go vet`, `golangci-lint run`, `make test`, `make build-arm`, `make deb-arm`.
+
+## 16. Commonly forgotten
+
+- `WithTelemetry` + `router.WithStatsCallback(routing.LogStats)` (with `cmd.auth.*` masking).
+- `task.Voter` gates — polling must stop when logged out.
+- Forced vs cached reports: `force=true` only for explicit get_report / inclusion sync.
+- `DestroyAllThings` wired into both `Uninstall()` and `RouteApp`'s exclude-all callback.
+- Legacy group labels / channel suffixes in specifications (hub-upgrade compatibility).
+- `config.Factory()` (zero-value factory) for `RouteApp` — not `config.New`.
+- Manifest auth block endpoints (often environment-dependent via `auth.ProxyURL(env)`).
+- `.githooks/pre-commit` + `make init` to install it.
+- Don't SHA-pin GitHub Actions; use major version tags.
+- Delete dead legacy code after the port (old router/poller/processor packages).

--- a/.claude/skills/port_to_cliffhanger_1.2/references/porting-manual.md
+++ b/.claude/skills/port_to_cliffhanger_1.2/references/porting-manual.md
@@ -176,7 +176,8 @@ Rules:
   Respect vendor rate limits (HTTP 429/402) — back off, don't tighten the loop.
 - **Prefer an async channel over polling if the vendor offers one**: LAN REST (mill),
   UPnP/GENA events (sonos), SignalR (easee), AMQP (zaptec), webhooks, MQTT. Wire it as a
-  `root.Service` manager + per-thing `adapter.Connector.Connect(thing)` registering a handler
+  `root.Service` manager + per-thing `adapter.ControllableConnector.Connect(thing)` (the
+  `Connect`/`Disconnect` lifecycle hooks live there, not on `adapter.Connector`) registering a handler
   that calls `svc.Send...Report(false)`. Keep a slow REST poll as reconciliation.
 - Gate tasks with `task.Voter`s so polling stops when disconnected (custom voters for
   "connected OR locally reachable", mill `whenConnectedOrLocal`).

--- a/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: port_to_cliffhanger_1.3
+description: Upgrade a Futurehome edge adapter from cliffhanger v1.2.10 to the v1.3.0 line (the `develop` branch), or build a new adapter directly on 1.3. Use when asked to bump an adapter to cliffhanger 1.3, adopt the new common blocks (ConnectivityChecker, config.Service, auth.Authenticator, secrets storage, stream.Supervisor, app flows, thing-sync helpers), or align an adapter with the extracted-common-block architecture. For a from-scratch port off legacy fimpgo/v0.x, do the base port with port_to_cliffhanger_1.2 first, then apply this on top.
+---
+
+# Upgrade an edge adapter from cliffhanger v1.2.10 to v1.3.0
+
+**1.3.0 is not a rewrite — it is the same architecture with the per-adapter boilerplate
+extracted into the framework.** Every adapter hand-rolled the same `Check()` state machine,
+OAuth refresh, config service, thing-sync wrapper, credential storage and push-transport
+supervisor. 1.3 (cliffhanger `develop`, waves 1–4 in #185/#186/#187/#189) ships these as
+reusable primitives. Porting to 1.3 = **deleting your copies and wiring the framework ones**,
+without changing any FIMP wire behaviour.
+
+Read [references/upgrade-to-1.3.md](references/upgrade-to-1.3.md) first — it is the full API
+catalog, the per-adapter Check() fit table, and the state/auth/config mapping. This file is the
+procedure. The 1.2 base architecture (package layout, packaging, tooling, FIMP compatibility)
+is unchanged — see the `port_to_cliffhanger_1.2` skill for it; do **not** repeat that work.
+
+Cliffhanger source for 1.3: the `develop` branch of `~/proj/go/cliffhanger` (there is no v1.3.0
+tag yet; `git describe` shows `v1.2.10-N-g<sha>`). Reference adapters still on 1.2.x live in
+`~/proj/go/edge-*-adapter`; `core-energy-guard` is a **core service on v1.2.7**, not an edge
+adapter and not a 1.3 template.
+
+## Golden rule: wire-compatibility is unchanged
+
+None of the 1.3 primitives change FIMP identity. Resource name, service names, service
+addresses (`ThingSeed.CustomAddress`), interfaces and value types must stay byte-identical
+across the bump — the framework code produces the same inclusion/exclusion/evt messages your
+hand-rolled code did. Diff a captured inclusion report + evt stream before/after the upgrade.
+
+## Procedure
+
+1. **Bump the dependency.** `go get github.com/futurehomeno/cliffhanger@<develop-pseudo-version>`
+   (`go.mod`), `go mod tidy`. Build; the compile errors map the API deltas (mostly additive —
+   the 1.2 surface is preserved, so nothing you already use breaks).
+
+2. **Adopt the typed HTTP errors first** (everything else keys on them). Make the API client
+   return `httpclient.ErrUnauthorized` (401/403), `httpclient.ErrTooManyRequests` /
+   `*httpclient.TooManyRequestsError{RetryAfter}` (429), plain errors otherwise — via
+   `httpclient.ErrorFromResponse(resp)`. This is the contract `ConnectivityChecker`,
+   `Authenticator` and the sync guards all consume. (refs §2)
+
+3. **Replace hand-rolled `Check()` with `app.ConnectivityChecker`** — the biggest deletion.
+   Build it with a `probe func() error` (a cheap real API call returning the sentinels above),
+   the lifecycle, the adapter as `ConnectivityReporter`, and a `CheckerConfig`
+   (`Interval`, `RecheckBackoff`, `MaxRechecks`, `RateLimitDelay`). It maps probe outcome →
+   lifecycle exactly like the old machine (success → Authenticated/Connected + repair;
+   401 → Lost/Disconnected; 429 → untouched + reschedule; transient → disconnect only after
+   `MaxRechecks`). Wire `checker.CheckNow` as the `Authorize` callback and `checker.Cancel` on
+   logout/reset. **Check the fit table first** (refs §3): sensibo/sonos/mill/netatmo fit
+   directly; zaptec/easee/tibber do **not** (event-driven / no-op / no-probe) — leave their
+   `Check()` alone. Customization hooks (`AuthLossState`, `Authorized`) cover the
+   Lost-vs-NotAuthenticated and teardown-guard nuances (refs §3).
+
+4. **Replace the OAuth refresh loop with `auth.Authenticator`** (username/password→JWT and
+   authorization-code refresh). Provide a `CredentialsStore` (your config) and a
+   `TokenExchanger` (your client), set `RefreshLead`, `Backoff` (a `backoff.Stateful`, e.g.
+   `backoff.NewTolerantFixed`), `UnauthorizedGrace`, and `OnAuthLoss`. Attach the token with
+   `auth.Transport` (a `http.RoundTripper`) instead of a hand-written bearer injector; use
+   `auth.TokenExpirationDate` for JWT expiry. (refs §4). Hub-proxied / plain-API-key auth
+   (adax/sensibo) does **not** use this — keep it.
+
+5. **Move credentials into secrets storage.** Split secrets out of the world-readable
+   `config.json` into `storage.NewSecrets(...)` / `NewCanonicalSecrets(...)` (0640
+   `data/secrets.json`). Migrate the legacy token fields once into the secrets file. (refs §6)
+
+6. **Adopt `config.Service[C]`** (generic, thread-safe) in place of the hand-rolled config
+   service: `Update`/`Persist`/`Reset`/`Migrate`/`DefaultStore`/`PublicModel`, plus `config.Get`
+   / `config.GetDuration` accessors and `config.BackoffConfig`. Keep your `Config` struct and its
+   JSON shape identical. (refs §5)
+
+7. **Collapse lifecycle bundles and thing-sync.** Use `lifecycle.MarkRunning()` /
+   `MarkNotConfigured()` and `SetConnAndAuthState` for atomic auth-loss bundles instead of four
+   separate setters. Replace the fetch→filter→map→`EnsureThings` wrapper with
+   `adapter.SeedsFromSelection` + `adapter.SyncThings` (shared anti-wipe guard,
+   `ErrIncompleteFetch`); replace a hand-rolled capability-drift rebuild (sensibo `reconcile.go`)
+   with `adapter.RebuildChangedThings`. (refs §7)
+
+8. **Adopt the remaining blocks where they apply:** `stream.Supervisor` for a push transport's
+   reconnect/backoff lifecycle (easee SignalR, sonos GENA, zaptec AMQP) via a `root.Service`;
+   `app.Reset`/`app.Logout`/`app.Authorize`/`app.ConfigModel` flow helpers; `bootstrap.EdgeRouting`
+   /`EdgeTasks` bundles; `router.DefaultLogStats(prefixes...)` for the stats callback;
+   `utils.Throttle` for log throttling and `utils.Timestamped` for last-value+staleness. (refs §8)
+
+9. **Delete the replaced code** — the old `Check()`/`scheduleRecheck`/`cancelRecheck`, the
+   bespoke authenticator/transport, the hand-rolled config service, the sync wrapper, the
+   credential-in-config plumbing. Less code is the point of this bump.
+
+10. **Verify.** `go vet ./...`, `golangci-lint run`, `make test` (coverage gate 75%, target
+    >80%), `make build-arm`, `make deb-arm`. Then **prove wire-compatibility**: diff the
+    inclusion report + a representative evt stream against the pre-bump capture. Finish with
+    `/improve_logs`.
+
+## Output expectations
+
+- Adapter compiles and runs on cliffhanger 1.3 (`develop`), with the hand-rolled Check/auth/
+  config/sync/secrets code replaced by framework primitives and net lines **removed**.
+- Identical FIMP behaviour: same addresses, same reports, no re-inclusion for existing users.
+- Adapters that don't fit a primitive (zaptec/easee/tibber Check, hub-proxy auth) are left as-is
+  with a one-line note why.
+- CI green.

--- a/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
@@ -32,9 +32,11 @@ hand-rolled code did. Diff a captured inclusion report + evt stream before/after
 
 ## Procedure
 
-1. **Bump the dependency.** `go get github.com/futurehomeno/cliffhanger@<develop-pseudo-version>`
-   (`go.mod`), `go mod tidy`. Build; the compile errors map the API deltas (mostly additive —
-   the 1.2 surface is preserved, so nothing you already use breaks).
+1. **Bump the dependency and toolchain.** cliffhanger `develop` requires **`go 1.26`** — first
+   `go mod edit -go=1.26` and bump CI/runtime images to Go 1.26, else module resolution fails
+   before any API work. Then `go get github.com/futurehomeno/cliffhanger@<develop-pseudo-version>`,
+   `go mod tidy`. Build; the compile errors map the API deltas (mostly additive — the 1.2 surface
+   is preserved, so nothing you already use breaks).
 
 2. **Adopt the typed HTTP errors first** (everything else keys on them). Make the API client
    return `httpclient.ErrUnauthorized` (401/403), `httpclient.ErrTooManyRequests` /

--- a/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
@@ -17,10 +17,11 @@ catalog, the per-adapter Check() fit table, and the state/auth/config mapping. T
 procedure. The 1.2 base architecture (package layout, packaging, tooling, FIMP compatibility)
 is unchanged — see the `port_to_cliffhanger_1.2` skill for it; do **not** repeat that work.
 
-Cliffhanger source for 1.3: the `develop` branch of `~/proj/go/cliffhanger` (there is no v1.3.0
-tag yet; `git describe` shows `v1.2.10-N-g<sha>`). Reference adapters still on 1.2.x live in
-`~/proj/go/edge-*-adapter`; `core-energy-guard` is a **core service on v1.2.7**, not an edge
-adapter and not a 1.3 template.
+Cliffhanger source for 1.3 is the `develop` branch of the cliffhanger checkout (there is no
+v1.3.0 tag yet; `git describe` shows `v1.2.10-N-g<sha>`). Reference adapters still on 1.2.x are
+the sibling `edge-*-adapter` repos in this workspace (here under `~/proj/go/`; adjust to your
+checkout); `core-energy-guard` is a **core service on v1.2.7**, not an edge adapter and not a
+1.3 template.
 
 ## Golden rule: wire-compatibility is unchanged
 
@@ -54,7 +55,9 @@ hand-rolled code did. Diff a captured inclusion report + evt stream before/after
    Lost-vs-NotAuthenticated and teardown-guard nuances (refs §3).
 
 4. **Replace the OAuth refresh loop with `auth.Authenticator`** (username/password→JWT and
-   authorization-code refresh). Provide a `CredentialsStore` (your config) and a
+   authorization-code refresh). Provide a `CredentialsStore` — back it by the **secrets
+   store** from step 5 (do step 5 first, or reorder, so credentials have a single source of
+   truth), not the plain config — and a
    `TokenExchanger` (your client), set `RefreshLead`, `Backoff` (a `backoff.Stateful`, e.g.
    `backoff.NewTolerantFixed`), `UnauthorizedGrace`, and `OnAuthLoss`. Attach the token with
    `auth.Transport` (a `http.RoundTripper`) instead of a hand-written bearer injector; use
@@ -89,8 +92,8 @@ hand-rolled code did. Diff a captured inclusion report + evt stream before/after
 
 10. **Verify.** `go vet ./...`, `golangci-lint run`, `make test` (coverage gate 75%, target
     >80%), `make build-arm`, `make deb-arm`. Then **prove wire-compatibility**: diff the
-    inclusion report + a representative evt stream against the pre-bump capture. Finish with
-    `/improve_logs`.
+    inclusion report + a representative evt stream against the pre-bump capture. Finally, review
+    logs — invoke the `improve_logs` skill if available, else check them by hand.
 
 ## Output expectations
 

--- a/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
@@ -67,8 +67,9 @@ hand-rolled code did. Diff a captured inclusion report + evt stream before/after
    (adax/sensibo) does **not** use this — keep it.
 
 5. **Move credentials into secrets storage.** Split secrets out of the world-readable
-   `config.json` into `storage.NewSecrets(...)` / `NewCanonicalSecrets(...)` (0640
-   `data/secrets.json`). Migrate the legacy token fields once into the secrets file. (refs §6)
+   `config.json` into `storage.NewSecrets(...)` (0640 `data/secrets.json`) — edge adapters use
+   this; `NewCanonicalSecrets(...)` is the core-application layout (`workDir/<name>`, no `data/`).
+   Migrate the legacy token fields once into the secrets file. (refs §6)
 
 6. **Adopt `config.Service[C]`** (generic, thread-safe) in place of the hand-rolled config
    service: `Update`/`Persist`/`Reset`/`Migrate`/`DefaultStore`/`PublicModel`, plus `config.Get`

--- a/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
@@ -76,8 +76,9 @@ hand-rolled code did. Diff a captured inclusion report + evt stream before/after
    JSON shape identical. (refs §5)
 
 7. **Collapse lifecycle bundles and thing-sync.** Use `lifecycle.MarkRunning()` /
-   `MarkNotConfigured()` and `SetConnAndAuthState` for atomic auth-loss bundles instead of four
-   separate setters. Replace the fetch→filter→map→`EnsureThings` wrapper with
+   `MarkNotConfigured()` (cloud-auth adapters only; apps at `AuthStateNA`/`ConnStateNA` set states
+   individually) and `SetConnAndAuthState` for atomic auth-loss bundles instead of four separate
+   setters. Replace the fetch→filter→map→`EnsureThings` wrapper with
    `adapter.SeedsFromSelection` + `adapter.SyncThings` (shared anti-wipe guard,
    `ErrIncompleteFetch`); replace a hand-rolled capability-drift rebuild (sensibo `reconcile.go`)
    with `adapter.RebuildChangedThings`. (refs §7)

--- a/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
@@ -173,8 +173,8 @@ public := cfgSrv.PublicModel()   // redact-returning; hand it a copy for pointer
 
 ## 6. Secrets storage
 
-`storage/secrets.go`. Move credentials out of the world-readable `config.json` (0644) into a
-0640 `data/secrets.json`:
+`storage/storage.go` (`NewSecrets`/`NewCanonicalSecrets`). Move credentials out of the
+world-readable `config.json` (0644) into a 0640 `data/secrets.json`:
 
 ```go
 secrets := storage.NewSecrets[*Credentials](&Credentials{}, workDir, "secrets.json")
@@ -230,7 +230,8 @@ backed by this secrets storage.
 
 ## 9. go.mod & migration checklist
 
-1. `go get github.com/futurehomeno/cliffhanger@<develop>` + `go mod tidy`; build to surface deltas.
+1. `go mod edit -go=1.26` (+ bump CI/runtime images to Go 1.26), then
+   `go get github.com/futurehomeno/cliffhanger@<develop>` + `go mod tidy`; build to surface deltas.
 2. httpclient error contract in the client (§2).
 3. Replace `Check()` with `ConnectivityChecker` **iff** the adapter is in the "Yes" fit set (§3).
 4. `Authenticator` + `Transport` for OAuth refresh (§4); skip for hub-proxy/API-key.

--- a/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
@@ -1,0 +1,269 @@
+# Cliffhanger v1.2.10 → v1.3.0 upgrade reference
+
+1.3.0 (cliffhanger `develop`) extracts the boilerplate that every edge adapter re-implemented
+into framework primitives. This doc catalogs the new APIs, maps each adapter's hand-rolled code
+onto them, and lists the fixes made between 1.2.10 and 1.3.0. It assumes the 1.2 base
+architecture (see the `port_to_cliffhanger_1.2` skill) — only the deltas are here.
+
+The change landed in four "waves":
+- **#185** (`44f6379`) — common blocks extracted from edge adapters (checker, httpclient errors, utils).
+- **#186** (`cb03c87`) — lifecycle bundles, app flows, generic config service.
+- **#187** (`db09e05`) — OAuth authenticator, bearer transport, seeds-selection helper.
+- **#189** (`d4459bd`) — edge bundles, stream supervisor, secrets storage.
+- Follow-up hardening: #197/#198/#200/#201/#202 (checker & auth race/edge fixes) and #203
+  (thing-sync helpers + checker customization hooks). See §10.
+
+---
+
+## 1. New package/API map (what replaces what)
+
+| New in 1.3 | Signature (key parts) | Replaces the hand-rolled… |
+|---|---|---|
+| `app.ConnectivityChecker` | `NewConnectivityChecker(probe func() error, lc, reporter ConnectivityReporter, cfg CheckerConfig)` → `Check()/CheckNow()/Cancel()/CheckInterval()` | `Check()` + `scheduleRecheck`/`cancelRecheck`/`checkFailed` |
+| `app.Reset/Logout/Authorize/ConfigModel` | `Authorize(lc, persistCredentials, check func() error)`, `Reset(lc, ThingDestroyer, resetConfig, teardown...)`, `Logout(lc, clearCredentials, teardown...)`, `ConfigModel[T](any)(T,error)` | inline Login/Logout/Reset lifecycle sequences |
+| `auth.Authenticator` | `NewAuthenticator(CredentialsStore, TokenExchanger, AuthenticatorConfig)` → `AccessToken()(string,error)` | bespoke token cache + refresh + backoff |
+| `auth.Transport` | `http.RoundTripper` wrapping a `TokenSource` | hand-written bearer-header injector |
+| `auth.TokenExpirationDate` | `(jwtToken string)(time.Time,error)` | manual JWT expiry parsing |
+| `httpclient` errors + builder | `ErrUnauthorized`, `ErrTooManyRequests`, `*TooManyRequestsError{RetryAfter}`, `ErrorFromResponse(resp)`, `NewJSONRequest(ctx,method,url,body,headers)` | per-adapter 401/429 sentinels + request builders |
+| `config.Service[C]` | `NewService[C](storage.Storage[C], defaults, redact)` → `Update/Persist/Reset/Migrate/DefaultStore/PublicModel`; `Get[C,V]`, `GetDuration[C]`; `config.BackoffConfig` | hand-rolled `Service` struct + RWMutex + setters |
+| `lifecycle.MarkRunning/MarkNotConfigured` + `SetConnAndAuthState` | state-bundle helpers; atomic conn+auth in one event | four separate `Set*State` calls |
+| `storage.NewSecrets/NewCanonicalSecrets` | `Storage[T]` at 0640 (`data/secrets.json`) | credentials living in world-readable `config.json` |
+| `stream.Supervisor` | `NewSupervisor(connect Connection, b backoff.Stateful)` → `Start()/Stop()/TriggerReconnect()` | bespoke SignalR/GENA/AMQP reconnect loops |
+| `adapter.SeedsFromSelection` + `SyncThings` + `RebuildChangedThings` | `SeedsFromSelection[T](available, selected, seed)`, `SyncThings[T](a, available, selected, seed) (ErrIncompleteFetch)`, `RebuildChangedThings(seeds)` | fetch→filter→map→EnsureThings wrapper, anti-wipe guard, sensibo `reconcile.go` |
+| `bootstrap.EdgeRouting/EdgeTasks` | `EdgeRouting[C](...)`, `EdgeTasks(...)` bundles | repeated builder wiring |
+| `router.DefaultLogStats` | `DefaultLogStats(redactedInterfacePrefixes ...string) func(Stats)` | per-adapter `LogStats` with `cmd.auth.` masking |
+| `backoff.NewTolerantFixed` | `(tolerance uint32, delay time.Duration) Stateful` | fixed-after-N-tolerated backoff presets |
+| `utils.Throttle`, `utils.Timestamped[T]` | `Throttle.Do(key, emit)/Reset()`; `Timestamped.Set/Get` | ad-hoc log throttling & last-value+staleness caches |
+
+All additive: the 1.2.10 API surface (`EnsureThings`, `NewAdapter`, `storage.New`, `config.Default`,
+`backoff.New/NewStateful`, cache strategies, `RouteApp`) is unchanged, so a bump breaks nothing you
+already use — you delete your copies at your own pace.
+
+---
+
+## 2. httpclient — the error contract (adopt first)
+
+`httpclient/errors.go` defines the sentinels the rest of 1.3 keys on:
+- `ErrUnauthorized` — 401 **or** 403.
+- `ErrTooManyRequests` — 429; `*TooManyRequestsError{RetryAfter time.Duration}` carries a parsed
+  `Retry-After` and matches `ErrTooManyRequests` via `errors.Is`.
+- `ErrorFromResponse(resp)` maps a status code to the right sentinel (with Retry-After).
+- `NewJSONRequest(ctx, method, url, body, headers)` builds a JSON request.
+
+Make the API client wrap these (`fmt.Errorf("...: %w", httpclient.ErrUnauthorized)` is fine —
+matched with `errors.Is`). Everything downstream (`ConnectivityChecker` branches, `Authenticator`
+grace, `SyncThings`) depends on this classification being correct.
+
+---
+
+## 3. ConnectivityChecker — the Check() replacement (the big one)
+
+`app/check.go`. Construct once, expose its `Check()`/`CheckInterval()` as the app's `CheckableApp`,
+and drive it from the task layer (`app.TaskApp`).
+
+```go
+checker := app.NewConnectivityChecker(
+    func() error { return client.Ping() },   // probe: cheap real call → httpclient sentinels
+    appLifecycle,
+    adapter,                                  // ConnectivityReporter (adapter.Adapter satisfies it)
+    app.CheckerConfig{
+        Interval:       time.Hour,            // 0 → DefaultCheckInterval (task layer)
+        RecheckBackoff: backoff.New(time.Minute, 5*time.Minute, 15*time.Minute, 1, 2),
+        MaxRechecks:    1,                    // disconnect only after >N consecutive failures
+        RateLimitDelay: 5 * time.Minute,
+        // 1.3 customization hooks (PR #203):
+        AuthLossState: func(cur lifecycle.State) lifecycle.State { // default: always Lost
+            if cur == lifecycle.AuthStateAuthenticated { return lifecycle.AuthStateLost }
+            return lifecycle.AuthStateNotAuthenticated              // stay silent if never authed
+        },
+        Authorized: func() bool { return cfg.GetCredentials().AccessToken != "" }, // gate restore vs teardown
+    },
+)
+```
+
+Outcome → lifecycle (identical to the old hand-rolled machine):
+- **success** → `Authenticated` + `Connected`, then `repairAppHealth` (Running/Configured if it was
+  stranded NOT_CONFIGURED); gated by `Authorized()`.
+- **`ErrUnauthorized`** → `SetConnAndAuthState(Disconnected, AuthLossState(cur))` — one atomic event.
+- **`ErrTooManyRequests`** → connectivity untouched, reschedule (honors `RetryAfter`).
+- **other/transient** → throttled warn, disconnect only once `failures > MaxRechecks`, reschedule with backoff.
+
+Wiring: `checker.CheckNow` is the `Authorize` callback (forces an immediate probe, resets the
+failure streak); `checker.Cancel` on logout/reset (stops rechecks, discards an in-flight probe via
+the cancelled/stale guard).
+
+### Per-adapter fit table (checked across all edge adapters)
+
+| Adapter | Probe today | Fits ConnectivityChecker? | Notes / hooks needed |
+|---|---|---|---|
+| **sensibo** | `client.Ping()` | **Yes** | `AuthLossState` (Lost only if was Authenticated) + `Authorized` (creds present). Move its checksum rebuild to `RebuildChangedThings`. |
+| **sonos** | `GetHouseHolds()` | **Yes** | Keep its UPnP event-driven `SyncThings()`; the hourly Check becomes the checker's periodic probe. |
+| **mill** | `AccessToken()`+`AllDevices()` | **Yes** | Fold token acquisition into the probe; drift self-heal → `RebuildChangedThings`. |
+| **netatmo** | `client.Ping()` | **Yes** | `AuthLossState` keyed on empty refresh token (closure over cfg); teardown via `Authorized`. |
+| **zaptec** | `restClient.Ping()` (ConnState only) | **No** | Auth-loss handled out-of-band via `rest.AuthLost` event; not even a `CheckableApp`. Leave as-is. |
+| **easee** | `Check()` is a no-op | **No** | Real probe lives in the `RefreshToken` task; use `stream.Supervisor` for SignalR, keep the task. |
+| **tibber** | none (local-state reconciler) | **No** | No network probe; pure `AuthState`/`ConnState` from local token presence. Leave as-is. |
+
+Rule: if the adapter does an active periodic probe that maps outcome→lifecycle, adopt the checker.
+If auth-loss is event-driven (zaptec), the work lives in a separate task (easee), or there's no
+probe at all (tibber), **don't** force it — that would change behaviour.
+
+---
+
+## 4. auth — Authenticator, Transport, JWT
+
+`auth/authenticator.go`. For username/password→JWT and authorization-code refresh:
+
+```go
+authr := auth.NewAuthenticator(cfgSecrets /*CredentialsStore*/, client /*TokenExchanger*/, auth.AuthenticatorConfig{
+    RefreshLead:       5 * time.Minute,                       // refresh this early
+    Backoff:           backoff.NewTolerantFixed(2, 5*time.Minute),
+    UnauthorizedGrace: time.Hour,                             // tolerate 401 streak before concluding loss
+    OnAuthLoss:        func(reason string) { appLifecycle.MarkNotConfigured() /* + notify */ },
+})
+token, err := authr.AccessToken()   // cached; refreshes on expiry; concludes auth loss past grace
+```
+
+- `CredentialsStore` = `{ Credentials() Credentials; SetCredentials(Credentials) error; ClearCredentials() error }`.
+- `TokenExchanger` = `{ ExchangeRefreshToken(string) (*OAuth2TokenResponse, error) }`.
+- `Credentials{AccessToken, RefreshToken, ExpiresAt, RefreshExpiresAt}`; `expired(lead)`; `Empty()`.
+- **`OnAuthLoss` runs under the Authenticator lock** (#199) — its callback must not call back into
+  the Authenticator (deadlock). Emit lifecycle/notifications only.
+- `UnauthorizedGrace` tolerates transient 401s; a rejection streak that outlives the grace concludes
+  auth loss even while backoff suppresses exchanges, and the streak is tied to the rejected refresh
+  token so an out-of-band credential swap isn't concluded lost on a stale timestamp (#197/#201).
+
+Attach the token with `auth.Transport` (`http.RoundTripper` over a `TokenSource`) rather than a
+hand-written header injector. Use `auth.TokenExpirationDate(jwt)` to read expiry.
+
+Auth models that do **not** use Authenticator: hub-proxied (adax — proxy + hub token, no refresh)
+and plain API key (sensibo — `credentials.accessToken` used directly). Leave those.
+
+---
+
+## 5. config.Service[C] — generic config service
+
+`config/service.go`. Replaces the per-adapter `Service` struct + RWMutex + stamped setters:
+
+```go
+cfgSrv := config.NewService[*Config](storageSvc, func(c *Config) *config.Default { return &c.Default }, redactFn)
+cfgSrv.Update(func(c *Config) { c.PollingInterval = "5m" })   // mutate + stamp ConfiguredAt + Save
+cfgSrv.Persist(fn); cfgSrv.Reset(); cfgSrv.Migrate(migrations...)
+interval := config.GetDuration(cfgSrv, func(c *Config) string { return c.PollingInterval }, time.Hour)
+public := cfgSrv.PublicModel()   // redact-returning; hand it a copy for pointer configs (see caveat)
+```
+
+- Keep your `Config` struct + JSON shape identical — this is a mechanical swap of the service layer.
+- `config.BackoffConfig{...}.Stateful(def)` builds a `backoff.Stateful` from persisted config.
+- **`PublicModel()` caveat**: for a pointer-backed config with no redactor it aliases the live model;
+  pass a copy-returning `redact` func (mirrors the `Get` helper caveat, #197). `Update`'s lock is
+  not reentrant — callbacks must not call back into the Service.
+
+---
+
+## 6. Secrets storage
+
+`storage/secrets.go`. Move credentials out of the world-readable `config.json` (0644) into a
+0640 `data/secrets.json`:
+
+```go
+secrets := storage.NewSecrets[*Credentials](&Credentials{}, workDir, "secrets.json")
+// or NewCanonicalSecrets(...) for the core-application canonical layout
+```
+
+Migrate once: on first 1.3 boot, if the legacy config still carries tokens, copy them into the
+secrets store and blank them in config. The `Authenticator`'s `CredentialsStore` is typically
+backed by this secrets storage.
+
+---
+
+## 7. lifecycle bundles + thing-sync helpers
+
+- **`lifecycle.MarkRunning()`** = Running+Configured+Connected+Authenticated;
+  **`MarkNotConfigured()`** = NotConfigured+Disconnected+NotAuthenticated (uninstall/reset/logout).
+  Only for cloud adapters with auth; apps at `*NA` set states individually.
+- **`SetConnAndAuthState(conn, auth)`** emits a single atomic auth event with both states applied —
+  use it on auth-loss so a watcher never sees `LOST` with a stale connection state (#198/#200). The
+  ConnectivityChecker already uses it internally.
+- **`adapter.SeedsFromSelection[T](available, selected, seed)`** builds `ThingSeeds` from a fetched
+  list filtered to the user's selection.
+- **`adapter.SyncThings[T](a, available, selected, seed)`** = SeedsFromSelection + `EnsureThings`
+  with a shared anti-wipe guard: returns `ErrIncompleteFetch` (non-fatal; log-and-retry) instead of
+  destroying live things when a registered selected device is missing from a partial fetch. Replaces
+  the guard hand-rolled four different ways (sensibo/sonos/mill/zaptec).
+- **`adapter.RebuildChangedThings(seeds)`** rebuilds a registered thing whose seed yields a different
+  service topology (picks up new capabilities), preserving its address **and** persisted per-thing
+  state, build-before-destroy. Replaces sensibo `reconcile.go`. `EnsureThings` still handles presence
+  only; call both (SyncThings for presence, then RebuildChangedThings for drift).
+
+---
+
+## 8. Remaining blocks
+
+- **`stream.Supervisor`** (`stream/supervisor.go`): wrap a push transport's connect loop.
+  `NewSupervisor(func(ctx, connected func()) error {...}, backoff.Stateful)` → `Start/Stop/
+  TriggerReconnect`. Register as a `root.Service` so its lifecycle follows the app. Use for easee
+  SignalR, sonos GENA, zaptec AMQP — replaces the bespoke reconnect/backoff goroutine (and fixes the
+  Stop/Start races, §10).
+- **`app` flow helpers** (`app/flow.go`): `Authorize(lc, persist, check)`, `Reset(lc, destroyer,
+  resetConfig, teardown...)`, `Logout(lc, clear, teardown...)`, `ConfigModel[T](any)`. Use in the
+  app's Login/Logout/Reset/Configure so the lifecycle sequence isn't hand-written.
+- **`bootstrap.EdgeRouting[C]` / `EdgeTasks`**: bundle the common routing/task wiring; adopt if it
+  reduces builder boilerplate for your adapter.
+- **`router.DefaultLogStats(prefixes...)`**: the stats callback with credential-prefix redaction
+  (`"cmd.auth."`) — pass to `router.WithStatsCallback`. Replaces the per-adapter `LogStats`.
+- **`utils.Throttle`**: `Do(key, emit)` collapses repeated log lines (the checker uses it for the
+  transient-error warn); `Reset()` on recovery. **`utils.Timestamped[T]`**: last-value + timestamp +
+  staleness, for "report only if newer" and connectivity-detail caches.
+
+---
+
+## 9. go.mod & migration checklist
+
+1. `go get github.com/futurehomeno/cliffhanger@<develop>` + `go mod tidy`; build to surface deltas.
+2. httpclient error contract in the client (§2).
+3. Replace `Check()` with `ConnectivityChecker` **iff** the adapter is in the "Yes" fit set (§3).
+4. `Authenticator` + `Transport` for OAuth refresh (§4); skip for hub-proxy/API-key.
+5. Secrets storage for credentials + one-time migration (§6).
+6. `config.Service[C]` swap, same Config JSON (§5).
+7. Lifecycle `Mark*`/`SetConnAndAuthState`; `SyncThings`/`RebuildChangedThings` for thing-sync (§7).
+8. `stream.Supervisor`, flow helpers, `DefaultLogStats`, utils where they apply (§8).
+9. Delete the replaced hand-rolled code.
+10. `go vet` / `golangci-lint` / `make test` (gate 75%, >80%) / `build-arm` / `deb-arm`.
+11. **Prove FIMP wire-compat**: diff inclusion report + evt stream vs the pre-bump capture.
+12. `/improve_logs`.
+
+---
+
+## 10. Fixes made between 1.2.10 and 1.3.0 (behaviours to inherit, not re-break)
+
+These landed while the common blocks were hardened; a from-scratch reimplementation must not
+regress them:
+
+- **Checker timer race** (#198): a `Cancel()` racing a firing recheck timer is caught by a fused
+  `{timer, cancelled}` commit or discarded via `stale()`. Don't "simplify" the checker's mutex to
+  atomics — the fusion is load-bearing.
+- **Auth-loss bundle** (#198/#200): auth-loss sets connection+auth atomically
+  (`SetConnAndAuthState`) so a watcher never reports `LOST` with an outdated connection state.
+- **CheckNow freshness** (#198/#201): manual/authorize checks use `CheckNow` (clears pending
+  backoff + resets the failure streak) so fresh credentials get a clean slate and aren't tripped by
+  a stale streak.
+- **Backoff vs grace** (#197/#201): an expired token whose 401 streak outlives `UnauthorizedGrace`
+  concludes auth loss even while backoff suppresses exchanges; the streak is tied to the rejected
+  refresh token (an out-of-band credential swap is not concluded lost on a stale timestamp).
+- **repairAppHealth guard** (#201/#202): a successful probe only repairs a *stranded* app
+  (NOT_CONFIGURED → Running/Configured); an already-RUNNING app is left untouched.
+- **Rebuild correctness** (#203): `RebuildChangedThings` preserves the thing's address (pins
+  `CustomAddress` to the live address) **and** its persisted per-thing state across the
+  destroy/create, runs under the adapter lock (atomic like `EnsureThings`), and guards a nil
+  inclusion report.
+- **SyncThings anti-wipe** (#203): a partial/empty fetch returns `ErrIncompleteFetch` rather than
+  destroying live things.
+- **Stream supervisor Stop/Start** (#189 hardening): fd-leak on Chmod failure and Stop/Start races
+  fixed — use the framework supervisor rather than a bespoke loop.
+- **OnAuthLoss under lock** (#199): the callback runs holding the Authenticator lock; keep it to
+  lifecycle/notification side effects only.
+
+The checker/auth test suites (`app/check_test.go`, `auth/authenticator_test.go`) and the
+thing-sync tests (`adapter/drift_test.go`, `adapter/sync_test.go`) are the executable spec for all
+of the above — read them when in doubt about an edge case.

--- a/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
@@ -211,7 +211,7 @@ backed by this secrets storage.
 ## 8. Remaining blocks
 
 - **`stream.Supervisor`** (`stream/supervisor.go`): wrap a push transport's connect loop.
-  `NewSupervisor(func(ctx, connected func()) error {...}, backoff.Stateful)` → `Start/Stop/
+  `NewSupervisor(func(ctx context.Context, connected func()) error {...}, backoff.Stateful)` → `Start/Stop/
   TriggerReconnect`. Register as a `root.Service` so its lifecycle follows the app. Use for easee
   SignalR, sonos GENA, zaptec AMQP — replaces the bespoke reconnect/backoff goroutine (and fixes the
   Stop/Start races, §10).

--- a/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
@@ -27,7 +27,7 @@ The change landed in four "waves":
 | `httpclient` errors + builder | `ErrUnauthorized`, `ErrTooManyRequests`, `*TooManyRequestsError{RetryAfter}`, `ErrorFromResponse(resp)`, `NewJSONRequest(ctx,method,url,body,headers)` | per-adapter 401/429 sentinels + request builders |
 | `config.Service[C]` | `NewService[C](storage.Storage[C], defaults, redact)` → `Update/Persist/Reset/Migrate/DefaultStore/PublicModel`; `Get[C,V]`, `GetDuration[C]`; `config.BackoffConfig` | hand-rolled `Service` struct + RWMutex + setters |
 | `lifecycle.MarkRunning/MarkNotConfigured` + `SetConnAndAuthState` | state-bundle helpers; atomic conn+auth in one event | four separate `Set*State` calls |
-| `storage.NewSecrets/NewCanonicalSecrets` | `Storage[T]` at 0640 (`data/secrets.json`) | credentials living in world-readable `config.json` |
+| `storage.NewSecrets/NewCanonicalSecrets` | `Storage[T]` at 0640 (edge: `data/secrets.json`; canonical/core: `workDir/<name>`) | credentials living in world-readable `config.json` |
 | `stream.Supervisor` | `NewSupervisor(connect Connection, b backoff.Stateful)` → `Start()/Stop()/TriggerReconnect()` | bespoke SignalR/GENA/AMQP reconnect loops |
 | `adapter.SeedsFromSelection` + `SyncThings` + `RebuildChangedThings` | `SeedsFromSelection[T](available, selected, seed)`, `SyncThings[T](a, available, selected, seed) (ErrIncompleteFetch)`, `RebuildChangedThings(seeds)` | fetch→filter→map→EnsureThings wrapper, anti-wipe guard, sensibo `reconcile.go` |
 | `bootstrap.EdgeRouting/EdgeTasks` | `EdgeRouting[C](...)`, `EdgeTasks(...)` bundles | repeated builder wiring |
@@ -76,7 +76,10 @@ checker := app.NewConnectivityChecker(
             if cur == lifecycle.AuthStateAuthenticated { return lifecycle.AuthStateLost }
             return lifecycle.AuthStateNotAuthenticated              // stay silent if never authed
         },
-        Authorized: func() bool { return secrets.Model().AccessToken != "" }, // creds live in the secrets store (§6)
+        // read creds through the credStore's synchronized accessor, NOT secrets.Model() directly:
+        // storage.Model() returns the live model unlocked, so an unguarded read here races with
+        // login/logout writes (the checker calls Authorized off the config lock).
+        Authorized: func() bool { return credStore.Credentials().AccessToken != "" }, // creds in secrets (§6)
     },
 )
 ```
@@ -116,10 +119,12 @@ probe at all (tibber), **don't** force it — that would change behaviour.
 
 ```go
 // credStore is YOUR thin adapter over the secrets store implementing auth.CredentialsStore —
-// storage.Storage[T] (Model/Load/Save/Reset) is NOT a CredentialsStore, so a wrapper is required:
-//   func (s *credStore) Credentials() auth.Credentials { m := s.secrets.Model(); return auth.Credentials{AccessToken: m.AccessToken, ...} }
-//   func (s *credStore) SetCredentials(c auth.Credentials) error { /* copy into s.secrets.Model(); */ return s.secrets.Save() }
-//   func (s *credStore) ClearCredentials() error { return s.secrets.Reset() }
+// storage.Storage[T] (Model/Load/Save/Reset) is NOT a CredentialsStore, so a wrapper is required.
+// storage.Model() returns the live model UNLOCKED, so guard the wrapper with its own mutex around
+// every read/write (login/logout/reset and the checker's Authorized read run on different goroutines):
+//   func (s *credStore) Credentials() auth.Credentials { s.mu.RLock(); defer s.mu.RUnlock(); m := s.secrets.Model(); return auth.Credentials{AccessToken: m.AccessToken, ...} }
+//   func (s *credStore) SetCredentials(c auth.Credentials) error { s.mu.Lock(); defer s.mu.Unlock(); /* copy into s.secrets.Model(); */ return s.secrets.Save() }
+//   func (s *credStore) ClearCredentials() error { s.mu.Lock(); defer s.mu.Unlock(); return s.secrets.Reset() }
 authr := auth.NewAuthenticator(credStore /*auth.CredentialsStore*/, client /*TokenExchanger*/, auth.AuthenticatorConfig{
     RefreshLead:       5 * time.Minute,                       // refresh this early
     Backoff:           backoff.NewTolerantFixed(2, 5*time.Minute),
@@ -168,6 +173,10 @@ public := cfgSrv.PublicModel()   // redact-returning; hand it a copy for pointer
 - **`PublicModel()` caveat**: for a pointer-backed config with no redactor it aliases the live model;
   pass a copy-returning `redact` func (mirrors the `Get` helper caveat, #197). `Update`'s lock is
   not reentrant — callbacks must not call back into the Service.
+- **`Update` no-rollback caveat**: `Update` mutates the live model *then* saves and does **not** roll
+  it back if the save fails — so a persistence error leaves the new value in memory while disk holds
+  the old one (the stale-in-memory hazard the 1.2 manual §17 warns about). Adapters needing strict
+  config/disk consistency must snapshot and restore on error themselves.
 
 ---
 

--- a/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
@@ -76,7 +76,7 @@ checker := app.NewConnectivityChecker(
             if cur == lifecycle.AuthStateAuthenticated { return lifecycle.AuthStateLost }
             return lifecycle.AuthStateNotAuthenticated              // stay silent if never authed
         },
-        Authorized: func() bool { return cfg.GetCredentials().AccessToken != "" }, // gate restore vs teardown
+        Authorized: func() bool { return secrets.Model().AccessToken != "" }, // creds live in the secrets store (§6)
     },
 )
 ```
@@ -231,7 +231,7 @@ backed by this secrets storage.
 9. Delete the replaced hand-rolled code.
 10. `go vet` / `golangci-lint` / `make test` (gate 75%, >80%) / `build-arm` / `deb-arm`.
 11. **Prove FIMP wire-compat**: diff inclusion report + evt stream vs the pre-bump capture.
-12. `/improve_logs`.
+12. Review logs (invoke `improve_logs` if available, else by hand).
 
 ---
 

--- a/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
@@ -115,16 +115,26 @@ probe at all (tibber), **don't** force it — that would change behaviour.
 `auth/authenticator.go`. For username/password→JWT and authorization-code refresh:
 
 ```go
-authr := auth.NewAuthenticator(cfgSecrets /*CredentialsStore*/, client /*TokenExchanger*/, auth.AuthenticatorConfig{
+// credStore is YOUR thin adapter over the secrets store implementing auth.CredentialsStore —
+// storage.Storage[T] (Model/Load/Save/Reset) is NOT a CredentialsStore, so a wrapper is required:
+//   func (s *credStore) Credentials() auth.Credentials { m := s.secrets.Model(); return auth.Credentials{AccessToken: m.AccessToken, ...} }
+//   func (s *credStore) SetCredentials(c auth.Credentials) error { /* copy into s.secrets.Model(); */ return s.secrets.Save() }
+//   func (s *credStore) ClearCredentials() error { return s.secrets.Reset() }
+authr := auth.NewAuthenticator(credStore /*auth.CredentialsStore*/, client /*TokenExchanger*/, auth.AuthenticatorConfig{
     RefreshLead:       5 * time.Minute,                       // refresh this early
     Backoff:           backoff.NewTolerantFixed(2, 5*time.Minute),
     UnauthorizedGrace: time.Hour,                             // tolerate 401 streak before concluding loss
-    OnAuthLoss:        func(reason string) { appLifecycle.MarkNotConfigured() /* + notify */ },
+    // auth loss = previously authenticated, now rejected → Lost (not MarkNotConfigured, which is
+    // logout/reset). SetConnAndAuthState so watchers see LOST with a consistent conn state:
+    OnAuthLoss: func(reason string) {
+        appLifecycle.SetConnAndAuthState(lifecycle.ConnStateDisconnected, lifecycle.AuthStateLost) // + notify
+    },
 })
 token, err := authr.AccessToken()   // cached; refreshes on expiry; concludes auth loss past grace
 ```
 
-- `CredentialsStore` = `{ Credentials() Credentials; SetCredentials(Credentials) error; ClearCredentials() error }`.
+- `CredentialsStore` = `{ Credentials() Credentials; SetCredentials(Credentials) error; ClearCredentials() error }`
+  — implement it on the adapter side over the secrets store (no cliffhanger type satisfies it).
 - `TokenExchanger` = `{ ExchangeRefreshToken(string) (*OAuth2TokenResponse, error) }`.
 - `Credentials{AccessToken, RefreshToken, ExpiresAt, RefreshExpiresAt}`; `expired(lead)`; `Empty()`.
 - **`OnAuthLoss` runs under the Authenticator lock** (#199) — its callback must not call back into


### PR DESCRIPTION
Project-scoped Claude skills for porting edge adapters onto cliffhanger:
- port_to_cliffhanger_1.2: the base port to v1.2.10 (copied from the global skill), architecture/packaging/tooling/FIMP compatibility.
- port_to_cliffhanger_1.3: the v1.2.10 -> v1.3.0 (develop) upgrade — adopting the extracted common blocks (ConnectivityChecker, auth.Authenticator, config.Service, secrets storage, stream.Supervisor, thing-sync helpers, lifecycle bundles), with a per-adapter Check() fit table (sensibo/sonos/mill/netatmo fit; zaptec/easee/tibber don't) and the 1.2.10->1.3.0 fixes to inherit.