### PR TITLE
Fix PR #197 integration findings (checker cancel, secrets reset, flow reset, retry-after)

### DIFF
--- a/app/check.go
+++ b/app/check.go
@@ -101,13 +101,17 @@ func (c *ConnectivityChecker) Check() error {
 	c.checkMu.Lock()
 	defer c.checkMu.Unlock()
 
-	// A pending recheck honors its backoff or Retry-After delay, so the periodic probe is skipped.
-	if c.pending() {
+	c.mu.Lock()
+	// Skip the periodic probe when a recheck is already pending (it honors its backoff /
+	// Retry-After delay) or when a Cancel (logout/reset) has torn the checker down and no
+	// re-authorizing CheckNow has resumed it. Reading both under one lock — rather than
+	// clearing cancelled unconditionally — closes the window where a Cancel racing the
+	// periodic Check would be silently overwritten and the stale probe applied anyway.
+	if c.timer != nil || c.cancelled {
+		c.mu.Unlock()
+
 		return nil
 	}
-
-	c.mu.Lock()
-	c.cancelled = false
 	c.mu.Unlock()
 
 	c.check()
@@ -164,7 +168,7 @@ func (c *ConnectivityChecker) check() {
 	}
 
 	if err == nil {
-		c.Cancel()
+		c.settle()
 
 		if c.authorized() {
 			c.apply(lifecycle.AuthStateAuthenticated, lifecycle.ConnStateConnected)
@@ -175,7 +179,7 @@ func (c *ConnectivityChecker) check() {
 	}
 
 	if errors.Is(err, httpclient.ErrUnauthorized) {
-		c.Cancel()
+		c.settle()
 		c.apply(c.authLossState(), lifecycle.ConnStateDisconnected)
 
 		return
@@ -183,7 +187,7 @@ func (c *ConnectivityChecker) check() {
 
 	// A rate limit does not mean connectivity is lost, so the connectivity state is left untouched.
 	if errors.Is(err, httpclient.ErrTooManyRequests) {
-		c.Cancel()
+		c.settle()
 		c.schedule(c.rateLimitDelay(err))
 
 		return
@@ -199,13 +203,29 @@ func (c *ConnectivityChecker) check() {
 	c.schedule(c.cfg.RecheckBackoff.Delay(failures))
 }
 
-// Cancel stops a pending recheck, discards the result of an in-flight probe and
-// clears the failure counter; call it on logout and reset.
+// Cancel tears the checker down on logout or reset: it marks the checker cancelled so an
+// in-flight probe's result is discarded (via stale) and subsequent periodic Checks are skipped,
+// and it settles any pending recheck. A re-authorizing CheckNow clears the flag and resumes.
 func (c *ConnectivityChecker) Cancel() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.cancelled = true
+	c.settleLocked()
+}
+
+// settle clears a pending recheck and the failure streak after a definitive probe result,
+// WITHOUT marking the checker cancelled — only an external Cancel does that. Using it here (not
+// Cancel) keeps the cancelled flag meaning "torn down", so a Cancel racing a Check is not masked
+// by the checker's own post-probe cleanup.
+func (c *ConnectivityChecker) settle() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.settleLocked()
+}
+
+func (c *ConnectivityChecker) settleLocked() {
 	c.failures = 0
 	c.warnLog.Reset()
 
@@ -227,13 +247,6 @@ func (c *ConnectivityChecker) repairAppHealth() {
 
 	c.lc.SetAppHealth(lifecycle.AppHealthRunning, nil)
 	c.lc.SetConfigState(lifecycle.ConfigStateConfigured)
-}
-
-func (c *ConnectivityChecker) pending() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	return c.timer != nil
 }
 
 func (c *ConnectivityChecker) stale() bool {

--- a/app/check.go
+++ b/app/check.go
@@ -171,7 +171,7 @@ func (c *ConnectivityChecker) check() {
 		c.settle()
 
 		if c.authorized() {
-			c.apply(lifecycle.AuthStateAuthenticated, lifecycle.ConnStateConnected)
+			c.apply(lifecycle.AuthStateAuthenticated, lifecycle.ConnStateConnected, "")
 			c.repairAppHealth()
 		}
 
@@ -180,7 +180,7 @@ func (c *ConnectivityChecker) check() {
 
 	if errors.Is(err, httpclient.ErrUnauthorized) {
 		c.settle()
-		c.apply(c.authLossState(), lifecycle.ConnStateDisconnected)
+		c.apply(c.authLossState(), lifecycle.ConnStateDisconnected, "unauthorized")
 
 		return
 	}
@@ -197,7 +197,7 @@ func (c *ConnectivityChecker) check() {
 
 	failures := c.fail()
 	if failures > c.cfg.MaxRechecks {
-		c.apply("", lifecycle.ConnStateDisconnected)
+		c.apply("", lifecycle.ConnStateDisconnected, "")
 	}
 
 	c.schedule(c.cfg.RecheckBackoff.Delay(failures))
@@ -267,8 +267,9 @@ func (c *ConnectivityChecker) rateLimitDelay(err error) time.Duration {
 }
 
 // apply sets the provided lifecycle states (empty auth leaves it untouched) and
-// broadcasts node availability if any of them changed.
-func (c *ConnectivityChecker) apply(auth, conn lifecycle.State) {
+// broadcasts node availability if any of them changed. reason accompanies an
+// AuthStateLost transition to tell the auth-loss watcher why the session was lost.
+func (c *ConnectivityChecker) apply(auth, conn lifecycle.State, reason string) {
 	changed := false
 
 	// AuthStateLost triggers the auth-loss watcher, which reports the whole state bundle.
@@ -276,7 +277,7 @@ func (c *ConnectivityChecker) apply(auth, conn lifecycle.State) {
 	// trigger is not evicted from its buffer by a separate connection event.
 	if auth == lifecycle.AuthStateLost {
 		if c.lc.ConnectionState() != conn || c.lc.AuthState() != auth {
-			c.lc.SetConnAndAuthState(conn, auth)
+			c.lc.SetConnAndAuthStateReason(conn, auth, reason)
 
 			changed = true
 		}

--- a/app/check_test.go
+++ b/app/check_test.go
@@ -218,6 +218,38 @@ func TestConnectivityChecker_RepairAppHealthLeavesRunningAppUntouched(t *testing
 		"an already-running app is left untouched, not re-configured by the repair guard")
 }
 
+func TestConnectivityChecker_CheckSkipsAfterCancel(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+
+	probe := func() error {
+		calls.Add(1)
+
+		return nil
+	}
+
+	lc := lifecycle.New(nil)
+	reporter := &fakeReporter{}
+	checker := app.NewConnectivityChecker(probe, lc, reporter, app.CheckerConfig{})
+
+	// A Cancel (logout/reset) that lands before a periodic Check must not be overwritten: the
+	// Check skips instead of running a probe that would restore Authenticated/Connected.
+	checker.Cancel()
+
+	assert.NoError(t, checker.Check())
+	assert.Equal(t, int32(0), calls.Load(), "Check after Cancel must not probe")
+	assert.Equal(t, lifecycle.ConnStateNA, lc.ConnectionState(), "no state restored after Cancel")
+	assert.Equal(t, int32(0), reporter.reports.Load())
+
+	// Re-authorization via CheckNow clears the cancelled state and resumes.
+	assert.NoError(t, checker.CheckNow())
+	assert.Equal(t, int32(1), calls.Load())
+	assert.Equal(t, lifecycle.ConnStateConnected, lc.ConnectionState())
+
+	checker.Cancel()
+}
+
 func TestConnectivityChecker_CancelDiscardsInFlightProbe(t *testing.T) {
 	t.Parallel()
 
@@ -301,8 +333,15 @@ func TestConnectivityChecker_PendingRecheckSkipsPeriodicProbe(t *testing.T) {
 
 	checker.Cancel()
 
+	// Cancel (logout/reset) tears the checker down: a periodic Check stays skipped until a
+	// re-authorizing CheckNow resumes it — so a Cancel racing a Check cannot be overwritten.
 	assert.NoError(t, checker.Check())
-	assert.Equal(t, int32(2), calls.Load(), "probe should resume once the pending recheck is canceled")
+	assert.Equal(t, int32(1), calls.Load(), "a periodic Check after Cancel must stay torn down")
+
+	assert.NoError(t, checker.CheckNow())
+	assert.Equal(t, int32(2), calls.Load(), "CheckNow resumes probing after Cancel")
+
+	checker.Cancel()
 }
 
 func TestConnectivityChecker_CheckNowProbesDespitePendingRecheck(t *testing.T) {

--- a/app/check_test.go
+++ b/app/check_test.go
@@ -445,6 +445,8 @@ func TestConnectivityChecker_AuthLossEventCarriesUpdatedConnState(t *testing.T) 
 
 			assert.Equal(t, lifecycle.ConnStateDisconnected, lc.ConnectionState(),
 				"an auth-loss observer must not see the outdated connection state")
+			assert.Equal(t, "unauthorized", event.Params["reason"],
+				"the auth-loss event carries why the session was lost")
 
 			return
 		case <-time.After(time.Second):

--- a/app/flow.go
+++ b/app/flow.go
@@ -37,15 +37,17 @@ func Reset(appLifecycle *lifecycle.Lifecycle, things ThingDestroyer, resetConfig
 	return errors.Join(errs...)
 }
 
-// Logout clears credentials and marks the application as not configured.
-// Optional teardown hooks run first, e.g. to cancel checks or close connections.
+// Logout clears credentials and marks the application as not configured. Optional
+// teardown hooks (e.g. cancel checks, close connections) run only after credentials are
+// cleared, so a failed clear leaves the previous session intact instead of tearing down
+// connections while the app still reports the old session.
 func Logout(appLifecycle *lifecycle.Lifecycle, clearCredentials func() error, teardown ...func()) error {
-	for _, fn := range teardown {
-		fn()
-	}
-
 	if err := clearCredentials(); err != nil {
 		return fmt.Errorf("clear credentials: %w", err)
+	}
+
+	for _, fn := range teardown {
+		fn()
 	}
 
 	appLifecycle.MarkNotConfigured()

--- a/app/flow.go
+++ b/app/flow.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/futurehomeno/cliffhanger/lifecycle"
@@ -18,17 +19,22 @@ func Reset(appLifecycle *lifecycle.Lifecycle, things ThingDestroyer, resetConfig
 		fn()
 	}
 
+	// Mark not configured before the destructive steps so a partial failure still leaves the app
+	// in a consistent unconfigured state, rather than "configured" over an already-wiped device
+	// set that a later boot would restore. Both steps run and their errors are joined.
+	appLifecycle.MarkNotConfigured()
+
+	var errs []error
+
 	if err := things.DestroyAllThings(); err != nil {
-		return fmt.Errorf("destroy things: %w", err)
+		errs = append(errs, fmt.Errorf("destroy things: %w", err))
 	}
 
 	if err := resetConfig(); err != nil {
-		return fmt.Errorf("reset configuration: %w", err)
+		errs = append(errs, fmt.Errorf("reset configuration: %w", err))
 	}
 
-	appLifecycle.MarkNotConfigured()
-
-	return nil
+	return errors.Join(errs...)
 }
 
 // Logout clears credentials and marks the application as not configured.

--- a/app/flow_test.go
+++ b/app/flow_test.go
@@ -58,16 +58,20 @@ func TestLogout(t *testing.T) {
 	lc := lifecycle.New(nil)
 	lc.MarkRunning()
 
-	err := app.Logout(lc, func() error { return nil })
+	tornDown := false
+	err := app.Logout(lc, func() error { return nil }, func() { tornDown = true })
 
 	assert.NoError(t, err)
+	assert.True(t, tornDown)
 	assert.Equal(t, lifecycle.AuthStateNotAuthenticated, lc.AuthState())
 
 	lc.MarkRunning()
 
-	err = app.Logout(lc, func() error { return errors.New("clear err") })
+	tornDown = false
+	err = app.Logout(lc, func() error { return errors.New("clear err") }, func() { tornDown = true })
 
 	assert.Error(t, err)
+	assert.False(t, tornDown, "teardown must not run when credential clearing failed")
 	assert.Equal(t, lifecycle.AuthStateAuthenticated, lc.AuthState())
 }
 

--- a/app/flow_test.go
+++ b/app/flow_test.go
@@ -41,10 +41,15 @@ func TestReset(t *testing.T) {
 
 	lc.MarkRunning()
 
-	err = app.Reset(lc, &fakeDestroyer{err: errors.New("destroy err")}, func() error { return nil })
+	destroyErr := &fakeDestroyer{err: errors.New("destroy err")}
+	resetRan := false
+	err = app.Reset(lc, destroyErr, func() error { resetRan = true; return nil })
 
 	assert.Error(t, err)
-	assert.Equal(t, lifecycle.AppHealthRunning, lc.AppHealth(), "states should be left untouched on failure")
+	assert.Equal(t, lifecycle.AppHealthNotConfigured, lc.AppHealth(),
+		"a partial failure still leaves the app in a consistent unconfigured state")
+	assert.True(t, destroyErr.called)
+	assert.True(t, resetRan, "config reset still runs even if destroy failed; the errors are joined")
 }
 
 func TestLogout(t *testing.T) {

--- a/app/logcapture.go
+++ b/app/logcapture.go
@@ -1,16 +1,30 @@
 package app
 
 import (
+	"sync"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/futurehomeno/cliffhanger/debug/formatters"
 )
 
-// NewLogCapture registers a warn+ ring-buffer hook on the global logger and
-// returns it as a LogProvider to embed in an app, backing cmd.app.get_diag.
-func NewLogCapture() LogProvider {
-	hook := formatters.NewErrorHook()
-	log.AddHook(hook)
+var (
+	logCaptureMu   sync.Mutex
+	logCaptureHook *formatters.ErrorHook
+)
 
-	return hook
+// NewLogCapture returns the LogProvider backing cmd.app.get_diag: a warn+
+// ring-buffer hook on the global logger, exposed via ErrorsReport. The hook is
+// installed once and shared by later calls, so repeated app construction (or
+// many app.New calls across a test binary) does not stack duplicate hooks.
+func NewLogCapture() LogProvider {
+	logCaptureMu.Lock()
+	defer logCaptureMu.Unlock()
+
+	if logCaptureHook == nil {
+		logCaptureHook = formatters.NewErrorHook()
+		log.AddHook(logCaptureHook)
+	}
+
+	return logCaptureHook
 }

--- a/app/logcapture.go
+++ b/app/logcapture.go
@@ -1,0 +1,16 @@
+package app
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/futurehomeno/cliffhanger/debug/formatters"
+)
+
+// NewLogCapture registers a warn+ ring-buffer hook on the global logger and
+// returns it as a LogProvider to embed in an app, backing cmd.app.get_diag.
+func NewLogCapture() LogProvider {
+	hook := formatters.NewErrorHook()
+	log.AddHook(hook)
+
+	return hook
+}

--- a/app/logcapture_test.go
+++ b/app/logcapture_test.go
@@ -1,0 +1,37 @@
+package app_test
+
+import (
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/futurehomeno/cliffhanger/app"
+)
+
+// TestNewLogCapture_CapturesGlobalWarnings verifies the returned provider is
+// wired to the global logger — the one behaviour the compiler can't enforce.
+// No t.Parallel: the logrus hook stays registered process-wide.
+func TestNewLogCapture_CapturesGlobalWarnings(t *testing.T) {
+	provider := app.NewLogCapture()
+	require.NotNil(t, provider)
+
+	const sentinel = "logcapture wiring sentinel 4f2a"
+	log.Warn(sentinel)
+
+	entries, err := provider.ErrorsReport()
+	require.NoError(t, err)
+
+	found := false
+	for _, e := range entries {
+		if strings.Contains(e, sentinel) {
+			found = true
+
+			break
+		}
+	}
+
+	assert.True(t, found, "global warning should be captured by the returned provider")
+}

--- a/app/logcapture_test.go
+++ b/app/logcapture_test.go
@@ -35,3 +35,13 @@ func TestNewLogCapture_CapturesGlobalWarnings(t *testing.T) {
 
 	assert.True(t, found, "global warning should be captured by the returned provider")
 }
+
+// TestNewLogCapture_InstallsHookOnce verifies repeated construction shares the single
+// process-wide hook instead of stacking a new global logrus hook on every call.
+func TestNewLogCapture_InstallsHookOnce(t *testing.T) { //nolint:paralleltest
+	first := app.NewLogCapture()
+	second := app.NewLogCapture()
+
+	require.NotNil(t, first)
+	assert.Same(t, first, second, "repeated NewLogCapture calls must share one hook, not stack duplicates")
+}

--- a/bootstrap/routing_test.go
+++ b/bootstrap/routing_test.go
@@ -43,7 +43,7 @@ func TestDefaultRoute_BundlesConfigDebugTelemetry(t *testing.T) { //nolint:paral
 	require.NoError(t, mqtt.Start(2*time.Second))
 	t.Cleanup(mqtt.Stop)
 
-	tel, err := telemetry.New(mqtt, "boot_svc", store)
+	tel, err := telemetry.New(mqtt, "boot_svc", store, "")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if stop, ok := tel.(interface{ Stop() }); ok {
@@ -83,7 +83,7 @@ func TestDefaultRoute_DispatchesConfigDebugAndTelemetry(t *testing.T) { //nolint
 				Setup: suite.BaseSetup(func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
 					t.Helper()
 
-					tel, err := telemetry.New(mqtt, "boot_svc", store)
+					tel, err := telemetry.New(mqtt, "boot_svc", store, "")
 					require.NoError(t, err)
 					t.Cleanup(func() {
 						if stop, ok := tel.(interface{ Stop() }); ok {
@@ -154,7 +154,7 @@ func TestDefaultRoute_CustomConfigGetterPayload(t *testing.T) { //nolint:paralle
 				Setup: suite.BaseSetup(func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
 					t.Helper()
 
-					tel, err := telemetry.New(mqtt, "boot_svc", store)
+					tel, err := telemetry.New(mqtt, "boot_svc", store, "")
 					require.NoError(t, err)
 					t.Cleanup(func() {
 						if stop, ok := tel.(interface{ Stop() }); ok {

--- a/httpclient/errors.go
+++ b/httpclient/errors.go
@@ -60,6 +60,10 @@ func ErrorFromResponse(resp *http.Response) error {
 
 // retryAfter returns the delay the server asks for via the Retry-After header
 // (delta-seconds or HTTP-date form), or 0.
+// maxRetryAfter caps a server-supplied Retry-After so a misconfigured or hostile server cannot
+// park the client (e.g. block the connectivity recheck) for an unbounded time.
+const maxRetryAfter = time.Hour
+
 func retryAfter(resp *http.Response) time.Duration {
 	header := resp.Header.Get("Retry-After")
 
@@ -68,12 +72,18 @@ func retryAfter(resp *http.Response) time.Duration {
 			return 0
 		}
 
-		return time.Duration(secs) * time.Second
+		// A large value can overflow the multiplication to a negative Duration; treat any
+		// non-positive or over-cap result as the cap.
+		if d := time.Duration(secs) * time.Second; d > 0 && d < maxRetryAfter {
+			return d
+		}
+
+		return maxRetryAfter
 	}
 
 	if date, err := http.ParseTime(header); err == nil {
 		if delay := time.Until(date); delay > 0 {
-			return delay
+			return min(delay, maxRetryAfter)
 		}
 	}
 

--- a/httpclient/errors.go
+++ b/httpclient/errors.go
@@ -67,7 +67,8 @@ const maxRetryAfter = time.Hour
 func retryAfter(resp *http.Response) time.Duration {
 	header := resp.Header.Get("Retry-After")
 
-	if secs, err := strconv.Atoi(header); err == nil {
+	secs, err := strconv.Atoi(header)
+	if err == nil {
 		if secs <= 0 {
 			return 0
 		}
@@ -78,6 +79,12 @@ func retryAfter(resp *http.Response) time.Duration {
 			return d
 		}
 
+		return maxRetryAfter
+	}
+
+	// A numeric header too large for int (Atoi returns ErrRange with the max magnitude value)
+	// is an over-cap delay, not a date — clamp positive overflow to the cap.
+	if errors.Is(err, strconv.ErrRange) && secs > 0 {
 		return maxRetryAfter
 	}
 

--- a/httpclient/errors.go
+++ b/httpclient/errors.go
@@ -73,13 +73,14 @@ func retryAfter(resp *http.Response) time.Duration {
 			return 0
 		}
 
-		// A large value can overflow the multiplication to a negative Duration; treat any
-		// non-positive or over-cap result as the cap.
-		if d := time.Duration(secs) * time.Second; d > 0 && d < maxRetryAfter {
-			return d
+		// Bound before multiplying: secs*1e9 can overflow int64 and wrap to a small positive
+		// Duration that would otherwise slip through as a too-short delay. Anything at or above
+		// the cap (in seconds) clamps, so the multiplication below is always in range.
+		if secs >= int(maxRetryAfter/time.Second) {
+			return maxRetryAfter
 		}
 
-		return maxRetryAfter
+		return time.Duration(secs) * time.Second
 	}
 
 	// A numeric header too large for int (Atoi returns ErrRange with the max magnitude value)

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -83,6 +83,7 @@ func TestErrorFromResponse_RetryAfter(t *testing.T) {
 	// overflow-large values clamp to the 1h ceiling rather than a huge (or negative) delay.
 	assert.Equal(t, time.Hour, rateLimited("100000"), "an over-cap Retry-After clamps to the ceiling")
 	assert.Equal(t, time.Hour, rateLimited("999999999999"), "an overflow-large Retry-After clamps, not negative")
+	assert.Equal(t, time.Hour, rateLimited("18446744074"), "a value whose ns product overflows to a small positive duration clamps, not a too-short delay")
 	assert.Equal(t, time.Hour, rateLimited("99999999999999999999999"), "a value too large for int64 clamps to the ceiling, not 0")
 	assert.Equal(t, time.Hour, rateLimited(time.Now().Add(48*time.Hour).UTC().Format(http.TimeFormat)),
 		"a far-future Retry-After date clamps to the ceiling")

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -78,4 +78,11 @@ func TestErrorFromResponse_RetryAfter(t *testing.T) {
 	assert.LessOrEqual(t, delay, 2*time.Minute)
 
 	assert.Equal(t, time.Duration(0), rateLimited(time.Now().Add(-time.Minute).UTC().Format(http.TimeFormat)))
+
+	// A misconfigured or hostile server must not park the client indefinitely: over-cap and
+	// overflow-large values clamp to the 1h ceiling rather than a huge (or negative) delay.
+	assert.Equal(t, time.Hour, rateLimited("100000"), "an over-cap Retry-After clamps to the ceiling")
+	assert.Equal(t, time.Hour, rateLimited("999999999999"), "an overflow-large Retry-After clamps, not negative")
+	assert.Equal(t, time.Hour, rateLimited(time.Now().Add(48*time.Hour).UTC().Format(http.TimeFormat)),
+		"a far-future Retry-After date clamps to the ceiling")
 }

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -83,6 +83,7 @@ func TestErrorFromResponse_RetryAfter(t *testing.T) {
 	// overflow-large values clamp to the 1h ceiling rather than a huge (or negative) delay.
 	assert.Equal(t, time.Hour, rateLimited("100000"), "an over-cap Retry-After clamps to the ceiling")
 	assert.Equal(t, time.Hour, rateLimited("999999999999"), "an overflow-large Retry-After clamps, not negative")
+	assert.Equal(t, time.Hour, rateLimited("99999999999999999999999"), "a value too large for int64 clamps to the ceiling, not 0")
 	assert.Equal(t, time.Hour, rateLimited(time.Now().Add(48*time.Hour).UTC().Format(http.TimeFormat)),
 		"a far-future Retry-After date clamps to the ceiling")
 }

--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -218,6 +218,22 @@ func (l *Lifecycle) SetConnAndAuthState(connectionState, authState State) {
 	l.emitStateChangeEvent(StateTypeAuthState, authState, nil)
 }
 
+// SetConnAndAuthStateReason is SetConnAndAuthState that attaches a reason to the
+// emitted auth event so the auth-loss watcher can report why the session was lost.
+func (l *Lifecycle) SetConnAndAuthStateReason(connectionState, authState State, reason string) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	if connectionState == l.connectionState && authState == l.authState {
+		return
+	}
+
+	l.connectionState = connectionState
+	l.authState = authState
+
+	l.emitStateChangeEvent(StateTypeAuthState, authState, map[string]string{"reason": reason})
+}
+
 func (l *Lifecycle) AppHealth() State {
 	l.lock.RLock()
 	defer l.lock.RUnlock()

--- a/lifecycle/lifecycle_test.go
+++ b/lifecycle/lifecycle_test.go
@@ -159,6 +159,25 @@ func TestSetConnAndAuthState_EmitsSingleAuthEventWithBothStatesApplied(t *testin
 	assert.Empty(t, ch, "no separate connection event competes for the subscriber buffer")
 }
 
+func TestSetConnAndAuthStateReason_EmitsAuthEventWithReason(t *testing.T) {
+	t.Parallel()
+
+	l := lifecycle.New(nil)
+	l.SetAuthState(lifecycle.AuthStateAuthenticated)
+	l.SetConnState(lifecycle.ConnStateConnected)
+
+	ch := l.Subscribe("test", 5)
+
+	l.SetConnAndAuthStateReason(lifecycle.ConnStateDisconnected, lifecycle.AuthStateLost, "unauthorized")
+
+	event := <-ch
+	assert.Equal(t, lifecycle.StateTypeAuthState, event.Type)
+	assert.Equal(t, lifecycle.AuthStateLost, event.State)
+	assert.Equal(t, "unauthorized", event.Params["reason"], "the reason rides the auth event")
+	assert.Equal(t, lifecycle.ConnStateDisconnected, l.ConnectionState())
+	assert.Equal(t, lifecycle.AuthStateLost, l.AuthState())
+}
+
 func TestSetConnAndAuthState_NoEventWhenBothStatesUnchanged(t *testing.T) {
 	t.Parallel()
 

--- a/root/app.go
+++ b/root/app.go
@@ -212,13 +212,16 @@ func (a *app) startAuthLossWatcher(tel telemetry.Telemetry) {
 
 	const subID = "auth_lost"
 
-	ch := a.lifecycle.Subscribe(subID, 5)
-
 	// Only an authenticated session can be lost: arm on AUTHENTICATED and report a LOST only
-	// while armed. Seed armed here — right after Subscribe, before the goroutine is scheduled —
-	// so a LOST queued immediately after subscription is still evaluated against the pre-LOST
-	// state, instead of one the goroutine-scheduling delay let that very event change.
+	// while armed. Seed armed BEFORE subscribing. SetAuthState updates the state field and then
+	// emits under the same lock, so a LOST landing after Subscribe but before the seed read would
+	// be captured in ch yet make AuthState() return LOST — seeding armed=false and dropping the
+	// very event that was queued. Reading first means any event ch delivers is evaluated against
+	// the state that preceded it; the only thing missed is a LOST that fires between the read and
+	// Subscribe, which is never queued and is equivalent to an already-lost startup.
 	armed := a.lifecycle.AuthState() == lifecycle.AuthStateAuthenticated
+
+	ch := a.lifecycle.Subscribe(subID, 5)
 
 	a.authWatcherStopCh = make(chan struct{})
 	a.authWatcherDoneCh = make(chan struct{})
@@ -253,7 +256,8 @@ func (a *app) startAuthLossWatcher(tel telemetry.Telemetry) {
 
 // nextAuthArm advances the arm state for one auth-state event: an AUTHENTICATED
 // session arms the watcher; a LOST reports only while armed, then disarms so a
-// repeated LOST (e.g. a connection-only change) does not re-fire.
+// repeated LOST (e.g. a connection-only change) does not re-fire; NOT_AUTHENTICATED
+// (logout/reset) disarms so a later failed re-login does not report a phantom loss.
 func nextAuthArm(armed bool, s lifecycle.State) (report, nowArmed bool) {
 	switch s {
 	case lifecycle.AuthStateAuthenticated:
@@ -263,6 +267,11 @@ func nextAuthArm(armed bool, s lifecycle.State) (report, nowArmed bool) {
 			return true, false
 		}
 
+		return false, false
+	case lifecycle.AuthStateNotAuthenticated:
+		// Logout/reset drive the app to NOT_AUTHENTICATED (MarkNotConfigured). Disarm so a later
+		// failed re-login — which never reaches AUTHENTICATED, only 401 -> LOST — does not report a
+		// loss for a session that was never re-established.
 		return false, false
 	}
 
@@ -281,12 +290,9 @@ func (a *app) reportAuthLoss(tel telemetry.Telemetry, reason string) {
 		log.WithError(err).Errorf("[cliff] failed to publish app state report on auth loss (%s)", reason)
 	}
 
-	data := map[string]any{}
-	if reason != "" {
-		data["reason"] = reason
-	}
-
-	telemetry.Emit(tel, telemetry.DomainAuth, telemetry.EventLoggedOut, data)
+	// Emit under the historical "cause" key that shipped on develop so downstream telemetry
+	// consumers keyed on data.cause keep matching; the value is the same loss reason.
+	telemetry.Emit(tel, telemetry.DomainAuth, telemetry.EventLoggedOut, map[string]any{"cause": reason})
 
 	if a.authLossNotifier != nil && a.authLossEvent != nil {
 		if err := a.authLossNotifier.Event(a.authLossEvent); err != nil {

--- a/root/app.go
+++ b/root/app.go
@@ -17,6 +17,7 @@ import (
 	cliffapp "github.com/futurehomeno/cliffhanger/app"
 	"github.com/futurehomeno/cliffhanger/config"
 	"github.com/futurehomeno/cliffhanger/lifecycle"
+	"github.com/futurehomeno/cliffhanger/notification"
 	"github.com/futurehomeno/cliffhanger/router"
 	"github.com/futurehomeno/cliffhanger/task"
 	"github.com/futurehomeno/cliffhanger/telemetry"
@@ -57,15 +58,18 @@ type app struct {
 	lock    *sync.Mutex
 	errCh   chan error
 
-	mqtt               *fimpgo.MqttTransport
-	lifecycle          *lifecycle.Lifecycle
-	telemetry          telemetry.Telemetry
-	resourceName       fimptype.ResourceNameT
-	topicSubscriptions []string
-	messageRouter      router.Router
-	taskManager        task.Manager
-	services           []Service
-	resetters          []Resetter
+	mqtt                  *fimpgo.MqttTransport
+	lifecycle             *lifecycle.Lifecycle
+	telemetry             telemetry.Telemetry
+	authLossNotifier      notification.Notification
+	authLossEvent         *notification.Event
+	authLossReportEnabled func() bool
+	resourceName          fimptype.ResourceNameT
+	topicSubscriptions    []string
+	messageRouter         router.Router
+	taskManager           task.Manager
+	services              []Service
+	resetters             []Resetter
 
 	authWatcherStopCh chan struct{}
 	authWatcherDoneCh chan struct{}
@@ -216,9 +220,10 @@ func (a *app) startAuthLossWatcher(tel telemetry.Telemetry) {
 		defer close(a.authWatcherDoneCh)
 		defer a.lifecycle.Unsubscribe(subID)
 
-		if a.lifecycle.AuthState() == lifecycle.AuthStateLost {
-			a.reportAuthLoss(tel, "startup")
-		}
+		// Only an authenticated session can be lost: arm on AUTHENTICATED and report a
+		// LOST only while armed. Seeding from the current state covers an app that is
+		// already authenticated when the watcher subscribes.
+		armed := a.lifecycle.AuthState() == lifecycle.AuthStateAuthenticated
 
 		for {
 			select {
@@ -227,11 +232,15 @@ func (a *app) startAuthLossWatcher(tel telemetry.Telemetry) {
 					return
 				}
 
-				if event.Type != lifecycle.StateTypeAuthState || event.State != lifecycle.AuthStateLost {
+				if event.Type != lifecycle.StateTypeAuthState {
 					continue
 				}
 
-				a.reportAuthLoss(tel, "transition")
+				var report bool
+				report, armed = nextAuthArm(armed, event.State)
+				if report {
+					a.reportAuthLoss(tel, event.Params["reason"])
+				}
 
 			case <-a.authWatcherStopCh:
 				return
@@ -240,14 +249,54 @@ func (a *app) startAuthLossWatcher(tel telemetry.Telemetry) {
 	}()
 }
 
-// reportAuthLoss publishes the FIMP app state report and emits a telemetry
-// event for an observed AuthStateLost transition.
-func (a *app) reportAuthLoss(tel telemetry.Telemetry, cause string) {
-	if err := sendAppStateReport(a.mqtt, a.resourceName, fimptype.ServiceNameT(a.resourceName), a.lifecycle); err != nil {
-		log.WithError(err).Errorf("[cliff] failed to publish app state report on auth loss (%s)", cause)
+// nextAuthArm advances the arm state for one auth-state event: an AUTHENTICATED
+// session arms the watcher; a LOST reports only while armed, then disarms so a
+// repeated LOST (e.g. a connection-only change) does not re-fire.
+func nextAuthArm(armed bool, s lifecycle.State) (report, nowArmed bool) {
+	switch s {
+	case lifecycle.AuthStateAuthenticated:
+		return false, true
+	case lifecycle.AuthStateLost:
+		if armed {
+			return true, false
+		}
+
+		return false, false
 	}
 
-	telemetry.Emit(tel, telemetry.DomainAuth, telemetry.EventLoggedOut, map[string]any{"cause": cause})
+	return false, armed
+}
+
+// reportAuthLoss notifies the user, publishes the FIMP app state report and emits a
+// telemetry event for a lost authenticated session. reason, when set, states why
+// (e.g. "unauthorized"). All three are suppressed when auth-loss reporting is disabled.
+func (a *app) reportAuthLoss(tel telemetry.Telemetry, reason string) {
+	if !a.authLossReportingEnabled() {
+		return
+	}
+
+	if err := sendAppStateReport(a.mqtt, a.resourceName, fimptype.ServiceNameT(a.resourceName), a.lifecycle); err != nil {
+		log.WithError(err).Errorf("[cliff] failed to publish app state report on auth loss (%s)", reason)
+	}
+
+	data := map[string]any{}
+	if reason != "" {
+		data["reason"] = reason
+	}
+
+	telemetry.Emit(tel, telemetry.DomainAuth, telemetry.EventLoggedOut, data)
+
+	if a.authLossNotifier != nil && a.authLossEvent != nil {
+		if err := a.authLossNotifier.Event(a.authLossEvent); err != nil {
+			log.WithError(err).Errorf("[cliff] failed to send auth-loss notification (%s)", reason)
+		}
+	}
+}
+
+// authLossReportingEnabled reports whether auth-loss reporting is on. The gate is
+// evaluated per loss so it can follow a runtime config flag; a nil gate reports every loss.
+func (a *app) authLossReportingEnabled() bool {
+	return a.authLossReportEnabled == nil || a.authLossReportEnabled()
 }
 
 // stopAuthLossWatcher stops the auth loss watcher goroutine started by startAuthLossWatcher.

--- a/root/app.go
+++ b/root/app.go
@@ -213,17 +213,19 @@ func (a *app) startAuthLossWatcher(tel telemetry.Telemetry) {
 	const subID = "auth_lost"
 
 	ch := a.lifecycle.Subscribe(subID, 5)
+
+	// Only an authenticated session can be lost: arm on AUTHENTICATED and report a LOST only
+	// while armed. Seed armed here — right after Subscribe, before the goroutine is scheduled —
+	// so a LOST queued immediately after subscription is still evaluated against the pre-LOST
+	// state, instead of one the goroutine-scheduling delay let that very event change.
+	armed := a.lifecycle.AuthState() == lifecycle.AuthStateAuthenticated
+
 	a.authWatcherStopCh = make(chan struct{})
 	a.authWatcherDoneCh = make(chan struct{})
 
 	go func() {
 		defer close(a.authWatcherDoneCh)
 		defer a.lifecycle.Unsubscribe(subID)
-
-		// Only an authenticated session can be lost: arm on AUTHENTICATED and report a
-		// LOST only while armed. Seeding from the current state covers an app that is
-		// already authenticated when the watcher subscribes.
-		armed := a.lifecycle.AuthState() == lifecycle.AuthStateAuthenticated
 
 		for {
 			select {

--- a/root/authloss_internal_test.go
+++ b/root/authloss_internal_test.go
@@ -80,6 +80,35 @@ func TestAuthLossWatcher_NotifiesOnlyOnLostAfterAuthenticated(t *testing.T) { //
 	assert.Equal(t, "test_status_offline", notifier.first().EventName)
 }
 
+// TestAuthLossWatcher_ArmsFromAuthenticatedStateAtSubscribe verifies the watcher seeds its armed
+// flag from the state present when it subscribes, so an app already authenticated at boot reports
+// the next LOST without having to observe the AUTHENTICATED transition live.
+func TestAuthLossWatcher_ArmsFromAuthenticatedStateAtSubscribe(t *testing.T) { //nolint:paralleltest
+	mqtt := suite.DefaultMQTT("root_authloss_seed", "", "", "")
+	require.NoError(t, mqtt.Start(5*time.Second))
+	defer mqtt.Stop()
+
+	lc := lifecycle.New(nil)
+	lc.SetAuthState(lifecycle.AuthStateAuthenticated)
+
+	notifier := &fakeNotifier{}
+	a := &app{
+		mqtt:             mqtt,
+		lifecycle:        lc,
+		resourceName:     "test_app",
+		authLossNotifier: notifier,
+		authLossEvent:    &notification.Event{EventName: "test_status_offline"},
+	}
+
+	a.startAuthLossWatcher(nil)
+	defer a.stopAuthLossWatcher()
+
+	lc.SetAuthState(lifecycle.AuthStateLost)
+
+	require.Eventually(t, func() bool { return notifier.count() == 1 }, time.Second, 10*time.Millisecond,
+		"already-authenticated app must arm at subscribe and report the next LOST")
+}
+
 // TestReportAuthLoss_SuppressedWhenReportingDisabled confirms the reporting gate suppresses the
 // notification (and the app-state report and telemetry emitted alongside it).
 func TestReportAuthLoss_SuppressedWhenReportingDisabled(t *testing.T) { //nolint:paralleltest

--- a/root/authloss_internal_test.go
+++ b/root/authloss_internal_test.go
@@ -1,0 +1,156 @@
+package root
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/futurehomeno/cliffhanger/lifecycle"
+	"github.com/futurehomeno/cliffhanger/notification"
+	"github.com/futurehomeno/cliffhanger/test/suite"
+)
+
+type fakeNotifier struct {
+	mu     sync.Mutex
+	events []*notification.Event
+}
+
+func (f *fakeNotifier) Event(e *notification.Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, e)
+
+	return nil
+}
+
+func (f *fakeNotifier) Message(string) error { return nil }
+
+func (f *fakeNotifier) EventWithProps(e *notification.Event, _ map[string]string) error {
+	return f.Event(e)
+}
+
+func (f *fakeNotifier) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return len(f.events)
+}
+
+func (f *fakeNotifier) first() *notification.Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if len(f.events) == 0 {
+		return nil
+	}
+
+	return f.events[0]
+}
+
+// TestAuthLossWatcher_NotifiesOnlyOnLostAfterAuthenticated drives real lifecycle transitions
+// through the watcher: a never-authenticated app dropping to NOT_AUTHENTICATED stays silent,
+// while a genuine AUTHENTICATED -> LOST transition sends exactly one notification.
+func TestAuthLossWatcher_NotifiesOnlyOnLostAfterAuthenticated(t *testing.T) { //nolint:paralleltest
+	mqtt := suite.DefaultMQTT("root_authloss_watch", "", "", "")
+	require.NoError(t, mqtt.Start(5*time.Second))
+	defer mqtt.Stop()
+
+	lc := lifecycle.New(nil)
+	notifier := &fakeNotifier{}
+	a := &app{
+		mqtt:             mqtt,
+		lifecycle:        lc,
+		resourceName:     "test_app",
+		authLossNotifier: notifier,
+		authLossEvent:    &notification.Event{EventName: "test_status_offline"},
+	}
+
+	a.startAuthLossWatcher(nil)
+	defer a.stopAuthLossWatcher()
+
+	lc.SetAuthState(lifecycle.AuthStateNotAuthenticated)
+	lc.SetAuthState(lifecycle.AuthStateAuthenticated)
+	lc.SetAuthState(lifecycle.AuthStateLost)
+
+	require.Eventually(t, func() bool { return notifier.count() == 1 }, time.Second, 10*time.Millisecond,
+		"AUTHENTICATED->LOST must send exactly one notification, NA->NOT_AUTHENTICATED none")
+	assert.Equal(t, "test_status_offline", notifier.first().EventName)
+}
+
+// TestReportAuthLoss_SuppressedWhenReportingDisabled confirms the reporting gate suppresses the
+// notification (and the app-state report and telemetry emitted alongside it).
+func TestReportAuthLoss_SuppressedWhenReportingDisabled(t *testing.T) { //nolint:paralleltest
+	notifier := &fakeNotifier{}
+	a := &app{
+		mqtt:                  suite.DefaultMQTT("root_authloss_off", "", "", ""),
+		lifecycle:             lifecycle.New(nil),
+		resourceName:          "test_app",
+		authLossNotifier:      notifier,
+		authLossEvent:         &notification.Event{EventName: "test_status_offline"},
+		authLossReportEnabled: func() bool { return false },
+	}
+
+	a.reportAuthLoss(nil, "unauthorized")
+
+	assert.Zero(t, notifier.count(), "disabled auth-loss reporting must suppress the notification")
+}
+
+func TestNextAuthArm(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		armed      bool
+		state      lifecycle.State
+		wantReport bool
+		wantArmed  bool
+	}{
+		{"authenticated arms", false, lifecycle.AuthStateAuthenticated, false, true},
+		{"authenticated keeps armed", true, lifecycle.AuthStateAuthenticated, false, true},
+		{"lost while armed reports and disarms", true, lifecycle.AuthStateLost, true, false},
+		{"lost while disarmed is ignored", false, lifecycle.AuthStateLost, false, false},
+		{"not authenticated leaves arm unchanged", true, lifecycle.AuthStateNotAuthenticated, false, true},
+		{"in progress leaves arm unchanged", false, lifecycle.AuthStateInProgress, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			report, armed := nextAuthArm(tt.armed, tt.state)
+			assert.Equal(t, tt.wantReport, report)
+			assert.Equal(t, tt.wantArmed, armed)
+		})
+	}
+}
+
+func TestNextAuthArm_Sequences(t *testing.T) {
+	t.Parallel()
+
+	// A LOST only reports after an AUTHENTICATED was seen, even across an intermediate state.
+	armed := false
+	reports := 0
+	for _, s := range []lifecycle.State{
+		lifecycle.AuthStateNotAuthenticated,
+		lifecycle.AuthStateAuthenticated,
+		lifecycle.AuthStateInProgress,
+		lifecycle.AuthStateLost,
+		lifecycle.AuthStateLost, // repeated LOST must not re-fire
+	} {
+		var report bool
+		report, armed = nextAuthArm(armed, s)
+		if report {
+			reports++
+		}
+	}
+
+	assert.Equal(t, 1, reports, "one report for the armed loss, none for the repeat")
+
+	// Re-authentication re-arms, so a subsequent loss reports again.
+	_, armed = nextAuthArm(armed, lifecycle.AuthStateAuthenticated)
+	report, _ := nextAuthArm(armed, lifecycle.AuthStateLost)
+	assert.True(t, report, "a loss after re-authentication reports again")
+}

--- a/root/authloss_internal_test.go
+++ b/root/authloss_internal_test.go
@@ -141,7 +141,7 @@ func TestNextAuthArm(t *testing.T) {
 		{"authenticated keeps armed", true, lifecycle.AuthStateAuthenticated, false, true},
 		{"lost while armed reports and disarms", true, lifecycle.AuthStateLost, true, false},
 		{"lost while disarmed is ignored", false, lifecycle.AuthStateLost, false, false},
-		{"not authenticated leaves arm unchanged", true, lifecycle.AuthStateNotAuthenticated, false, true},
+		{"not authenticated disarms", true, lifecycle.AuthStateNotAuthenticated, false, false},
 		{"in progress leaves arm unchanged", false, lifecycle.AuthStateInProgress, false, false},
 	}
 

--- a/root/builder.go
+++ b/root/builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/futurehomeno/cliffhanger/bootstrap"
 	"github.com/futurehomeno/cliffhanger/discovery"
 	"github.com/futurehomeno/cliffhanger/lifecycle"
+	"github.com/futurehomeno/cliffhanger/notification"
 
 	"github.com/futurehomeno/cliffhanger/router"
 	"github.com/futurehomeno/cliffhanger/task"
@@ -34,21 +35,24 @@ func newBuilder(edge bool) *Builder {
 
 // Builder is a root app builder that helps to set up and run root application on a hub.
 type Builder struct {
-	edge               bool
-	mqtt               *fimpgo.MqttTransport
-	resourceName       fimptype.ResourceNameT
-	resourceType       fimptype.ResourceTypeT
-	packageName        string
-	instanceID         string
-	version            string
-	lifecycle          *lifecycle.Lifecycle
-	telemetry          telemetry.Telemetry
-	topicSubscriptions []string
-	routing            []*router.Routing
-	routerOptions      []router.Option
-	tasks              []*task.Task
-	services           []Service
-	resetters          []Resetter
+	edge                  bool
+	mqtt                  *fimpgo.MqttTransport
+	resourceName          fimptype.ResourceNameT
+	resourceType          fimptype.ResourceTypeT
+	packageName           string
+	instanceID            string
+	version               string
+	lifecycle             *lifecycle.Lifecycle
+	telemetry             telemetry.Telemetry
+	authLossNotifier      notification.Notification
+	authLossEvent         *notification.Event
+	authLossReportEnabled func() bool
+	topicSubscriptions    []string
+	routing               []*router.Routing
+	routerOptions         []router.Option
+	tasks                 []*task.Task
+	services              []Service
+	resetters             []Resetter
 }
 
 func (b *Builder) WithMQTT(mqtt *fimpgo.MqttTransport) *Builder {
@@ -73,6 +77,22 @@ func (b *Builder) WithLifecycle(l *lifecycle.Lifecycle) *Builder {
 
 func (b *Builder) WithTelemetry(t telemetry.Telemetry) *Builder {
 	b.telemetry = t
+	return b
+}
+
+// WithAuthLossNotification makes the app send the provided push notification event whenever
+// authorization transitions to lost. The event name is adapter-specific, e.g. "easee_status_offline".
+func (b *Builder) WithAuthLossNotification(n notification.Notification, event *notification.Event) *Builder {
+	b.authLossNotifier = n
+	b.authLossEvent = event
+	return b
+}
+
+// WithAuthLossReporting gates whether the app reports authorization loss (push
+// notification, FIMP app-state report and telemetry). enabled is evaluated at each
+// loss, so it can follow a runtime config flag. A nil enabled reports every loss.
+func (b *Builder) WithAuthLossReporting(enabled func() bool) *Builder {
+	b.authLossReportEnabled = enabled
 	return b
 }
 
@@ -133,13 +153,16 @@ func (b *Builder) doBuild() App {
 		lock:  &sync.Mutex{},
 		errCh: make(chan error),
 
-		mqtt:         b.mqtt,
-		lifecycle:    b.lifecycle,
-		telemetry:    b.telemetry,
-		resourceName: b.resourceName,
-		taskManager:  task.NewManager(b.tasks...),
-		services:     b.services,
-		resetters:    b.resetters,
+		mqtt:                  b.mqtt,
+		lifecycle:             b.lifecycle,
+		telemetry:             b.telemetry,
+		authLossNotifier:      b.authLossNotifier,
+		authLossEvent:         b.authLossEvent,
+		authLossReportEnabled: b.authLossReportEnabled,
+		resourceName:          b.resourceName,
+		taskManager:           task.NewManager(b.tasks...),
+		services:              b.services,
+		resetters:             b.resetters,
 	}
 
 	b.prepareRouting(rootApp)

--- a/storage/secrets_test.go
+++ b/storage/secrets_test.go
@@ -29,6 +29,22 @@ func TestNewSecrets_FileMode(t *testing.T) {
 	assert.NoError(t, s.Load(), "load without data and defaults should not fail")
 }
 
+func TestNewSecrets_ResetZeroesModel(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+
+	s := storage.NewSecrets(&secrets{AccessToken: "token"}, workDir, "secrets.json")
+	assert.NoError(t, s.Save())
+
+	assert.NoError(t, s.Reset())
+
+	assert.Nil(t, s.Model(), "reset must not keep serving stale credentials in memory")
+
+	_, err := os.Stat(filepath.Join(workDir, "data", "secrets.json"))
+	assert.True(t, os.IsNotExist(err), "reset must remove the persisted secrets file")
+}
+
 func TestNew_ConfigFileMode(t *testing.T) {
 	t.Parallel()
 

--- a/storage/secrets_test.go
+++ b/storage/secrets_test.go
@@ -45,6 +45,25 @@ func TestNewSecrets_ResetZeroesModel(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "reset must remove the persisted secrets file")
 }
 
+func TestNewSecrets_ResetRemovesBackup(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+
+	s := storage.NewSecrets(&secrets{AccessToken: "token"}, workDir, "secrets.json")
+	assert.NoError(t, s.Save())
+	assert.NoError(t, s.Save(), "second save creates the .bak backup of the first")
+
+	backupPath := filepath.Join(workDir, "data", "secrets.json.bak")
+	_, err := os.Stat(backupPath)
+	assert.NoError(t, err, "second save should have produced a backup file")
+
+	assert.NoError(t, s.Reset())
+
+	_, err = os.Stat(backupPath)
+	assert.True(t, os.IsNotExist(err), "reset must remove the secrets backup file")
+}
+
 func TestNew_ConfigFileMode(t *testing.T) {
 	t.Parallel()
 

--- a/storage/secrets_test.go
+++ b/storage/secrets_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/futurehomeno/cliffhanger/storage"
 )
@@ -39,10 +40,28 @@ func TestNewSecrets_ResetZeroesModel(t *testing.T) {
 
 	assert.NoError(t, s.Reset())
 
-	assert.Nil(t, s.Model(), "reset must not keep serving stale credentials in memory")
+	require.NotNil(t, s.Model(), "reset keeps a usable (non-nil) model so Load/re-persist still work")
+	assert.Empty(t, s.Model().AccessToken, "reset must clear the stored credentials in memory")
 
 	_, err := os.Stat(filepath.Join(workDir, "data", "secrets.json"))
 	assert.True(t, os.IsNotExist(err), "reset must remove the persisted secrets file")
+}
+
+func TestNewSecrets_LoadAfterResetSucceeds(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+
+	s := storage.NewSecrets(&secrets{AccessToken: "token"}, workDir, "secrets.json")
+	require.NoError(t, s.Save())
+	require.NoError(t, s.Reset())
+
+	// After reset the model must remain a valid unmarshal/mutation target — nilling it
+	// regressed re-login into a "json: Unmarshal(nil)" error (and a nil deref on SetCredentials).
+	s.Model().AccessToken = "fresh"
+	require.NoError(t, s.Save())
+	require.NoError(t, s.Load())
+	assert.Equal(t, "fresh", s.Model().AccessToken)
 }
 
 func TestNewSecrets_ResetRemovesBackup(t *testing.T) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -279,11 +280,17 @@ func (s *storage[T]) Reset() error {
 	}
 
 	if s.defaultsPath == "" {
-		// Secrets stores have no defaults to reload from; zero the in-memory model so a reset
-		// (logout) does not keep serving stale credentials via Model() until process restart.
-		var zero T
+		// Secrets stores have no defaults to reload from; clear the in-memory model so a reset
+		// (logout) does not keep serving stale credentials. Zero the pointed-to struct in place
+		// rather than nil the reference: that wipes the fields any cached pointer still holds and
+		// keeps s.model a valid (non-nil) target for a later Load() or credential re-persist.
+		if v := reflect.ValueOf(s.model); v.Kind() == reflect.Pointer && !v.IsNil() {
+			v.Elem().Set(reflect.Zero(v.Elem().Type()))
+		} else {
+			var zero T
 
-		s.model = zero
+			s.model = zero
+		}
 
 		return nil
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -279,6 +279,12 @@ func (s *storage[T]) Reset() error {
 	}
 
 	if s.defaultsPath == "" {
+		// Secrets stores have no defaults to reload from; zero the in-memory model so a reset
+		// (logout) does not keep serving stale credentials via Model() until process restart.
+		var zero T
+
+		s.model = zero
+
 		return nil
 	}
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -110,7 +110,7 @@ func RecoverAndEmit(tel Telemetry, name string, terminate bool) {
 	log.Error(r)
 }
 
-func New(mqtt *fimpgo.MqttTransport, sourceRn fimptype.ResourceNameT, store *config.DefaultStore) (Telemetry, error) {
+func New(mqtt *fimpgo.MqttTransport, sourceRn fimptype.ResourceNameT, store *config.DefaultStore, version string) (Telemetry, error) {
 	if mqtt == nil {
 		return nil, errors.New("telemetry: mqtt transport is nil")
 	}
@@ -133,6 +133,7 @@ func New(mqtt *fimpgo.MqttTransport, sourceRn fimptype.ResourceNameT, store *con
 		mqtt:     mqtt,
 		sourceRn: sourceRn,
 		store:    store,
+		version:  version,
 		topic:    telemetryReportEvtTopic,
 	}
 
@@ -156,6 +157,7 @@ type telemetryT struct {
 	mqtt     *fimpgo.MqttTransport
 	sourceRn fimptype.ResourceNameT
 	store    *config.DefaultStore
+	version  string
 
 	lock           sync.Mutex
 	topic          string
@@ -354,6 +356,13 @@ func (ptr *telemetryT) config() types.TelemetryConfig {
 func (ptr *telemetryT) publish(topic, domain, event string, data map[string]any) error {
 	if event == "" {
 		return errors.New("telemetry: event name is required")
+	}
+
+	if ptr.version != "" {
+		d := make(map[string]any, len(data)+1)
+		maps.Copy(d, data)
+		d["version"] = ptr.version
+		data = d
 	}
 
 	msg := fimpgo.NewObjectMessage(telemetryInterface, fimptype.ServiceNameT(ptr.sourceRn), &Event{

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -50,7 +50,7 @@ func stopTel(t *testing.T, tel telemetry.Telemetry) {
 }
 
 func TestNew_NilMQTT_Errors(t *testing.T) { //nolint:paralleltest
-	_, err := telemetry.New(nil, "src", newStore().DefaultStore)
+	_, err := telemetry.New(nil, "src", newStore().DefaultStore, "")
 	require.Error(t, err)
 }
 
@@ -59,7 +59,7 @@ func TestNew_EmptySource_Errors(t *testing.T) { //nolint:paralleltest
 	require.NoError(t, mqtt.Start(2*time.Second))
 	t.Cleanup(mqtt.Stop)
 
-	_, err := telemetry.New(mqtt, "", newStore().DefaultStore)
+	_, err := telemetry.New(mqtt, "", newStore().DefaultStore, "")
 	require.Error(t, err)
 }
 
@@ -68,7 +68,7 @@ func TestNew_NilStore_Errors(t *testing.T) { //nolint:paralleltest
 	require.NoError(t, mqtt.Start(2*time.Second))
 	t.Cleanup(mqtt.Stop)
 
-	_, err := telemetry.New(mqtt, "src", nil)
+	_, err := telemetry.New(mqtt, "src", nil, "")
 	require.Error(t, err)
 }
 
@@ -80,7 +80,7 @@ func TestNew_SeedsTelemetryBlock(t *testing.T) { //nolint:paralleltest
 	store := newStore()
 	assert.Nil(t, store.model.Telemetry, "no telemetry block before New")
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -96,7 +96,7 @@ func TestEnable_TogglesAndPersists(t *testing.T) { //nolint:paralleltest
 
 	store := newStore()
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -117,7 +117,7 @@ func TestEnable_RepeatedTrue_ExtendsValidityWindow(t *testing.T) { //nolint:para
 
 	store := newStore()
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -139,7 +139,7 @@ func TestSetValidity_RejectsNonPositive(t *testing.T) { //nolint:paralleltest
 	require.NoError(t, mqtt.Start(2*time.Second))
 	t.Cleanup(mqtt.Stop)
 
-	tel, err := telemetry.New(mqtt, "src", newStore().DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", newStore().DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -154,7 +154,7 @@ func TestSetValidity_PersistsAndReturned(t *testing.T) { //nolint:paralleltest
 
 	store := newStore()
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -173,7 +173,7 @@ func TestSuppressed_PersistsAndClones(t *testing.T) { //nolint:paralleltest
 
 	store := newStore()
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -210,7 +210,7 @@ func TestSuppressed_NoSuppression_ReturnsEmptyMap(t *testing.T) { //nolint:paral
 
 	store := newStore()
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -227,7 +227,7 @@ func TestServiceName_DerivedFromSource(t *testing.T) { //nolint:paralleltest
 	require.NoError(t, mqtt.Start(2*time.Second))
 	t.Cleanup(mqtt.Stop)
 
-	tel, err := telemetry.New(mqtt, "my-app", newStore().DefaultStore)
+	tel, err := telemetry.New(mqtt, "my-app", newStore().DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -241,7 +241,7 @@ func TestSaveError_PropagatesToCaller(t *testing.T) { //nolint:paralleltest
 
 	store := newStore()
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -272,7 +272,7 @@ func TestEmit_Disabled_IsDropped(t *testing.T) { //nolint:paralleltest
 	store := newStore()
 	store.model.Telemetry = &types.TelemetryConfig{Enabled: false}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -294,7 +294,7 @@ func TestEmit_SuppressedDomain_IsDropped(t *testing.T) { //nolint:paralleltest
 		Suppressed: &types.SuppressedEntry{Domains: []string{"weather"}},
 	}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -316,7 +316,7 @@ func TestEmit_SuppressedEvent_IsDropped(t *testing.T) { //nolint:paralleltest
 		Suppressed: &types.SuppressedEntry{Events: []string{"temperature"}},
 	}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -333,7 +333,7 @@ func TestEmit_EmptySuppressedEntry_DropsAll(t *testing.T) { //nolint:paralleltes
 	store := newStore()
 	store.model.Telemetry = &types.TelemetryConfig{Enabled: true, EnabledAt: time.Now(), Validity: time.Hour}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -404,7 +404,7 @@ func TestEmit_NilSuppressed_EmitsNormally(t *testing.T) { //nolint:paralleltest
 		// Suppressed nil = no suppression
 	}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -438,7 +438,7 @@ func TestEmit_DomainSuppressedThenUnsuppressed_ResumesEmitting(t *testing.T) { /
 		Suppressed: &types.SuppressedEntry{Domains: []string{"weather"}},
 	}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -475,7 +475,7 @@ func TestEmit_EnableDisableEnable_TogglesPublishing(t *testing.T) { //nolint:par
 	store := newStore()
 	store.model.Telemetry = &types.TelemetryConfig{Enabled: true, EnabledAt: time.Now(), Validity: time.Hour}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -527,7 +527,7 @@ func TestEmit_SuppressedEvent_OtherEventsInSameDomainEmit(t *testing.T) { //noli
 		Suppressed: &types.SuppressedEntry{Events: []string{"temperature"}},
 	}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -572,7 +572,7 @@ func TestEmitOnChange_ThrottlesWithinInterval(t *testing.T) { //nolint:parallelt
 	store := newStore()
 	store.model.Telemetry = &types.TelemetryConfig{Enabled: true, EnabledAt: time.Now(), Validity: time.Hour}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -609,7 +609,7 @@ func TestEmitOnChange_AllowsAfterInterval(t *testing.T) { //nolint:paralleltest
 	store := newStore()
 	store.model.Telemetry = &types.TelemetryConfig{Enabled: true, EnabledAt: time.Now(), Validity: time.Hour}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -647,7 +647,7 @@ func TestSetEvtTopic_OverrideAndDefault(t *testing.T) { //nolint:paralleltest
 	require.NoError(t, mqtt.Start(2*time.Second))
 	t.Cleanup(mqtt.Stop)
 
-	tel, err := telemetry.New(mqtt, "src", newStore().DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", newStore().DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -663,7 +663,7 @@ func TestEmit_Enabled_Publishes(t *testing.T) { //nolint:paralleltest
 	store := newStore()
 	store.model.Telemetry = &types.TelemetryConfig{Enabled: true, EnabledAt: time.Now(), Validity: time.Hour}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -680,6 +680,72 @@ func TestEmit_Enabled_Publishes(t *testing.T) { //nolint:paralleltest
 	close(got)
 }
 
+func TestEmit_StampsVersionIntoData(t *testing.T) { //nolint:paralleltest
+	mqtt := suite.DefaultMQTT("cliff_test_emit_version", "", "", "")
+	require.NoError(t, mqtt.Start(2*time.Second))
+	t.Cleanup(mqtt.Stop)
+
+	store := newStore()
+	store.model.Telemetry = &types.TelemetryConfig{Enabled: true, EnabledAt: time.Now(), Validity: time.Hour}
+
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "1.2.3")
+	require.NoError(t, err)
+	stopTel(t, tel)
+
+	customTopic := "pt:j1/mt:evt/rt:app/rn:version_test/ad:1"
+	tel.SetEvtTopic(customTopic)
+	require.NoError(t, mqtt.Subscribe(customTopic))
+
+	ch := make(fimpgo.MessageCh, 4)
+	mqtt.RegisterChannel("version_ch", ch)
+	t.Cleanup(func() { mqtt.UnregisterChannel("version_ch") })
+
+	telemetry.Emit(tel, "auth", "logged_out", map[string]any{"cause": "transition"})
+
+	select {
+	case m := <-ch:
+		var ev telemetry.Event
+		require.NoError(t, m.Payload.GetObjectValue(&ev))
+		assert.Equal(t, "1.2.3", ev.Data["version"], "version stamped into every event's data")
+		assert.Equal(t, "transition", ev.Data["cause"], "caller data preserved")
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected telemetry message not received")
+	}
+}
+
+func TestEmit_EmptyVersion_NoVersionKey(t *testing.T) { //nolint:paralleltest
+	mqtt := suite.DefaultMQTT("cliff_test_emit_no_version", "", "", "")
+	require.NoError(t, mqtt.Start(2*time.Second))
+	t.Cleanup(mqtt.Stop)
+
+	store := newStore()
+	store.model.Telemetry = &types.TelemetryConfig{Enabled: true, EnabledAt: time.Now(), Validity: time.Hour}
+
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
+	require.NoError(t, err)
+	stopTel(t, tel)
+
+	customTopic := "pt:j1/mt:evt/rt:app/rn:no_version_test/ad:1"
+	tel.SetEvtTopic(customTopic)
+	require.NoError(t, mqtt.Subscribe(customTopic))
+
+	ch := make(fimpgo.MessageCh, 4)
+	mqtt.RegisterChannel("no_version_ch", ch)
+	t.Cleanup(func() { mqtt.UnregisterChannel("no_version_ch") })
+
+	telemetry.Emit(tel, "auth", "logged_out", map[string]any{"cause": "x"})
+
+	select {
+	case m := <-ch:
+		var ev telemetry.Event
+		require.NoError(t, m.Payload.GetObjectValue(&ev))
+		_, ok := ev.Data["version"]
+		assert.False(t, ok, "no version key when version is empty")
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected telemetry message not received")
+	}
+}
+
 func TestEnable_TinyValidity_TimerDisables(t *testing.T) { //nolint:paralleltest
 	mqtt := suite.DefaultMQTT("cliff_test_tiny_validity", "", "", "")
 	require.NoError(t, mqtt.Start(2*time.Second))
@@ -688,7 +754,7 @@ func TestEnable_TinyValidity_TimerDisables(t *testing.T) { //nolint:paralleltest
 	store := newStore()
 	store.model.Telemetry = &types.TelemetryConfig{Enabled: true, EnabledAt: time.Now(), Validity: 50 * time.Millisecond}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -712,7 +778,7 @@ func TestSetValidity_BelowElapsed_DisablesImmediately(t *testing.T) { //nolint:p
 		Validity:  24 * time.Hour,
 	}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -732,7 +798,7 @@ func TestResumeValidityWindow_ExpiredBeforeStartup_DisablesAtBoot(t *testing.T) 
 		Validity:  time.Hour,
 	}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -751,7 +817,7 @@ func TestResumeValidityWindow_ClockSkew_NormalizesToNow(t *testing.T) { //nolint
 		Validity:  time.Hour,
 	}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 
@@ -769,7 +835,7 @@ func TestRouting_EnabledRoundTrip(t *testing.T) { //nolint:paralleltest
 				Setup: suite.BaseSetup(func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
 					t.Helper()
 
-					tel, err := telemetry.New(mqtt, "tel_test", store.DefaultStore)
+					tel, err := telemetry.New(mqtt, "tel_test", store.DefaultStore, "")
 					require.NoError(t, err)
 					stopTel(t, tel)
 
@@ -813,7 +879,7 @@ func TestRouting_ValidityRoundTrip(t *testing.T) { //nolint:paralleltest
 				Setup: suite.BaseSetup(func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
 					t.Helper()
 
-					tel, err := telemetry.New(mqtt, "tel_validity", store.DefaultStore)
+					tel, err := telemetry.New(mqtt, "tel_validity", store.DefaultStore, "")
 					require.NoError(t, err)
 					stopTel(t, tel)
 
@@ -855,7 +921,7 @@ func TestRouting_SuppressedGet(t *testing.T) { //nolint:paralleltest
 				Setup: suite.BaseSetup(func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
 					t.Helper()
 
-					tel, err := telemetry.New(mqtt, "tel_supp_get", store.DefaultStore)
+					tel, err := telemetry.New(mqtt, "tel_supp_get", store.DefaultStore, "")
 					require.NoError(t, err)
 					stopTel(t, tel)
 
@@ -902,7 +968,7 @@ func TestRouting_SetTelemetry_PersistsToStore(t *testing.T) { //nolint:parallelt
 				Setup: suite.BaseSetup(func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
 					t.Helper()
 
-					tel, err := telemetry.New(mqtt, "tel_persist", store.DefaultStore)
+					tel, err := telemetry.New(mqtt, "tel_persist", store.DefaultStore, "")
 					require.NoError(t, err)
 					stopTel(t, tel)
 
@@ -993,7 +1059,7 @@ func TestRouting_SetTelemetry_UpdatesConfiguredAt(t *testing.T) { //nolint:paral
 				Setup: suite.BaseSetup(func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
 					t.Helper()
 
-					tel, err := telemetry.New(mqtt, "tel_cfg_at", store)
+					tel, err := telemetry.New(mqtt, "tel_cfg_at", store, "")
 					require.NoError(t, err)
 					stopTel(t, tel)
 
@@ -1053,7 +1119,7 @@ func setupTelChannel(t *testing.T, name string) (telemetry.Telemetry, fimpgo.Mes
 	store := newStore()
 	store.model.Telemetry = &types.TelemetryConfig{Enabled: true, EnabledAt: time.Now(), Validity: time.Hour}
 
-	tel, err := telemetry.New(mqtt, "src", store.DefaultStore)
+	tel, err := telemetry.New(mqtt, "src", store.DefaultStore, "")
 	require.NoError(t, err)
 	stopTel(t, tel)
 


### PR DESCRIPTION
Fixes 4 review findings surfaced on #197 (develop→main), all in the merged develop code.

- **P1** [Direct Check can still run after a racing Cancel](https://github.com/futurehomeno/cliffhanger/pull/197#discussion_r3616564512) — `app/check.go`: `cancelled` is now external-only (`settle()` for post-probe cleanup), so a logout/reset `Cancel()` racing a periodic `Check()` is not overwritten; `CheckNow` resumes.
- **P2** [Secret stores keep stale credentials in memory after Reset](https://github.com/futurehomeno/cliffhanger/pull/197#discussion_r3610402002) — `storage/storage.go`: zero the model on reset of a defaults-less (secrets) store.
- **P2** [Reset leaves a half-reset app when config reset fails](https://github.com/futurehomeno/cliffhanger/pull/197#discussion_r3613602983) — `app/flow.go`: mark NOT_CONFIGURED before the destructive steps and join their errors.
- **P3** [Retry-After parsing allows arbitrarily large delay values](https://github.com/futurehomeno/cliffhanger/pull/197#discussion_r3616702841) — `httpclient/errors.go`: clamp Retry-After (with overflow guard) to a 1h ceiling.

Each fix has a test. `go vet`, `golangci-lint` (0 issues) and `-race` tests pass on the touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)