### PR TITLE
Add app.NewLogCapture to enclose the diag error-log hook

### DIFF
--- a/app/logcapture.go
+++ b/app/logcapture.go
@@ -1,0 +1,16 @@
+package app
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/futurehomeno/cliffhanger/debug/formatters"
+)
+
+// NewLogCapture registers a warn+ ring-buffer hook on the global logger and
+// returns it as a LogProvider to embed in an app, backing cmd.app.get_diag.
+func NewLogCapture() LogProvider {
+	hook := formatters.NewErrorHook()
+	log.AddHook(hook)
+
+	return hook
+}

--- a/app/logcapture_test.go
+++ b/app/logcapture_test.go
@@ -1,0 +1,37 @@
+package app_test
+
+import (
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/futurehomeno/cliffhanger/app"
+)
+
+// TestNewLogCapture_CapturesGlobalWarnings verifies the returned provider is
+// wired to the global logger — the one behaviour the compiler can't enforce.
+// No t.Parallel: the logrus hook stays registered process-wide.
+func TestNewLogCapture_CapturesGlobalWarnings(t *testing.T) {
+	provider := app.NewLogCapture()
+	require.NotNil(t, provider)
+
+	const sentinel = "logcapture wiring sentinel 4f2a"
+	log.Warn(sentinel)
+
+	entries, err := provider.ErrorsReport()
+	require.NoError(t, err)
+
+	found := false
+	for _, e := range entries {
+		if strings.Contains(e, sentinel) {
+			found = true
+
+			break
+		}
+	}
+
+	assert.True(t, found, "global warning should be captured by the returned provider")
+}


### PR DESCRIPTION
## What

Adds `app.NewLogCapture()` — a one-liner that creates the `formatters.ErrorHook`, registers it on the global logger via `log.AddHook`, and returns it as an `app.LogProvider`.

## Why

Every adapter backing `cmd.app.get_diag` currently repeats the same plumbing: create the hook, `log.AddHook` it, store it in a field, and forward `ErrorsReport()` to satisfy `app.LogProvider`. This folds the create+register step into cliffhanger so an app can enclose it by embedding a single field:

```go
type application struct {
	app.LogProvider
	...
}

func New(...) App {
	return &application{ LogProvider: app.NewLogCapture(), ... }
}
```

That drops the `formatters` import, the `hook := …` / `log.AddHook` lines, the hook field, and the `ErrorsReport` forwarding method from each adapter — while keeping the existing `LogProvider` compile contract intact (the embedded field still satisfies it).

## Notes

- Additive and non-breaking: no change to `app.App` or `RouteApp`.
- Adapter rewire (edge-tibber-adapter) is intentionally **not** in this PR; it can adopt `NewLogCapture` once a cliffhanger release carries this helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)