### PR TITLE
Make cmd.app.get_diag a compile-required app handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -11,6 +11,8 @@ type App interface {
 	GetManifest() (*manifest.Manifest, error)
 	Configure(config any) error
 	Uninstall() error
+	// LogProvider requires ErrorsReport for the cmd.app.get_diag handler.
+	LogProvider
 }
 
 type ResettableApp interface {

--- a/app/routing.go
+++ b/app/routing.go
@@ -65,6 +65,7 @@ func RouteApp[C any](
 		RouteCmdAppGetManifest(serviceName, appLifecycle, configStorage, app),
 		RouteCmdConfigExtendedSet(serviceName, appLifecycle, configFactory, app, locker),
 		RouteCmdAppUninstall(serviceName, appLifecycle, app, locker, excludeAllThings),
+		RouteCmdAppDiagGetReport(serviceName, appLifecycle, app),
 	}
 
 	resettable, ok := app.(ResettableApp)
@@ -92,11 +93,6 @@ func RouteApp[C any](
 			RouteCmdAuthSetTokens(serviceName, appLifecycle, locker, authorizable),
 			RouteCmdAuthLogout(serviceName, appLifecycle, locker, authorizable),
 		)
-	}
-
-	logProvider, ok := app.(LogProvider)
-	if ok {
-		routing = append(routing, RouteCmdAppDiagGetReport(serviceName, appLifecycle, logProvider))
 	}
 
 	return routing

--- a/app/task_test.go
+++ b/app/task_test.go
@@ -22,6 +22,7 @@ type stubCheckableApp struct {
 func (s *stubCheckableApp) GetManifest() (*manifest.Manifest, error) { return nil, nil }
 func (s *stubCheckableApp) Configure(any) error                      { return nil }
 func (s *stubCheckableApp) Uninstall() error                         { return nil }
+func (s *stubCheckableApp) ErrorsReport() ([]string, error)          { return nil, nil }
 func (s *stubCheckableApp) CheckInterval() time.Duration             { return s.checkInterval }
 func (s *stubCheckableApp) Check() error {
 	s.calls++


### PR DESCRIPTION
## What

Turns the app diagnostics handler (`cmd.app.get_diag`) from an *optional, runtime-detected* capability into a *compile-time contract*.

Previously `RouteApp` wired the diag route only when a runtime type assertion `app.(LogProvider)` succeeded. An app that forgot to implement `ErrorsReport()` compiled and ran fine but **silently dropped** the diag handler — no compile error, no runtime error.

## Change

- Embed `LogProvider` (`ErrorsReport() ([]string, error)`) into the `app.App` interface.
- Wire `RouteCmdAppDiagGetReport` unconditionally in `RouteApp` and delete the runtime type assertion.
- Any `app.App` that lacks `ErrorsReport()` now fails to compile.

`cmd.app.get_state` reads only from the lifecycle and needs nothing from the app, so it was already wired unconditionally — no change there.

## ⚠️ Breaking change

Adding a method to the exported `app.App` interface is source-breaking: every adapter must now provide `ErrorsReport() ([]string, error)`, typically by delegating to `debug/formatters.ErrorHook.ErrorsReport` (which most adapters already build for the diag report). Should land with the next intentionally-breaking release (v1.3 line).

## Verification

- `go build ./...`, `go vet ./...`, `golangci-lint run` — pass.
- `go test ./app/...` — pass.
- Negative check: a type implementing `App` without `ErrorsReport` now fails to compile (`missing method ErrorsReport`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)