### PR TITLE
Add wiring test for app.NewLogCapture

### DIFF
--- a/app/logcapture_test.go
+++ b/app/logcapture_test.go
@@ -1,0 +1,37 @@
+package app_test
+
+import (
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/futurehomeno/cliffhanger/app"
+)
+
+// TestNewLogCapture_CapturesGlobalWarnings verifies the returned provider is
+// wired to the global logger — the one behaviour the compiler can't enforce.
+// No t.Parallel: the logrus hook stays registered process-wide.
+func TestNewLogCapture_CapturesGlobalWarnings(t *testing.T) {
+	provider := app.NewLogCapture()
+	require.NotNil(t, provider)
+
+	const sentinel = "logcapture wiring sentinel 4f2a"
+	log.Warn(sentinel)
+
+	entries, err := provider.ErrorsReport()
+	require.NoError(t, err)
+
+	found := false
+	for _, e := range entries {
+		if strings.Contains(e, sentinel) {
+			found = true
+
+			break
+		}
+	}
+
+	assert.True(t, found, "global warning should be captured by the returned provider")
+}


### PR DESCRIPTION
## What

Adds `TestNewLogCapture_CapturesGlobalWarnings` — verifies the `LogProvider` returned by `NewLogCapture()` is actually registered on the global logrus logger: a warning logged after construction surfaces in `ErrorsReport()`.

## Why

Addresses the PR #209 review finding [P3 - No unit tests for NewLogCapture](https://github.com/futurehomeno/cliffhanger/pull/209#discussion_r3618002891). The `LogProvider` interface contract is already compile-enforced (the function returns `LogProvider`), so the test targets only the one behaviour the compiler can't verify — the global-logger wiring.

## Notes

- Targets `feat/app-log-capture` so the test flows into PR #209.
- No `t.Parallel()`: the logrus hook stays registered process-wide; the test uses a unique sentinel and asserts on that alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)