### PR TITLE
Lazy ProxyClient endpoint and builder-sourced telemetry version

### DIFF
--- a/auth/client.go
+++ b/auth/client.go
@@ -20,10 +20,16 @@ type ProxyClientConfig struct {
 	PartnerCode string
 	Token       string
 	URL         string
-	Retry       int
-	RetryDelay  time.Duration
-	Timeout     time.Duration
-	Headers     map[string]string
+	// Endpoint, when set, resolves the base URL and bearer token per exchange instead of using
+	// the static URL/Token. It lets adapters whose proxy URL or hub token is only known at call
+	// time (e.g. resolved from the hub environment and a rotating hub token) use ProxyClient
+	// without a bespoke exchanger. A returned error fails the exchange. URL/Token are ignored
+	// when Endpoint is set.
+	Endpoint   func() (baseURL, token string, err error)
+	Retry      int
+	RetryDelay time.Duration
+	Timeout    time.Duration
+	Headers    map[string]string
 }
 
 func (cfg *ProxyClientConfig) setDefaults() {
@@ -70,28 +76,43 @@ type proxyClient struct {
 func (c *proxyClient) ExchangeAuthorizationCode(code string) (*OAuth2TokenResponse, error) {
 	request := &OAuth2AuthCodeProxyRequest{AuthCode: code, PartnerCode: c.cfg.PartnerCode}
 
-	return c.getToken(request, c.cfg.URL+"/api/control/edge/proxy/auth-code")
+	return c.getToken(request, "/api/control/edge/proxy/auth-code")
 }
 
 func (c *proxyClient) ExchangeRefreshToken(refreshToken string) (*OAuth2TokenResponse, error) {
 	request := OAuth2RefreshProxyRequest{RefreshToken: refreshToken, PartnerCode: c.cfg.PartnerCode}
 
-	return c.getToken(request, c.cfg.URL+"/api/control/edge/proxy/refresh")
+	return c.getToken(request, "/api/control/edge/proxy/refresh")
 }
 
-func (c *proxyClient) getToken(request any, url string) (*OAuth2TokenResponse, error) {
+// endpoint resolves the base URL and bearer token for one exchange, lazily via cfg.Endpoint
+// when set, otherwise from the static cfg.URL/cfg.Token.
+func (c *proxyClient) endpoint() (baseURL, token string, err error) {
+	if c.cfg.Endpoint != nil {
+		return c.cfg.Endpoint()
+	}
+
+	return c.cfg.URL, c.cfg.Token, nil
+}
+
+func (c *proxyClient) getToken(request any, path string) (*OAuth2TokenResponse, error) {
+	baseURL, token, err := c.endpoint()
+	if err != nil {
+		return nil, fmt.Errorf("proxy proxyClient: failed to resolve endpoint: %w", err)
+	}
+
 	requestData, err := json.Marshal(request)
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewBuffer(requestData))
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodPost, baseURL+path, bytes.NewBuffer(requestData))
 	if err != nil {
 		return nil, fmt.Errorf("proxy proxyClient: failed to create request: %w", err)
 	}
 
 	r.Header.Add("Content-Type", "application/json")
-	r.Header.Add("Authorization", "Bearer "+c.cfg.Token)
+	r.Header.Add("Authorization", "Bearer "+token)
 
 	for k, v := range c.cfg.Headers {
 		if http.CanonicalHeaderKey(k) == "Authorization" || http.CanonicalHeaderKey(k) == "Content-Type" {

--- a/auth/client_test.go
+++ b/auth/client_test.go
@@ -44,6 +44,51 @@ func TestProxyClient_RetryResendsBody(t *testing.T) {
 	assert.Equal(t, bodies[0], bodies[1], "retry must resend the full request body")
 }
 
+func TestProxyClient_EndpointResolvesURLAndTokenPerExchange(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth, gotPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+
+		_, err := w.Write([]byte(`{"access_token":"token","expires_in":3600}`))
+		assert.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	calls := 0
+	client := auth.NewProxyClient(&auth.ProxyClientConfig{
+		// URL/Token are intentionally bogus: Endpoint must take precedence.
+		URL:   "http://unused.invalid",
+		Token: "unused",
+		Endpoint: func() (string, string, error) {
+			calls++
+
+			return srv.URL, "hub-token", nil
+		},
+	})
+
+	response, err := client.ExchangeRefreshToken("refresh")
+	assert.NoError(t, err)
+	assert.Equal(t, "token", response.AccessToken)
+	assert.Equal(t, 1, calls, "Endpoint is resolved once per exchange")
+	assert.Equal(t, "Bearer hub-token", gotAuth)
+	assert.Equal(t, "/api/control/edge/proxy/refresh", gotPath)
+}
+
+func TestProxyClient_EndpointErrorFailsExchange(t *testing.T) {
+	t.Parallel()
+
+	client := auth.NewProxyClient(&auth.ProxyClientConfig{
+		Endpoint: func() (string, string, error) { return "", "", assert.AnError },
+	})
+
+	_, err := client.ExchangeRefreshToken("refresh")
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
 func TestProxyClient_RateLimitedExchangeIsNotRetried(t *testing.T) {
 	t.Parallel()
 

--- a/root/builder.go
+++ b/root/builder.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 
@@ -10,6 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/futurehomeno/cliffhanger/bootstrap"
+	"github.com/futurehomeno/cliffhanger/config"
 	"github.com/futurehomeno/cliffhanger/discovery"
 	"github.com/futurehomeno/cliffhanger/lifecycle"
 	"github.com/futurehomeno/cliffhanger/notification"
@@ -44,6 +46,7 @@ type Builder struct {
 	version               string
 	lifecycle             *lifecycle.Lifecycle
 	telemetry             telemetry.Telemetry
+	telemetryStore        *config.DefaultStore
 	authLossNotifier      notification.Notification
 	authLossEvent         *notification.Event
 	authLossReportEnabled func() bool
@@ -77,6 +80,15 @@ func (b *Builder) WithLifecycle(l *lifecycle.Lifecycle) *Builder {
 
 func (b *Builder) WithTelemetry(t telemetry.Telemetry) *Builder {
 	b.telemetry = t
+	return b
+}
+
+// WithTelemetryStore builds telemetry from the given store at Build time, stamping every event
+// with the version passed to WithServiceDiscovery. It keeps the version single-sourced in the
+// builder, unlike WithTelemetry which requires the caller to construct telemetry (and repeat the
+// version) itself. WithTelemetry, when set, takes precedence.
+func (b *Builder) WithTelemetryStore(store *config.DefaultStore) *Builder {
+	b.telemetryStore = store
 	return b
 }
 
@@ -129,6 +141,15 @@ func (b *Builder) WithResetter(resetter ...Resetter) *Builder {
 func (b *Builder) Build() (App, error) {
 	if err := b.check(); err != nil {
 		return nil, err
+	}
+
+	if b.telemetry == nil && b.telemetryStore != nil {
+		t, err := telemetry.New(b.mqtt, b.resourceName, b.telemetryStore, b.version)
+		if err != nil {
+			return nil, fmt.Errorf("builder: build telemetry: %w", err)
+		}
+
+		b.telemetry = t
 	}
 
 	return b.doBuild(), nil

--- a/root/builder_test.go
+++ b/root/builder_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/futurehomeno/cliffhanger/config"
 	"github.com/futurehomeno/cliffhanger/discovery"
 	"github.com/futurehomeno/cliffhanger/lifecycle"
 	"github.com/futurehomeno/cliffhanger/root"
@@ -86,4 +88,23 @@ func TestBuilder_Build(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuilder_WithTelemetryStore verifies the builder constructs telemetry from the store,
+// sourcing the version from WithServiceDiscovery so it is not duplicated at the call site.
+func TestBuilder_WithTelemetryStore(t *testing.T) {
+	t.Parallel()
+
+	mqtt := suite.DefaultMQTT("root_app_builder_telemetry", "", "", "")
+	cfg := &config.Default{}
+	store := config.NewDefaultStore(func() *config.Default { return cfg }, func() error { return nil })
+
+	app, err := root.NewCoreAppBuilder().
+		WithMQTT(mqtt).
+		WithServiceDiscovery("test_app", discovery.ResourceTypeApp, "test_app", "1", "1.2.3").
+		WithTelemetryStore(store).
+		Build()
+
+	require.NoError(t, err)
+	assert.NotNil(t, app)
 }


### PR DESCRIPTION
Follow-up proposals from the PR #197 integration review. The two concrete defects that review
found (auth-loss watcher seed race, `Retry-After` overflow) already landed on `develop` via #207,
so this PR carries the two remaining, additive improvements an adapter hits when adopting the
shared surfaces.

## Changes

**`auth.ProxyClient` — lazy endpoint resolution**
`ProxyClientConfig` gains an optional `Endpoint func() (baseURL, token string, err error)` that
resolves the base URL and bearer token *per exchange* instead of using the static `URL`/`Token`.
Adapters whose proxy URL or hub token is only known at call time — e.g. resolved from the hub
environment and a rotating hub token — can now use `ProxyClient` directly instead of writing a
bespoke `TokenExchanger`. `Endpoint` is nil by default, preserving the static behaviour exactly.

**`root.Builder` — builder-sourced telemetry version**
`WithTelemetryStore(store)` constructs telemetry at `Build` time from the store and the version
already passed to `WithServiceDiscovery`, keeping the version single-sourced in the builder.
Previously `WithTelemetry` required the caller to build telemetry (and repeat the version)
themselves, so the version added to `telemetry.New` was effectively dead through the builder path.
`WithTelemetry` still takes precedence when both are set.

Both are additive and covered by new tests (`auth/client_test.go`, `root/builder_test.go`).

## Not included
Minor review nits left for discussion rather than changed here: telemetry per-event map alloc,
and the "secret zeroing" doc caveat (Go strings are immutable; the real protection is the file
mode). Happy to fold in if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)