### PR TITLE
All apps must implement app.App.ErrorsReport

### DIFF
--- a/bootstrap/edge_test.go
+++ b/bootstrap/edge_test.go
@@ -19,6 +19,7 @@ type fakeApp struct{}
 func (a *fakeApp) GetManifest() (*manifest.Manifest, error) { return nil, nil }
 func (a *fakeApp) Configure(any) error                      { return nil }
 func (a *fakeApp) Uninstall() error                         { return nil }
+func (a *fakeApp) ErrorsReport() ([]string, error)          { return nil, nil }
 
 type testCfg struct{ Name string }
 


### PR DESCRIPTION
## Why

#205 promoted `ErrorsReport() ([]string, error)` into the `app.App` interface. That PR was cut from a branch where the `fakeApp` test double didn't exist, so its `bootstrap/edge_test.go` wasn't updated. On `develop`, `fakeApp` **does** exist, so the bootstrap test build is now broken:

```
cannot use &fakeApp{} as app.App value in argument to bootstrap.EdgeRouting:
*fakeApp does not implement app.App (missing method ErrorsReport)
```

## Fix

Add the trivial `ErrorsReport` method to `fakeApp` (same no-op pattern already applied to `stubCheckableApp` in #205).

## Verification

- `go build ./...`, `go vet ./bootstrap/...`, `golangci-lint run ./bootstrap/...` — pass.
- `go test ./bootstrap/... ./app/...` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)