### PR TITLE
test: cover RouteApp auth default and direct EnsureThings resync reports

### DIFF
--- a/adapter/sync_report_test.go
+++ b/adapter/sync_report_test.go
@@ -1,0 +1,208 @@
+package adapter_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/futurehomeno/fimpgo"
+	"github.com/futurehomeno/fimpgo/fimptype"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/adapter"
+	"github.com/futurehomeno/cliffhanger/router"
+	"github.com/futurehomeno/cliffhanger/task"
+	adapterhelper "github.com/futurehomeno/cliffhanger/test/helper/adapter"
+	mockedadapter "github.com/futurehomeno/cliffhanger/test/mocks/adapter"
+	"github.com/futurehomeno/cliffhanger/test/suite"
+)
+
+// seedByID maps a device to a seed whose address equals its ID, so sync-created things land
+// at predictable addresses the report matchers can assert on.
+func seedByID(d device) *adapter.ThingSeed {
+	return &adapter.ThingSeed{ID: d.ID, CustomAddress: d.ID, Info: d.Name}
+}
+
+func syncReportSetup(ad *adapter.Adapter, seeds adapter.ThingSeeds) suite.BaseSetup {
+	return func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
+		t.Helper()
+
+		factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, ts adapter.ThingState) (adapter.Thing, error) {
+			cfg := &adapter.ThingConfig{
+				InclusionReport: &fimptype.ThingInclusionReport{Address: ts.Address()},
+				Connector:       mockedadapter.NewDefaultConnector(t),
+			}
+
+			return adapter.NewThing(publisher, ts, cfg), nil
+		})
+
+		*ad = adapterhelper.PrepareSeededAdapter(t, testAdapterWorkDir, mqtt, factory, seeds)
+
+		return adapter.RouteAdapter(*ad), nil, nil
+	}
+}
+
+func TestSyncThings_AddsDeviceAndSendsInclusionReport(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	// Three devices are already registered; a fourth appears in the fetched list.
+	seeds := adapter.ThingSeeds{seedByID(device{ID: "1"}), seedByID(device{ID: "2"}), seedByID(device{ID: "3"})}
+	available := []device{{"1", "a"}, {"2", "b"}, {"3", "c"}, {"4", "d"}}
+
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "a new fetched device is added and announced",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    syncReportSetup(&ad, seeds),
+				Nodes: []*suite.Node{
+					{
+						Name:    "syncing four devices over three creates the fourth and sends its inclusion report",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							assert.Nil(t, ad.ThingByID("4"), "device 4 must not exist before the sync")
+							assert.NoError(t, adapter.SyncThings(ad, available, []string{"1", "2", "3", "4"}, seedByID))
+							assert.NotNil(t, ad.ThingByID("4"), "device 4 must be registered after the sync")
+						}},
+						Expectations: []*suite.Expectation{
+							expectInclusion("4").AtLeastOnce(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func TestSyncThings_RemovesDeviceAndSendsExclusionReport(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	// Four devices are registered; the fetched list drops the fourth (genuinely deselected).
+	seeds := adapter.ThingSeeds{
+		seedByID(device{ID: "1"}), seedByID(device{ID: "2"}), seedByID(device{ID: "3"}), seedByID(device{ID: "4"}),
+	}
+	available := []device{{"1", "a"}, {"2", "b"}, {"3", "c"}}
+
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "a dropped device is destroyed and announced",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    syncReportSetup(&ad, seeds),
+				Nodes: []*suite.Node{
+					{
+						Name:    "syncing three devices over four destroys the fourth and sends its exclusion report",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							assert.NotNil(t, ad.ThingByID("4"), "device 4 must exist before the sync")
+							assert.NoError(t, adapter.SyncThings(ad, available, []string{"1", "2", "3"}, seedByID))
+							assert.Nil(t, ad.ThingByID("4"), "device 4 must be removed after the sync")
+						}},
+						Expectations: []*suite.Expectation{
+							expectExclusion("4").ExactlyOnce(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func TestEnsureThings_AddsDeviceAndSendsInclusionReport(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	// Three devices registered; EnsureThings is called directly with a fourth seed added.
+	seeds := adapter.ThingSeeds{seedByID(device{ID: "1"}), seedByID(device{ID: "2"}), seedByID(device{ID: "3"})}
+	withFourth := adapter.ThingSeeds{
+		seedByID(device{ID: "1"}), seedByID(device{ID: "2"}), seedByID(device{ID: "3"}), seedByID(device{ID: "4"}),
+	}
+
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "EnsureThings creates a missing thing and announces it",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    syncReportSetup(&ad, seeds),
+				Nodes: []*suite.Node{
+					{
+						Name:    "an extra seed creates the fourth thing and sends its inclusion report",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							assert.Nil(t, ad.ThingByID("4"), "device 4 must not exist before EnsureThings")
+							assert.NoError(t, ad.EnsureThings(withFourth))
+							assert.NotNil(t, ad.ThingByID("4"), "device 4 must be registered after EnsureThings")
+						}},
+						Expectations: []*suite.Expectation{
+							expectInclusion("4").AtLeastOnce(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func TestEnsureThings_RemovesDeviceAndSendsExclusionReport(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	// Four devices registered; EnsureThings is called directly with the fourth seed dropped.
+	seeds := adapter.ThingSeeds{
+		seedByID(device{ID: "1"}), seedByID(device{ID: "2"}), seedByID(device{ID: "3"}), seedByID(device{ID: "4"}),
+	}
+	withoutFourth := adapter.ThingSeeds{seedByID(device{ID: "1"}), seedByID(device{ID: "2"}), seedByID(device{ID: "3"})}
+
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "EnsureThings destroys a stale thing and announces it",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    syncReportSetup(&ad, seeds),
+				Nodes: []*suite.Node{
+					{
+						Name:    "a dropped seed destroys the fourth thing and sends its exclusion report",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							assert.NotNil(t, ad.ThingByID("4"), "device 4 must exist before EnsureThings")
+							assert.NoError(t, ad.EnsureThings(withoutFourth))
+							assert.Nil(t, ad.ThingByID("4"), "device 4 must be removed after EnsureThings")
+						}},
+						Expectations: []*suite.Expectation{
+							expectExclusion("4").ExactlyOnce(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func expectInclusion(address string) *suite.Expectation {
+	return suite.NewExpectation().
+		ExpectTopic(testAdapterEvtTopic).
+		ExpectType(adapter.EvtThingInclusionReport).
+		ExpectService(testAdapterName).
+		Expect(router.MessageVoterFn(func(m *fimpgo.Message) bool {
+			var report fimptype.ThingInclusionReport
+
+			if err := m.Payload.GetObjectValue(&report); err != nil {
+				return false
+			}
+
+			return report.Address == address
+		}))
+}

--- a/app/routing_test.go
+++ b/app/routing_test.go
@@ -9,8 +9,81 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/futurehomeno/cliffhanger/app"
+	"github.com/futurehomeno/cliffhanger/auth"
 	"github.com/futurehomeno/cliffhanger/lifecycle"
+	"github.com/futurehomeno/cliffhanger/manifest"
+	"github.com/futurehomeno/cliffhanger/router"
+	"github.com/futurehomeno/cliffhanger/storage"
 )
+
+type stubConfig struct{}
+
+// stubAuthApp implements app.App + app.AuthorizableApp (OAuth2). Handlers are never invoked in
+// these tests — only RouteApp's build-time auth-state default is exercised.
+type stubAuthApp struct{}
+
+func (stubAuthApp) GetManifest() (*manifest.Manifest, error)  { return &manifest.Manifest{}, nil }
+func (stubAuthApp) Configure(any) error                       { return nil }
+func (stubAuthApp) Uninstall() error                          { return nil }
+func (stubAuthApp) Logout() error                             { return nil }
+func (stubAuthApp) Authorize(*auth.OAuth2TokenResponse) error { return nil }
+func (stubAuthApp) ErrorsReport() ([]string, error)           { return nil, nil }
+
+// stubLoginApp implements app.App + app.LogginableApp (password/token) — NOT AuthorizableApp.
+type stubLoginApp struct{}
+
+func (stubLoginApp) GetManifest() (*manifest.Manifest, error) { return &manifest.Manifest{}, nil }
+func (stubLoginApp) Configure(any) error                      { return nil }
+func (stubLoginApp) Uninstall() error                         { return nil }
+func (stubLoginApp) Logout() error                            { return nil }
+func (stubLoginApp) Login(*app.LoginCredentials) error        { return nil }
+func (stubLoginApp) ErrorsReport() ([]string, error)          { return nil, nil }
+
+func TestRouteApp_DefaultsAuthorizableAppToNotAuthenticated(t *testing.T) {
+	t.Parallel()
+
+	build := func(t *testing.T, application app.App, lc *lifecycle.Lifecycle) {
+		t.Helper()
+
+		st := storage.New(&stubConfig{}, t.TempDir(), "config.json")
+
+		app.RouteApp[*stubConfig](
+			testDiagService, lc, st,
+			func() *stubConfig { return &stubConfig{} },
+			router.NewMessageHandlerLocker(),
+			application,
+			func() error { return nil },
+		)
+	}
+
+	t.Run("authorizable app left undecided defaults to not authenticated", func(t *testing.T) {
+		t.Parallel()
+
+		lc := lifecycle.New(nil) // auth starts at NA
+		build(t, stubAuthApp{}, lc)
+
+		assert.Equal(t, lifecycle.AuthStateNotAuthenticated, lc.AuthState())
+	})
+
+	t.Run("authorizable app already authenticated is left untouched", func(t *testing.T) {
+		t.Parallel()
+
+		lc := lifecycle.New(nil)
+		lc.SetAuthState(lifecycle.AuthStateAuthenticated) // adapter loaded creds in Initialize
+		build(t, stubAuthApp{}, lc)
+
+		assert.Equal(t, lifecycle.AuthStateAuthenticated, lc.AuthState())
+	})
+
+	t.Run("login-only app is not defaulted, the fallback is OAuth2-only", func(t *testing.T) {
+		t.Parallel()
+
+		lc := lifecycle.New(nil)
+		build(t, stubLoginApp{}, lc)
+
+		assert.Equal(t, lifecycle.AuthStateNA, lc.AuthState())
+	})
+}
 
 const testDiagService = "test_app"
 


### PR DESCRIPTION
Test-only additions from a coverage audit — no production changes.

- **app/routing_test.go** — `TestRouteApp_DefaultsAuthorizableAppToNotAuthenticated`: RouteApp defaults an authorizable (OAuth2) app left at `AuthStateNA` to `NotAuthenticated`, leaves an already-authenticated app untouched, and does **not** default a login-only app (documents that the fallback is OAuth2-only and state-based, not credential-based).
- **adapter/sync_report_test.go** — `TestEnsureThings_AddsDeviceAndSendsInclusionReport` / `...RemovesDeviceAndSendsExclusionReport`: exercise `EnsureThings` **directly** for add→inclusion_report and remove→exclusion_report, covering the base primitive independently of the `SyncThings` wrapper (whose tests are also in this file).

`go vet`, `golangci-lint` (0 issues), and the tests pass (adapter suite uses the local MQTT broker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)