### PR TITLE
Introduce selected devices concept, harden thing sync

### DIFF
--- a/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
@@ -83,7 +83,7 @@ hand-rolled code did. Diff a captured inclusion report + evt stream before/after
    `adapter.SeedsFromSelection` + `adapter.SyncThings` (the fetch is owned by the sync, so a
    failed fetch mutates nothing); replace a hand-rolled capability-drift rebuild (sensibo
    `reconcile.go`) with `adapter.RebuildChangedThings`; store the user's device selection in
-   `selection.Devices` and wire `adapter.WithSelectionRemover` so `cmd.thing.delete` deselects
+   `selection.Devices` and wire `adapter.WithSelection` so `cmd.thing.delete` deselects
    the device it deletes. (refs §7, worked recipe and its two hazards in §7.1)
 
 8. **Adopt the remaining blocks where they apply:** `stream.Supervisor` for a push transport's

--- a/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
@@ -84,7 +84,7 @@ hand-rolled code did. Diff a captured inclusion report + evt stream before/after
    failed fetch mutates nothing); replace a hand-rolled capability-drift rebuild (sensibo
    `reconcile.go`) with `adapter.RebuildChangedThings`; store the user's device selection in
    `selection.Devices` and wire `adapter.WithSelectionRemover` so `cmd.thing.delete` deselects
-   the device it deletes. (refs §7)
+   the device it deletes. (refs §7, worked recipe and its two hazards in §7.1)
 
 8. **Adopt the remaining blocks where they apply:** `stream.Supervisor` for a push transport's
    reconnect/backoff lifecycle (easee SignalR, sonos GENA, zaptec AMQP) via a `root.Service`;

--- a/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
@@ -80,9 +80,11 @@ hand-rolled code did. Diff a captured inclusion report + evt stream before/after
    `MarkNotConfigured()` (cloud-auth adapters only; apps at `AuthStateNA`/`ConnStateNA` set states
    individually) and `SetConnAndAuthState` for atomic auth-loss bundles instead of four separate
    setters. Replace the fetch→filter→map→`EnsureThings` wrapper with
-   `adapter.SeedsFromSelection` + `adapter.SyncThings` (shared anti-wipe guard,
-   `ErrIncompleteFetch`); replace a hand-rolled capability-drift rebuild (sensibo `reconcile.go`)
-   with `adapter.RebuildChangedThings`. (refs §7)
+   `adapter.SeedsFromSelection` + `adapter.SyncThings` (the fetch is owned by the sync, so a
+   failed fetch mutates nothing); replace a hand-rolled capability-drift rebuild (sensibo
+   `reconcile.go`) with `adapter.RebuildChangedThings`; store the user's device selection in
+   `selection.Devices` and wire `adapter.WithSelectionRemover` so `cmd.thing.delete` deselects
+   the device it deletes. (refs §7)
 
 8. **Adopt the remaining blocks where they apply:** `stream.Supervisor` for a push transport's
    reconnect/backoff lifecycle (easee SignalR, sonos GENA, zaptec AMQP) via a `root.Service`;

--- a/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
@@ -29,7 +29,7 @@ The change landed in four "waves":
 | `lifecycle.MarkRunning/MarkNotConfigured` + `SetConnAndAuthState` | state-bundle helpers; atomic conn+auth in one event | four separate `Set*State` calls |
 | `storage.NewSecrets/NewCanonicalSecrets` | `Storage[T]` at 0640 (edge: `data/secrets.json`; canonical/core: `workDir/<name>`) | credentials living in world-readable `config.json` |
 | `stream.Supervisor` | `NewSupervisor(connect Connection, b backoff.Stateful)` → `Start()/Stop()/TriggerReconnect()` | bespoke SignalR/GENA/AMQP reconnect loops |
-| `adapter.SeedsFromSelection` + `SyncThings` + `RebuildChangedThings` | `SeedsFromSelection[T](available, selected, seed)`, `SyncThings[T](a, available, selected, seed) (ErrIncompleteFetch)`, `RebuildChangedThings(seeds)` | fetch→filter→map→EnsureThings wrapper, anti-wipe guard, sensibo `reconcile.go` |
+| `adapter.SeedsFromSelection` + `SyncThings` + `RebuildChangedThings`, `selection` | `SeedsFromSelection[T](available, selected, seed)`, `SyncThings[T](a, fetch, selected, seed) (ThingSeeds, error)`, `RebuildChangedThings(seeds)`, `selection.Devices`/`Store`/`PrepareManifest`, `adapter.WithSelectionRemover` | fetch→filter→map→EnsureThings wrapper, sensibo `reconcile.go`, per-adapter `selected_devices` plumbing and `cmd.thing.delete` route |
 | `bootstrap.EdgeRouting/EdgeTasks` | `EdgeRouting[C](...)`, `EdgeTasks(...)` bundles | repeated builder wiring |
 | `router.DefaultLogStats` | `DefaultLogStats(redactedInterfacePrefixes ...string) func(Stats)` | per-adapter `LogStats` with `cmd.auth.` masking |
 | `backoff.NewTolerantFixed` | `(tolerance uint32, delay time.Duration) Stateful` | fixed-after-N-tolerated backoff presets |
@@ -205,15 +205,28 @@ backed by this secrets storage.
   use it on auth-loss so a watcher never sees `LOST` with a stale connection state (#198/#200). The
   ConnectivityChecker already uses it internally.
 - **`adapter.SeedsFromSelection[T](available, selected, seed)`** builds `ThingSeeds` from a fetched
-  list filtered to the user's selection.
-- **`adapter.SyncThings[T](a, available, selected, seed)`** = SeedsFromSelection + `EnsureThings`
-  with a shared anti-wipe guard: returns `ErrIncompleteFetch` (non-fatal; log-and-retry) instead of
-  destroying live things when a registered selected device is missing from a partial fetch. Replaces
-  the guard hand-rolled four different ways (sensibo/sonos/mill/zaptec).
+  list filtered to the user's selection. A **nil** selection includes every available device; a
+  non-nil empty one includes none. Duplicate entries collapse to a single seed.
+- **`adapter.SyncThings[T](a, fetch, selected, seed) (ThingSeeds, error)`** = fetch +
+  SeedsFromSelection + `EnsureThings`, returning the applied seeds so a drift rebuild does not
+  fetch again. **The fetch owns the truth**: it fails → nothing is mutated; it succeeds → every
+  selected device absent from the response is destroyed, including on an empty response. Make the
+  client return an error, never a truncated or empty slice, on a non-2xx, a rate limit or an
+  unparsable body. Selected devices the adapter owns no thing for still get an exclusion, which
+  clears stale nodes left by a pre-cliffhanger adapter.
 - **`adapter.RebuildChangedThings(seeds)`** rebuilds a registered thing whose seed yields a different
   service topology (picks up new capabilities), preserving its address **and** persisted per-thing
   state, build-before-destroy. Replaces sensibo `reconcile.go`. `EnsureThings` still handles presence
-  only; call both (SyncThings for presence, then RebuildChangedThings for drift).
+  only; call both (SyncThings for presence, then RebuildChangedThings for drift). Filter the seeds
+  first if a degenerate third-party response must never rebuild a thing (sensibo's null capabilities).
+- **`selection`** owns the user's device selection: `selection.Devices` is the config mixin carrying
+  `selected_devices`, `selection.Store` reads/writes it, and `selection.PrepareManifest` renders the
+  device selector's three states (not ready / fetch failed / ready). Pass the store to
+  `adapter.RouteAdapter(ad, adapter.WithSelectionRemover(store), adapter.WithLocker(locker))` so
+  `cmd.thing.delete` also deselects the device; without it the next sync recreates the deleted thing.
+- **Best effort**: `EnsureThings`, `RebuildChangedThings`, `DestroyAllThings` and `SyncThings` no
+  longer abort on the first bad device — they continue and join the errors. A non-nil error means
+  *partially applied*, not "nothing happened".
 
 ---
 
@@ -277,8 +290,10 @@ regress them:
   `CustomAddress` to the live address) **and** its persisted per-thing state across the
   destroy/create, runs under the adapter lock (atomic like `EnsureThings`), and guards a nil
   inclusion report.
-- **SyncThings anti-wipe** (#203): a partial/empty fetch returns `ErrIncompleteFetch` rather than
-  destroying live things.
+- **SyncThings fetch ownership**: a *failed* fetch mutates nothing, so a network glitch cannot wipe
+  live things; a *successful* one is authoritative, so a device it no longer lists is excluded even
+  if the response is empty. The anti-wipe responsibility sits in the adapter's client, which must
+  turn a partial or rate-limited response into an error rather than a short slice.
 - **Stream supervisor Stop/Start** (#189 hardening): fd-leak on Chmod failure and Stop/Start races
   fixed — use the framework supervisor rather than a bespoke loop.
 - **OnAuthLoss under lock** (#199): the callback runs holding the Authenticator lock; keep it to

--- a/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
@@ -29,7 +29,7 @@ The change landed in four "waves":
 | `lifecycle.MarkRunning/MarkNotConfigured` + `SetConnAndAuthState` | state-bundle helpers; atomic conn+auth in one event | four separate `Set*State` calls |
 | `storage.NewSecrets/NewCanonicalSecrets` | `Storage[T]` at 0640 (edge: `data/secrets.json`; canonical/core: `workDir/<name>`) | credentials living in world-readable `config.json` |
 | `stream.Supervisor` | `NewSupervisor(connect Connection, b backoff.Stateful)` → `Start()/Stop()/TriggerReconnect()` | bespoke SignalR/GENA/AMQP reconnect loops |
-| `adapter.SeedsFromSelection` + `SyncThings` + `RebuildChangedThings`, `selection` | `SeedsFromSelection[T](available, selected, seed)`, `SyncThings[T](a, fetch, selected, seed) (ThingSeeds, error)`, `RebuildChangedThings(seeds)`, `selection.Devices`/`Store`/`PrepareManifest`, `adapter.WithSelectionRemover` | fetch→filter→map→EnsureThings wrapper, sensibo `reconcile.go`, per-adapter `selected_devices` plumbing and `cmd.thing.delete` route |
+| `adapter.SeedsFromSelection` + `SyncThings` + `RebuildChangedThings`, `selection` | `SeedsFromSelection[T](available, selected, seed)`, `SyncThings[T](a, fetch, selected, seed) (ThingSeeds, error)`, `RebuildChangedThings(seeds)`, `selection.Devices`/`Store`/`PrepareManifest`, `adapter.WithSelection` | fetch→filter→map→EnsureThings wrapper, sensibo `reconcile.go`, per-adapter `selected_devices` plumbing and `cmd.thing.delete` route |
 | `bootstrap.EdgeRouting/EdgeTasks` | `EdgeRouting[C](...)`, `EdgeTasks(...)` bundles | repeated builder wiring |
 | `router.DefaultLogStats` | `DefaultLogStats(redactedInterfacePrefixes ...string) func(Stats)` | per-adapter `LogStats` with `cmd.auth.` masking |
 | `backoff.NewTolerantFixed` | `(tolerance uint32, delay time.Duration) Stateful` | fixed-after-N-tolerated backoff presets |
@@ -222,7 +222,7 @@ backed by this secrets storage.
 - **`selection`** owns the user's device selection: `selection.Devices` is the config mixin carrying
   `selected_devices`, `selection.Store` reads/writes it, and `selection.PrepareManifest` renders the
   device selector's three states (not ready / fetch failed / ready). Pass the store to
-  `adapter.RouteAdapter(ad, adapter.WithSelectionRemover(store), adapter.WithLocker(locker))` so
+  `adapter.RouteAdapter(ad, adapter.WithSelection(store, locker))` so
   `cmd.thing.delete` also deselects the device; without it the next sync recreates the deleted thing.
 - **Best effort**: `EnsureThings`, `RebuildChangedThings`, `DestroyAllThings` and `SyncThings` no
   longer abort on the first bad device — they continue and join the errors. A non-nil error means
@@ -269,9 +269,8 @@ thing store is empty — a partially lost store never recovers otherwise.
 Routing — delete the adapter's own `cmd.thing.delete` route and pass the store instead:
 
 ```go
-cliffAdapter.RouteAdapter(ad,
-	cliffAdapter.WithSelectionRemover(store),
-	cliffAdapter.WithLocker(configurationLocker)) // the same locker as app.RouteApp
+// the same locker as app.RouteApp
+cliffAdapter.RouteAdapter(ad, cliffAdapter.WithSelection(store, configurationLocker))
 ```
 
 Manifest — `selection.PrepareManifest(m, block, ready, fetch, option)` replaces the hand-rolled

--- a/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
@@ -228,6 +228,67 @@ backed by this secrets storage.
   longer abort on the first bad device — they continue and join the errors. A non-nil error means
   *partially applied*, not "nothing happened".
 
+### 7.1 Porting a device selection
+
+Config — embed the mixin and wire a store over the adapter's own locked accessors (`selection.Store`
+is closure-based precisely so adopting it does not force a `config.Service` migration first):
+
+```go
+type PublicConfig struct {
+	BaseURL string `json:"base_url"`
+	selection.Devices // replaces SelectedDevices []string `json:"selected_devices"`
+}
+
+store := selection.NewStore(
+	func() selection.Selection { return cfgSrv.GetSelectedDevices() },
+	func(next selection.Selection) error { return cfgSrv.SetSelectedDevices(next) },
+)
+```
+
+`get` must copy under the read lock and `set` must write under the write lock and stamp
+`ConfiguredAt` — `Store.Remove` is a read-then-write and relies on the handler lock below.
+
+One helper serves both `Configure` and the boot re-sync:
+
+```go
+func (a *application) syncDevices(sel selection.Selection) error {
+	seeds, err := adapter.SyncThings(a.adapter, a.fetchDevices, sel, seedDevice)
+	if err != nil {
+		return fmt.Errorf("sync things: %w", err)
+	}
+
+	// Filter before the drift pass if a degenerate response must never rebuild a thing.
+	return a.adapter.RebuildChangedThings(rebuildable(seeds))
+}
+```
+
+`Configure` calls `syncDevices(cfg.SelectedDevices)` then `store.Set(...)`; the boot path calls
+`syncDevices(store.Get())` and logs rather than failing. Run it on **every** boot, not only when the
+thing store is empty — a partially lost store never recovers otherwise.
+
+Routing — delete the adapter's own `cmd.thing.delete` route and pass the store instead:
+
+```go
+cliffAdapter.RouteAdapter(ad,
+	cliffAdapter.WithSelectionRemover(store),
+	cliffAdapter.WithLocker(configurationLocker)) // the same locker as app.RouteApp
+```
+
+Manifest — `selection.PrepareManifest(m, block, ready, fetch, option)` replaces the hand-rolled
+three-state builder and tolerates a template that renamed the block or config (dereferencing those
+panics the app on `cmd.app.get_manifest`).
+
+**Two hazards when porting:**
+
+1. **The nil flip.** An adapter where a missing `selected_devices` meant "no devices" needs a config
+   migration pinning `nil` → `selection.Selection{}`, or every install without the key silently
+   includes the whole account. An adapter where empty already meant "all devices" needs none —
+   check what its writers actually persist, since `append([]string(nil), …)` marshals to `null`.
+2. **The fetch must error.** With `ErrIncompleteFetch` gone, any client that returns a short or empty
+   slice on a non-2xx, a rate limit, an unparsable body or a truncated page will destroy things. A
+   retry budget for a flaky list endpoint belongs *inside* the fetch closure, returning an error on
+   exhaustion — not in the sync.
+
 ---
 
 ## 8. Remaining blocks
@@ -241,7 +302,9 @@ backed by this secrets storage.
   resetConfig, teardown...)`, `Logout(lc, clear, teardown...)`, `ConfigModel[T](any)`. Use in the
   app's Login/Logout/Reset/Configure so the lifecycle sequence isn't hand-written.
 - **`bootstrap.EdgeRouting[C]` / `EdgeTasks`**: bundle the common routing/task wiring; adopt if it
-  reduces builder boilerplate for your adapter.
+  reduces builder boilerplate for your adapter. `EdgeRouting` takes an `adapterOptions
+  []adapter.RoutingOption` argument before its variadic extras — pass `nil`, or the selection
+  wiring from §7.1.
 - **`router.DefaultLogStats(prefixes...)`**: the stats callback with credential-prefix redaction
   (`"cmd.auth."`) — pass to `router.WithStatsCallback`. Replaces the per-adapter `LogStats`.
 - **`utils.Throttle`**: `Do(key, emit)` collapses repeated log lines (the checker uses it for the

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/futurehomeno/fimpgo"
 	"github.com/futurehomeno/fimpgo/fimptype"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/futurehomeno/cliffhanger/event"
 )
@@ -49,12 +50,10 @@ type Adapter interface {
 	// CreateThing creates thing and adds it to the adapter.
 	CreateThing(seed *ThingSeed) error
 	// DestroyThingByID destroys thing and removes it from the adapter. An unknown ID is a no-op:
-	// there is no address to announce an exclusion for. Use DestroyThingByAddress when the
-	// exclusion must be sent regardless.
+	// there is no address to announce an exclusion for.
 	DestroyThingByID(id string) error
 	// DestroyThingByAddress destroys thing and removes it from the adapter. An unregistered
-	// address still emits the exclusion: an upgraded hub may hold a stale node the adapter's
-	// state never knew about, and exclusion reports are idempotent.
+	// address still emits the exclusion, clearing a stale hub node the state never knew about.
 	DestroyThingByAddress(address string) error
 	// DestroyAllThings destroys all things and removes them from the adapter.
 	DestroyAllThings() error
@@ -247,9 +246,7 @@ func (a *adapter) InitializeThings() error {
 }
 
 // EnsureThings creates and destroys things based on provided map of IDs and custom information objects.
-// The pass is best-effort per device: a failure on one device does not stop the others and all
-// failures are returned joined, so a single broken device can never block a whole sync. A non-nil
-// error therefore means partially applied, not "nothing happened".
+// Best-effort per device: failures are joined, so a non-nil error means partially applied.
 func (a *adapter) EnsureThings(seeds ThingSeeds) error {
 	a.lock.Lock()
 	defer a.lock.Unlock()
@@ -317,9 +314,8 @@ func (a *adapter) DestroyThingByAddress(address string) error {
 	return a.destroyThing(address)
 }
 
-// DestroyAllThings destroys all things and removes them from the adapter. The pass is
-// best-effort per device: the adapter is always left empty, so a single stuck device cannot
-// leave a half-reset adapter behind.
+// DestroyAllThings destroys all things and removes them from the adapter. Best-effort per
+// device: the adapter is always left empty, never half-reset.
 func (a *adapter) DestroyAllThings() error {
 	a.lock.Lock()
 	defer a.lock.Unlock()
@@ -378,12 +374,15 @@ func (a *adapter) createThing(seed *ThingSeed) (err error) {
 		return fmt.Errorf("failed to create state for thing with ID %s: %w", seed.ID, err)
 	}
 
-	// Roll the state record back on failure: a persisted record with no live thing is a ghost
-	// that EnsureThings treats as present forever, so the device stays missing until the store
-	// is reset. Best-effort passes make this likely, as a failure no longer aborts the sync.
+	// Roll the state record back on failure: a record with no live thing is a ghost that
+	// EnsureThings treats as present forever, so the device stays missing until a reset.
 	defer func() {
-		if err != nil {
-			_ = a.state.remove(seed.ID)
+		if err == nil {
+			return
+		}
+
+		if rollbackErr := a.state.remove(seed.ID); rollbackErr != nil {
+			log.Warnf("adapter: failed to roll back state of thing with ID %s: %v", seed.ID, rollbackErr)
 		}
 	}()
 
@@ -436,14 +435,16 @@ func (a *adapter) createThingState(seed *ThingSeed) (ThingState, error) {
 	return ts, nil
 }
 
+// destroyThing is best-effort across all three steps: a failed state write must not skip the
+// unregister, or the thing keeps its connector open while the adapter drops the last reference
+// to it. The state record is already gone from memory by then, so there is nothing to retry.
 func (a *adapter) destroyThing(address string) error {
-	var err error
+	var errs []error
 
 	ts := a.state.byAddress(address)
 	if ts != nil {
-		err = a.state.remove(ts.ID())
-		if err != nil {
-			return fmt.Errorf("failed to remove state for thing with ID %s: %w", ts.ID(), err)
+		if err := a.state.remove(ts.ID()); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove state for thing with ID %s: %w", ts.ID(), err))
 		}
 	}
 
@@ -452,12 +453,11 @@ func (a *adapter) destroyThing(address string) error {
 		a.unregisterThing(t)
 	}
 
-	err = a.sendExclusionReport(address)
-	if err != nil {
-		return fmt.Errorf("failed to send exclusion report for thing with address %s: %w", address, err)
+	if err := a.sendExclusionReport(address); err != nil {
+		errs = append(errs, fmt.Errorf("failed to send exclusion report for thing with address %s: %w", address, err))
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (a *adapter) sendExclusionReport(address string) error {

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -47,9 +48,13 @@ type Adapter interface {
 	RebuildChangedThings(seeds ThingSeeds) error
 	// CreateThing creates thing and adds it to the adapter.
 	CreateThing(seed *ThingSeed) error
-	// DestroyThingByID destroys thing and removes it from the adapter.
+	// DestroyThingByID destroys thing and removes it from the adapter. An unknown ID is a no-op:
+	// there is no address to announce an exclusion for. Use DestroyThingByAddress when the
+	// exclusion must be sent regardless.
 	DestroyThingByID(id string) error
-	// DestroyThingByAddress destroys thing and removes it from the adapter.
+	// DestroyThingByAddress destroys thing and removes it from the adapter. An unregistered
+	// address still emits the exclusion: an upgraded hub may hold a stale node the adapter's
+	// state never knew about, and exclusion reports are idempotent.
 	DestroyThingByAddress(address string) error
 	// DestroyAllThings destroys all things and removes them from the adapter.
 	DestroyAllThings() error
@@ -242,6 +247,9 @@ func (a *adapter) InitializeThings() error {
 }
 
 // EnsureThings creates and destroys things based on provided map of IDs and custom information objects.
+// The pass is best-effort per device: a failure on one device does not stop the others and all
+// failures are returned joined, so a single broken device can never block a whole sync. A non-nil
+// error therefore means partially applied, not "nothing happened".
 func (a *adapter) EnsureThings(seeds ThingSeeds) error {
 	a.lock.Lock()
 	defer a.lock.Unlock()
@@ -260,21 +268,23 @@ func (a *adapter) EnsureThings(seeds ThingSeeds) error {
 		seeds = seeds.Without(ts.ID())
 	}
 
+	var errs []error
+
 	for _, address := range addressesToRemove {
 		err := a.destroyThing(address)
 		if err != nil {
-			return fmt.Errorf("failed to destroy thing with address %s: %w", address, err)
+			errs = append(errs, fmt.Errorf("failed to destroy thing with address %s: %w", address, err))
 		}
 	}
 
 	for _, seed := range seeds {
 		err := a.createThing(seed)
 		if err != nil {
-			return fmt.Errorf("failed to create thing with ID %s: %w", seed.ID, err)
+			errs = append(errs, fmt.Errorf("failed to create thing with ID %s: %w", seed.ID, err))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (a *adapter) CreateThing(seed *ThingSeed) error {
@@ -307,20 +317,25 @@ func (a *adapter) DestroyThingByAddress(address string) error {
 	return a.destroyThing(address)
 }
 
+// DestroyAllThings destroys all things and removes them from the adapter. The pass is
+// best-effort per device: the adapter is always left empty, so a single stuck device cannot
+// leave a half-reset adapter behind.
 func (a *adapter) DestroyAllThings() error {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
+	var errs []error
+
 	for _, ts := range a.state.all() {
 		err := a.destroyThing(ts.Address())
 		if err != nil {
-			return fmt.Errorf("failed to destroy thing with ID %s: %w", ts.ID(), err)
+			errs = append(errs, fmt.Errorf("failed to destroy thing with ID %s: %w", ts.ID(), err))
 		}
 	}
 
 	a.things = make(map[string]Thing)
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (a *adapter) SendConnectivityReport() error {
@@ -357,11 +372,20 @@ func (a *adapter) unregisterThing(t Thing) {
 }
 
 // createThing utilizes factory to create a thing, persists it in the state and adds to the adapter.
-func (a *adapter) createThing(seed *ThingSeed) error {
+func (a *adapter) createThing(seed *ThingSeed) (err error) {
 	ts, err := a.createThingState(seed)
 	if err != nil {
 		return fmt.Errorf("failed to create state for thing with ID %s: %w", seed.ID, err)
 	}
+
+	// Roll the state record back on failure: a persisted record with no live thing is a ghost
+	// that EnsureThings treats as present forever, so the device stays missing until the store
+	// is reset. Best-effort passes make this likely, as a failure no longer aborts the sync.
+	defer func() {
+		if err != nil {
+			_ = a.state.remove(seed.ID)
+		}
+	}()
 
 	t, err := a.factory.Create(a, a.publisher, ts)
 	if err != nil {

--- a/adapter/adapter_internal_test.go
+++ b/adapter/adapter_internal_test.go
@@ -45,13 +45,18 @@ func (c *recordingConnector) wasDisconnected() bool {
 	return c.disconnected
 }
 
-// failingRemoveState fails every removal, standing in for a state file that can no longer be
-// persisted. The in-memory record is dropped regardless, which is why destroyThing must carry on.
+// failingRemoveState stands in for a state file that can no longer be persisted. It mirrors
+// state.remove faithfully: the in-memory record is dropped first and only the save fails, which
+// is why every caller of destroyThing must treat the error as already-applied rather than retry.
 type failingRemoveState struct {
 	State
 }
 
-func (failingRemoveState) remove(string) error { return errors.New("state write failed") }
+func (f failingRemoveState) remove(id string) error {
+	_ = f.State.remove(id)
+
+	return errors.New("state write failed")
+}
 
 // TestDestroyThing_UnregistersWhenStateRemoveFails pins that a failed state write does not skip
 // the unregister. Returning early there left the thing connected while DestroyAllThings cleared

--- a/adapter/adapter_internal_test.go
+++ b/adapter/adapter_internal_test.go
@@ -1,0 +1,88 @@
+package adapter
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/futurehomeno/fimpgo"
+	"github.com/futurehomeno/fimpgo/fimptype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubPublisher swallows everything the adapter publishes; the destroy tests only care about
+// what happened to the thing, not about the exclusion report reaching MQTT.
+type stubPublisher struct{}
+
+func (stubPublisher) PublishAdapterMessage(*fimpgo.FimpMessage) error          { return nil }
+func (stubPublisher) PublishThingMessage(Thing, *fimpgo.FimpMessage) error     { return nil }
+func (stubPublisher) PublishThingEvent(ThingEvent)                             {}
+func (stubPublisher) PublishServiceMessage(Service, *fimpgo.FimpMessage) error { return nil }
+func (stubPublisher) PublishServiceEvent(Service, ServiceEvent)                {}
+
+// recordingConnector is a ControllableConnector that records whether the thing was disconnected.
+type recordingConnector struct {
+	lock         sync.Mutex
+	disconnected bool
+}
+
+func (c *recordingConnector) Connectivity() *ConnectivityDetails { return &ConnectivityDetails{} }
+func (c *recordingConnector) Ping() *PingDetails                 { return &PingDetails{} }
+func (c *recordingConnector) Connect(Thing)                      {}
+
+func (c *recordingConnector) Disconnect(Thing) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.disconnected = true
+}
+
+func (c *recordingConnector) wasDisconnected() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return c.disconnected
+}
+
+// failingRemoveState fails every removal, standing in for a state file that can no longer be
+// persisted. The in-memory record is dropped regardless, which is why destroyThing must carry on.
+type failingRemoveState struct {
+	State
+}
+
+func (failingRemoveState) remove(string) error { return errors.New("state write failed") }
+
+// TestDestroyThing_UnregistersWhenStateRemoveFails pins that a failed state write does not skip
+// the unregister. Returning early there left the thing connected while DestroyAllThings cleared
+// the map, dropping the last reference to a live connector and leaking it for the process
+// lifetime.
+func TestDestroyThing_UnregistersWhenStateRemoveFails(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewState(t.TempDir())
+	require.NoError(t, err)
+
+	ts, err := s.add(&thingStateModel{ID: "B", Address: "2"})
+	require.NoError(t, err)
+
+	connector := &recordingConnector{}
+
+	thing := NewThing(stubPublisher{}, ts, &ThingConfig{
+		InclusionReport: &fimptype.ThingInclusionReport{Address: "2"},
+		Connector:       connector,
+	})
+
+	a := &adapter{
+		publisher: stubPublisher{},
+		state:     failingRemoveState{State: s},
+		things:    map[string]Thing{"2": thing},
+		lock:      &sync.RWMutex{},
+	}
+
+	err = a.DestroyAllThings()
+
+	assert.Error(t, err, "the failed state write must still surface")
+	assert.True(t, connector.wasDisconnected(), "the connector must be released even when the state write fails")
+	assert.Empty(t, a.things, "the thing must not linger in the adapter")
+}

--- a/adapter/drift.go
+++ b/adapter/drift.go
@@ -11,13 +11,10 @@ import (
 
 // RebuildChangedThings rebuilds any already-registered thing whose seed would produce a
 // different service topology than the live thing. EnsureThings only reconciles presence, so
-// a device that gains a capability keeps its old services until it is rebuilt. The prospective
-// thing is built first, so a factory error returns before the destructive destroy.
+// a device that gains a capability keeps its old services until it is rebuilt.
 //
-// The pass is best-effort per seed: a failure on one device does not stop the others and all
-// failures are returned joined. The whole pass runs under the adapter lock, matching
-// EnsureThings, so no concurrent operation can destroy a thing between the lookup and its
-// rebuild.
+// Best-effort per seed: failures are joined. The whole pass runs under the adapter lock, so
+// nothing can destroy a thing between the lookup and its rebuild.
 func (a *adapter) RebuildChangedThings(seeds ThingSeeds) error {
 	a.lock.Lock()
 	defer a.lock.Unlock()
@@ -46,8 +43,8 @@ func (a *adapter) rebuildChangedThing(seed *ThingSeed) error {
 		return nil
 	}
 
-	// The prospective thing reuses the live address so only genuine capability changes,
-	// not address-derived fields, differ.
+	// Reuse the live address so only genuine capability changes, not address-derived fields,
+	// differ. Building before the destroy also means a factory error costs nothing.
 	prospective, err := a.factory.Create(a, a.publisher, newSeedState(seed, ts.Address()))
 	if err != nil {
 		return fmt.Errorf("build prospective thing: %w", err)
@@ -67,16 +64,15 @@ func (a *adapter) rebuildChangedThing(seed *ThingSeed) error {
 		return nil
 	}
 
-	// destroyThing drops the whole state record and createThing rebuilds only
-	// ID/Address/Info, so capture any persisted per-thing state and restore it after the
-	// swap; otherwise a topology rebuild would silently discard it.
+	// destroyThing drops the whole state record, so capture any persisted per-thing state and
+	// restore it after the swap; otherwise a rebuild would silently discard it.
 	var savedState json.RawMessage
 	if err := ts.State(&savedState); err != nil {
 		return fmt.Errorf("read state: %w", err)
 	}
 
-	// Preserve the live address so the rebuilt thing keeps its topic identity; a seed
-	// without a CustomAddress would otherwise be assigned a fresh address on recreation.
+	// Preserve the live address so the rebuilt thing keeps its topic identity; a seed without
+	// a CustomAddress would be assigned a fresh one on recreation.
 	rebuildSeed := &ThingSeed{ID: seed.ID, CustomAddress: ts.Address(), Info: seed.Info}
 
 	if err := a.destroyThing(ts.Address()); err != nil {

--- a/adapter/drift.go
+++ b/adapter/drift.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/crc32"
 
@@ -11,70 +12,85 @@ import (
 // RebuildChangedThings rebuilds any already-registered thing whose seed would produce a
 // different service topology than the live thing. EnsureThings only reconciles presence, so
 // a device that gains a capability keeps its old services until it is rebuilt. The prospective
-// thing is built first, so a factory error aborts before the destructive destroy. The whole
-// pass runs under the adapter lock, matching EnsureThings, so no concurrent operation can
-// destroy a thing between the lookup and its rebuild.
+// thing is built first, so a factory error returns before the destructive destroy.
+//
+// The pass is best-effort per seed: a failure on one device does not stop the others and all
+// failures are returned joined. The whole pass runs under the adapter lock, matching
+// EnsureThings, so no concurrent operation can destroy a thing between the lookup and its
+// rebuild.
 func (a *adapter) RebuildChangedThings(seeds ThingSeeds) error {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
+	var errs []error
+
 	for _, seed := range seeds {
-		ts := a.state.byID(seed.ID)
-		if ts == nil {
-			continue
+		if err := a.rebuildChangedThing(seed); err != nil {
+			errs = append(errs, fmt.Errorf("rebuild %s: %w", seed.ID, err))
 		}
+	}
 
-		live := a.things[ts.Address()]
-		if live == nil {
-			continue
-		}
+	return errors.Join(errs...)
+}
 
-		// The prospective thing reuses the live address so only genuine capability changes,
-		// not address-derived fields, differ.
-		prospective, err := a.factory.Create(a, a.publisher, newSeedState(seed, ts.Address()))
-		if err != nil {
-			return fmt.Errorf("rebuild %s: build prospective thing: %w", seed.ID, err)
-		}
+// rebuildChangedThing rebuilds a single registered thing if its service topology drifted.
+// Assumes the adapter lock is held.
+func (a *adapter) rebuildChangedThing(seed *ThingSeed) error {
+	ts := a.state.byID(seed.ID)
+	if ts == nil {
+		return nil
+	}
 
-		fresh, err := topologyChecksum(prospective.InclusionReport())
-		if err != nil {
-			return fmt.Errorf("rebuild %s: checksum prospective: %w", seed.ID, err)
-		}
+	live := a.things[ts.Address()]
+	if live == nil {
+		return nil
+	}
 
-		current, err := topologyChecksum(live.InclusionReport())
-		if err != nil {
-			return fmt.Errorf("rebuild %s: checksum live: %w", seed.ID, err)
-		}
+	// The prospective thing reuses the live address so only genuine capability changes,
+	// not address-derived fields, differ.
+	prospective, err := a.factory.Create(a, a.publisher, newSeedState(seed, ts.Address()))
+	if err != nil {
+		return fmt.Errorf("build prospective thing: %w", err)
+	}
 
-		if fresh == current {
-			continue
-		}
+	fresh, err := topologyChecksum(prospective.InclusionReport())
+	if err != nil {
+		return fmt.Errorf("checksum prospective: %w", err)
+	}
 
-		// destroyThing drops the whole state record and createThing rebuilds only
-		// ID/Address/Info, so capture any persisted per-thing state and restore it after the
-		// swap; otherwise a topology rebuild would silently discard it.
-		var savedState json.RawMessage
-		if err := ts.State(&savedState); err != nil {
-			return fmt.Errorf("rebuild %s: read state: %w", seed.ID, err)
-		}
+	current, err := topologyChecksum(live.InclusionReport())
+	if err != nil {
+		return fmt.Errorf("checksum live: %w", err)
+	}
 
-		// Preserve the live address so the rebuilt thing keeps its topic identity; a seed
-		// without a CustomAddress would otherwise be assigned a fresh address on recreation.
-		rebuildSeed := &ThingSeed{ID: seed.ID, CustomAddress: ts.Address(), Info: seed.Info}
+	if fresh == current {
+		return nil
+	}
 
-		if err := a.destroyThing(ts.Address()); err != nil {
-			return fmt.Errorf("rebuild %s: destroy: %w", seed.ID, err)
-		}
+	// destroyThing drops the whole state record and createThing rebuilds only
+	// ID/Address/Info, so capture any persisted per-thing state and restore it after the
+	// swap; otherwise a topology rebuild would silently discard it.
+	var savedState json.RawMessage
+	if err := ts.State(&savedState); err != nil {
+		return fmt.Errorf("read state: %w", err)
+	}
 
-		if err := a.createThing(rebuildSeed); err != nil {
-			return fmt.Errorf("rebuild %s: recreate (device excluded until next restart): %w", seed.ID, err)
-		}
+	// Preserve the live address so the rebuilt thing keeps its topic identity; a seed
+	// without a CustomAddress would otherwise be assigned a fresh address on recreation.
+	rebuildSeed := &ThingSeed{ID: seed.ID, CustomAddress: ts.Address(), Info: seed.Info}
 
-		if len(savedState) > 0 {
-			if newTS := a.state.byID(seed.ID); newTS != nil {
-				if err := newTS.SetState(savedState); err != nil {
-					return fmt.Errorf("rebuild %s: restore state: %w", seed.ID, err)
-				}
+	if err := a.destroyThing(ts.Address()); err != nil {
+		return fmt.Errorf("destroy: %w", err)
+	}
+
+	if err := a.createThing(rebuildSeed); err != nil {
+		return fmt.Errorf("recreate (device excluded until next restart): %w", err)
+	}
+
+	if len(savedState) > 0 {
+		if newTS := a.state.byID(seed.ID); newTS != nil {
+			if err := newTS.SetState(savedState); err != nil {
+				return fmt.Errorf("restore state: %w", err)
 			}
 		}
 	}

--- a/adapter/drift.go
+++ b/adapter/drift.go
@@ -7,6 +7,7 @@ import (
 	"hash/crc32"
 
 	"github.com/futurehomeno/fimpgo/fimptype"
+	log "github.com/sirupsen/logrus"
 )
 
 // RebuildChangedThings rebuilds any already-registered thing whose seed would produce a
@@ -75,8 +76,11 @@ func (a *adapter) rebuildChangedThing(seed *ThingSeed) error {
 	// a CustomAddress would be assigned a fresh one on recreation.
 	rebuildSeed := &ThingSeed{ID: seed.ID, CustomAddress: ts.Address(), Info: seed.Info}
 
+	// destroyThing is best-effort and has already completed the in-memory removal by the time it
+	// reports an error, so aborting here would leave the device excluded and never recreated -
+	// and discard savedState with it. Carry on and let the recreate put the thing back.
 	if err := a.destroyThing(ts.Address()); err != nil {
-		return fmt.Errorf("destroy: %w", err)
+		log.Warnf("adapter: rebuild of thing with ID %s: destroy reported errors, recreating anyway: %v", seed.ID, err)
 	}
 
 	if err := a.createThing(rebuildSeed); err != nil {

--- a/adapter/drift_internal_test.go
+++ b/adapter/drift_internal_test.go
@@ -1,6 +1,14 @@
 package adapter
 
-import "testing"
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/futurehomeno/fimpgo/fimptype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestTopologyChecksum_NilReportDoesNotPanic(t *testing.T) {
 	t.Parallel()
@@ -9,4 +17,70 @@ func TestTopologyChecksum_NilReportDoesNotPanic(t *testing.T) {
 	if err != nil || sum != 0 {
 		t.Fatalf("nil report: got (%d, %v), want (0, nil)", sum, err)
 	}
+}
+
+// groupsInfo drives the topology checksum: changing the groups makes a seed drift from the live
+// thing, which is what triggers a rebuild.
+type groupsInfo struct {
+	Groups []string `json:"groups"`
+}
+
+// groupsFactory builds a thing whose inclusion report carries the groups held in its state.
+type groupsFactory struct{}
+
+func (groupsFactory) Create(_ Adapter, publisher Publisher, ts ThingState) (Thing, error) {
+	var info groupsInfo
+
+	if err := ts.Info(&info); err != nil {
+		return nil, err
+	}
+
+	return NewThing(publisher, ts, &ThingConfig{
+		InclusionReport: &fimptype.ThingInclusionReport{Address: ts.Address(), Groups: info.Groups},
+		Connector:       &recordingConnector{},
+	}), nil
+}
+
+// TestRebuildChangedThing_RecreatesWhenDestroyReportsError pins that a destroy reporting an error
+// does not abort the rebuild. destroyThing is best-effort and has already removed the thing from
+// memory by the time it returns, so aborting left the device excluded and never recreated, taking
+// the persisted state the rebuild had just captured down with it.
+func TestRebuildChangedThing_RecreatesWhenDestroyReportsError(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewState(t.TempDir())
+	require.NoError(t, err)
+
+	ts, err := s.add(&thingStateModel{ID: "B", Address: "2", Info: json.RawMessage(`{"groups":["g1"]}`)})
+	require.NoError(t, err)
+
+	require.NoError(t, ts.SetState(map[string]string{"keep": "me"}))
+
+	live, err := groupsFactory{}.Create(nil, stubPublisher{}, ts)
+	require.NoError(t, err)
+
+	a := &adapter{
+		publisher: stubPublisher{},
+		state:     failingRemoveState{State: s},
+		factory:   groupsFactory{},
+		things:    map[string]Thing{"2": live},
+		lock:      &sync.RWMutex{},
+	}
+
+	// The seed gains a group, so the topology drifts and the thing is rebuilt.
+	err = a.RebuildChangedThings(ThingSeeds{{ID: "B", Info: groupsInfo{Groups: []string{"g1", "g2"}}}})
+
+	assert.NoError(t, err, "a destroy that only reports an error must not fail the rebuild")
+
+	rebuilt := a.things["2"]
+	require.NotNil(t, rebuilt, "the thing must be recreated, not left excluded")
+	assert.Equal(t, []string{"g1", "g2"}, rebuilt.InclusionReport().Groups, "the rebuilt thing must carry the fresh topology")
+
+	newTS := a.state.byID("B")
+	require.NotNil(t, newTS, "the state record must be back")
+
+	var kept map[string]string
+
+	require.NoError(t, newTS.State(&kept))
+	assert.Equal(t, map[string]string{"keep": "me"}, kept, "persisted state must survive the rebuild")
 }

--- a/adapter/drift_test.go
+++ b/adapter/drift_test.go
@@ -255,6 +255,78 @@ func expectExclusion(address string) *suite.Expectation {
 		}))
 }
 
+func TestRebuildChangedThings_ContinuesAfterFailure(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	const badAddress = "6"
+
+	// Two drifted things, the failing one first in the ordered seed slice: a pass that aborted
+	// on the first error would never reach the healthy one.
+	initial := adapter.ThingSeeds{
+		{ID: "bad", CustomAddress: badAddress, Info: driftInfo{Groups: []string{"g1"}}},
+		{ID: "ok", CustomAddress: testDriftAddress, Info: driftInfo{Groups: []string{"g1"}}},
+	}
+	rebuild := adapter.ThingSeeds{
+		{ID: "bad", CustomAddress: badAddress, Info: driftInfo{Groups: []string{"g1", "g2"}, Fail: true}},
+		{ID: "ok", CustomAddress: testDriftAddress, Info: driftInfo{Groups: []string{"g1", "g2"}}},
+	}
+
+	setup := suite.BaseSetup(func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
+		t.Helper()
+
+		factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, ts adapter.ThingState) (adapter.Thing, error) {
+			var info driftInfo
+			if err := ts.Info(&info); err != nil {
+				return nil, err
+			}
+
+			if info.Fail {
+				return nil, errors.New("factory boom")
+			}
+
+			cfg := &adapter.ThingConfig{
+				InclusionReport: &fimptype.ThingInclusionReport{Address: ts.Address(), Groups: info.Groups},
+				Connector:       mockedadapter.NewDefaultConnector(t),
+			}
+
+			return adapter.NewThing(publisher, ts, cfg), nil
+		})
+
+		ad = adapterhelper.PrepareSeededAdapter(t, testAdapterWorkDir, mqtt, factory, initial)
+
+		return adapter.RouteAdapter(ad), nil, nil
+	})
+
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "a device that cannot be rebuilt does not block the others",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    setup,
+				Nodes: []*suite.Node{
+					{
+						Name:    "the healthy device is rebuilt even though the first seed fails",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+							assert.Error(t, ad.RebuildChangedThings(rebuild))
+						}},
+						Expectations: []*suite.Expectation{
+							// Building the prospective thing failed, so the broken device was
+							// never destroyed.
+							expectExclusion(badAddress).Never(),
+							expectExclusion(testDriftAddress).ExactlyOnce(),
+							expectInclusionWithGroup(testDriftAddress, "g2").AtLeastOnce(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
 func expectInclusionWithGroup(address, group string) *suite.Expectation {
 	return suite.NewExpectation().
 		ExpectTopic(testAdapterEvtTopic).

--- a/adapter/routing.go
+++ b/adapter/routing.go
@@ -1,6 +1,7 @@
 package adapter
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/futurehomeno/fimpgo"
@@ -24,10 +25,48 @@ const (
 	EvtPingReport              = "evt.ping.report"
 )
 
-func RouteAdapter(adapter Adapter) []*router.Routing {
+// SelectionRemover drops a device from the user's device selection, so a thing deleted from the
+// hub is not recreated by the next sync. It is satisfied by *selection.Store.
+type SelectionRemover interface {
+	Remove(id string) error
+}
+
+// RoutingOption configures the adapter routing.
+type RoutingOption func(*routingConfig)
+
+type routingConfig struct {
+	selection SelectionRemover
+	locker    router.MessageHandlerLocker
+}
+
+// WithSelectionRemover makes cmd.thing.delete drop the deleted device from the user's device
+// selection in addition to destroying the thing. Without it a deleted thing comes back on the
+// next sync, as the selection still lists it.
+//
+// It has no effect on an adapter whose selection includes every device: "include all" cannot
+// express an exclusion, so an adapter with user-deletable devices must keep an explicit
+// selection.
+func WithSelectionRemover(remover SelectionRemover) RoutingOption {
+	return func(c *routingConfig) { c.selection = remover }
+}
+
+// WithLocker makes cmd.thing.delete share a lock with the application's configuration handlers,
+// so deleting a thing cannot interleave with cmd.config.extended_set rewriting the selection.
+// Pass the same locker as app.RouteApp.
+func WithLocker(locker router.MessageHandlerLocker) RoutingOption {
+	return func(c *routingConfig) { c.locker = locker }
+}
+
+func RouteAdapter(adapter Adapter, options ...RoutingOption) []*router.Routing {
+	cfg := &routingConfig{}
+
+	for _, option := range options {
+		option(cfg)
+	}
+
 	return []*router.Routing{
 		routeCmdThingGetInclusionReport(adapter),
-		routeCmdThingDelete(adapter),
+		routeCmdThingDelete(adapter, cfg),
 		routeCmdNetworkReset(adapter),
 		routeCmdNetworkGetNode(adapter),
 		routeCmdNetworkGetAllNodes(adapter),
@@ -61,15 +100,15 @@ func handleCmdThingGetInclusionReport(adapter Adapter) router.MessageHandler {
 	)
 }
 
-func routeCmdThingDelete(adapter Adapter) *router.Routing {
+func routeCmdThingDelete(adapter Adapter, cfg *routingConfig) *router.Routing {
 	return router.NewRouting(
-		handleCmdThingDelete(adapter),
+		handleCmdThingDelete(adapter, cfg),
 		router.ForService(fimptype.ServiceNameT(adapter.Name())),
 		router.ForType(CmdThingDelete),
 	)
 }
 
-func handleCmdThingDelete(adapter Adapter) router.MessageHandler {
+func handleCmdThingDelete(adapter Adapter, cfg *routingConfig) router.MessageHandler {
 	return router.NewMessageHandler(
 		router.MessageProcessorFn(func(message *fimpgo.Message) (reply *fimpgo.FimpMessage, err error) {
 			value, err := message.Payload.GetStrMapValue()
@@ -78,14 +117,37 @@ func handleCmdThingDelete(adapter Adapter) router.MessageHandler {
 			}
 
 			address := value["address"]
+			if address == "" {
+				return nil, errors.New("provided address is empty")
+			}
+
+			// Resolve the device ID before the destroy: destroying a thing drops the state
+			// record mapping its address to its ID, so a later lookup would find nothing.
+			id, ok := adapter.ExchangeAddress(address)
 
 			err = adapter.DestroyThingByAddress(address)
 			if err != nil {
 				return nil, fmt.Errorf("failed to delete thing with address %s: %w", address, err)
 			}
 
+			if cfg.selection == nil {
+				return nil, nil
+			}
+
+			if !ok {
+				// No thing state: the hub is deleting a node this adapter never registered,
+				// which for an ID-addressed adapter is a device left behind by an older
+				// version. Removing an unselected ID is a no-op elsewhere.
+				id = address
+			}
+
+			if err := cfg.selection.Remove(id); err != nil {
+				return nil, fmt.Errorf("failed to remove device %s from the selection: %w", id, err)
+			}
+
 			return nil, nil
 		}),
+		router.WithExternalLock(cfg.locker),
 	)
 }
 

--- a/adapter/routing.go
+++ b/adapter/routing.go
@@ -28,6 +28,7 @@ const (
 // SelectionRemover drops a device from the user's device selection, so a thing deleted from the
 // hub is not recreated by the next sync. It is satisfied by *selection.Store.
 type SelectionRemover interface {
+	// Remove drops the device, and is a no-op when it is not selected.
 	Remove(id string) error
 }
 
@@ -39,22 +40,22 @@ type routingConfig struct {
 	locker    router.MessageHandlerLocker
 }
 
-// WithSelectionRemover makes cmd.thing.delete drop the deleted device from the user's device
-// selection in addition to destroying the thing. Without it a deleted thing comes back on the
-// next sync, as the selection still lists it.
-//
-// It has no effect on an adapter whose selection includes every device: "include all" cannot
-// express an exclusion, so an adapter with user-deletable devices must keep an explicit
-// selection.
-func WithSelectionRemover(remover SelectionRemover) RoutingOption {
-	return func(c *routingConfig) { c.selection = remover }
-}
+// WithSelection makes cmd.thing.delete deselect the device it deletes; without it the next sync
+// recreates the thing. It cannot help an "include all" selection, which has no way to express an
+// exclusion. The locker serialises the delete against the application's configuration handlers,
+// so the remover's read-then-write cannot interleave with cmd.config.extended_set rewriting the
+// selection - pass the same locker as app.RouteApp. Both are required: a nil locker leaves the
+// handler unlocked, silently defeating the serialisation the remover depends on, so it panics
+// at wiring time rather than handing back a selection that quietly loses updates.
+func WithSelection(remover SelectionRemover, locker router.MessageHandlerLocker) RoutingOption {
+	if remover == nil || locker == nil {
+		panic("adapter: WithSelection requires a non-nil remover and locker")
+	}
 
-// WithLocker makes cmd.thing.delete share a lock with the application's configuration handlers,
-// so deleting a thing cannot interleave with cmd.config.extended_set rewriting the selection.
-// Pass the same locker as app.RouteApp.
-func WithLocker(locker router.MessageHandlerLocker) RoutingOption {
-	return func(c *routingConfig) { c.locker = locker }
+	return func(c *routingConfig) {
+		c.selection = remover
+		c.locker = locker
+	}
 }
 
 func RouteAdapter(adapter Adapter, options ...RoutingOption) []*router.Routing {
@@ -121,28 +122,28 @@ func handleCmdThingDelete(adapter Adapter, cfg *routingConfig) router.MessageHan
 				return nil, errors.New("provided address is empty")
 			}
 
-			// Resolve the device ID before the destroy: destroying a thing drops the state
-			// record mapping its address to its ID, so a later lookup would find nothing.
+			// Resolve before the destroy: it drops the record mapping address to ID.
 			id, ok := adapter.ExchangeAddress(address)
+
+			// Deselect before destroying. The reverse order resurrects the device: a failed
+			// deselect after a successful destroy leaves it selected, so the next sync recreates
+			// the thing the user just deleted. This way a failure leaves the thing intact and
+			// retryable, and a destroy that fails afterwards is undone by the next sync anyway.
+			if cfg.selection != nil {
+				if !ok {
+					// No thing state: the hub is deleting a node this adapter never registered,
+					// which for an ID-addressed adapter is a device left behind by an older version.
+					id = address
+				}
+
+				if err := cfg.selection.Remove(id); err != nil {
+					return nil, fmt.Errorf("failed to remove device %s from the selection: %w", id, err)
+				}
+			}
 
 			err = adapter.DestroyThingByAddress(address)
 			if err != nil {
 				return nil, fmt.Errorf("failed to delete thing with address %s: %w", address, err)
-			}
-
-			if cfg.selection == nil {
-				return nil, nil
-			}
-
-			if !ok {
-				// No thing state: the hub is deleting a node this adapter never registered,
-				// which for an ID-addressed adapter is a device left behind by an older
-				// version. Removing an unselected ID is a no-op elsewhere.
-				id = address
-			}
-
-			if err := cfg.selection.Remove(id); err != nil {
-				return nil, fmt.Errorf("failed to remove device %s from the selection: %w", id, err)
 			}
 
 			return nil, nil

--- a/adapter/routing_delete_test.go
+++ b/adapter/routing_delete_test.go
@@ -1,0 +1,242 @@
+package adapter_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/futurehomeno/fimpgo"
+	"github.com/futurehomeno/fimpgo/fimptype"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/futurehomeno/cliffhanger/adapter"
+	"github.com/futurehomeno/cliffhanger/router"
+	"github.com/futurehomeno/cliffhanger/selection"
+	"github.com/futurehomeno/cliffhanger/task"
+	adapterhelper "github.com/futurehomeno/cliffhanger/test/helper/adapter"
+	mockedadapter "github.com/futurehomeno/cliffhanger/test/mocks/adapter"
+	"github.com/futurehomeno/cliffhanger/test/suite"
+)
+
+// deletableDevices mirrors setupAdapterWithDeletableThings: the ID differs from the address, as
+// it does for every adapter that lets cliffhanger assign addresses, so a handler that mistook one
+// for the other would be caught.
+var deletableDevices = []device{{ID: "B", Name: testThingAddressB}, {ID: "C", Name: testThingAddressC}}
+
+// seedDeletable maps a device to a seed pinned at the address carried in Name.
+func seedDeletable(d device) *adapter.ThingSeed {
+	return &adapter.ThingSeed{ID: d.ID, CustomAddress: d.Name}
+}
+
+// selection.Store must satisfy the interface the delete route accepts; its doc comment says so.
+var _ adapter.SelectionRemover = (*selection.Store)(nil)
+
+// testSelection stands in for an application configuration. It locks around the selection because
+// NewStore requires it: the delete handler writes from the router goroutine while the test reads.
+type testSelection struct {
+	lock sync.RWMutex
+	sel  selection.Selection
+}
+
+// newTestSelection returns a store over an in-memory selection along with the backing fixture, for
+// inspecting what the handler wrote.
+func newTestSelection(ids ...string) (*selection.Store, *testSelection) {
+	s := &testSelection{sel: selection.Selection(ids)}
+
+	return selection.NewStore(s.get, s.set), s
+}
+
+func (s *testSelection) get() selection.Selection {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return s.sel.Clone()
+}
+
+func (s *testSelection) set(next selection.Selection) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.sel = next
+
+	return nil
+}
+
+func setupAdapterWithDeletableThings(ad *adapter.Adapter, store *selection.Store) suite.BaseSetup {
+	return func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
+		t.Helper()
+
+		factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, ts adapter.ThingState) (adapter.Thing, error) {
+			cfg := &adapter.ThingConfig{
+				InclusionReport: &fimptype.ThingInclusionReport{Address: ts.Address()},
+				Connector:       mockedadapter.NewDefaultConnector(t),
+			}
+
+			return adapter.NewThing(publisher, ts, cfg), nil
+		})
+
+		seeds := adapter.SeedsFromSelection(deletableDevices, nil, seedDeletable)
+
+		*ad = adapterhelper.PrepareSeededAdapter(t, testAdapterWorkDir, mqtt, factory, seeds)
+
+		return adapter.RouteAdapter(*ad, adapter.WithSelectionRemover(store)), nil, nil
+	}
+}
+
+func deleteThingCommand(address string) *fimpgo.Message {
+	return suite.StringMapMessage(
+		testAdapterCmdTopic,
+		adapter.CmdThingDelete,
+		testAdapterName,
+		map[string]string{"address": address},
+	)
+}
+
+func TestRouteAdapter_ThingDelete(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	store, sel := newTestSelection("B", "C")
+
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "cmd.thing.delete destroys the thing, announces it and deselects the device",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    setupAdapterWithDeletableThings(&ad, store),
+				Nodes: []*suite.Node{
+					{
+						Name:    "deleting thing B excludes it",
+						Timeout: 500 * time.Millisecond,
+						Command: deleteThingCommand(testThingAddressB),
+						Expectations: []*suite.Expectation{
+							expectExclusion(testThingAddressB).ExactlyOnce(),
+							suite.ExpectError(testAdapterEvtTopic, testAdapterName).Never(),
+						},
+					},
+					{
+						Name:    "the device is deselected and a following sync does not bring it back",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							assert.Nil(t, ad.ThingByAddress(testThingAddressB), "thing B must be destroyed")
+							// "B", not "2": the ID is resolved before the destroy drops the
+							// record that maps the address to it.
+							assert.Equal(t, selection.Selection{"C"}, sel.get())
+
+							// The third party still lists both devices; only the selection
+							// decides, which is what makes the deletion stick.
+							_, err := adapter.SyncThings(ad, fetchOK(deletableDevices), store.Get(), seedDeletable)
+
+							assert.NoError(t, err)
+							assert.Nil(t, ad.ThingByAddress(testThingAddressB), "the deleted device must stay gone")
+							assert.NotNil(t, ad.ThingByAddress(testThingAddressC), "the kept device must survive")
+						}},
+						Expectations: []*suite.Expectation{
+							expectInclusion(testThingAddressB).Never(),
+						},
+					},
+					{
+						Name:    "re-selecting the device recreates it and announces it again",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							assert.NoError(t, store.Set(selection.Selection{"B", "C"}))
+
+							_, err := adapter.SyncThings(ad, fetchOK(deletableDevices), store.Get(), seedDeletable)
+
+							assert.NoError(t, err)
+							assert.NotNil(t, ad.ThingByAddress(testThingAddressB), "the re-selected device must be back")
+						}},
+						Expectations: []*suite.Expectation{
+							expectInclusion(testThingAddressB).ExactlyOnce(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func TestRouteAdapter_ThingDeleteWithoutSelection(t *testing.T) { //nolint:paralleltest
+	// Without a selection remover the handler keeps its original behaviour: destroy and
+	// announce, leaving the application's configuration alone.
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "cmd.thing.delete destroys the thing when no selection is wired",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    setupAdapterWithTwoThings(),
+				Nodes: []*suite.Node{
+					{
+						Name:    "deleting thing B excludes it",
+						Timeout: 500 * time.Millisecond,
+						Command: deleteThingCommand(testThingAddressB),
+						Expectations: []*suite.Expectation{
+							expectExclusion(testThingAddressB).ExactlyOnce(),
+							suite.ExpectError(testAdapterEvtTopic, testAdapterName).Never(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func TestRouteAdapter_ThingDeleteErrorPaths(t *testing.T) { //nolint:paralleltest
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "cmd.thing.delete error paths never announce an exclusion",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    setupAdapterWithTwoThings(),
+				Nodes: []*suite.Node{
+					{
+						Name:    "an empty address responds with an error",
+						Timeout: 500 * time.Millisecond,
+						Command: deleteThingCommand(""),
+						Expectations: []*suite.Expectation{
+							suite.ExpectError(testAdapterEvtTopic, testAdapterName).ExactlyOnce(),
+							expectAnyExclusion().Never(),
+						},
+					},
+					{
+						Name:    "a missing address key responds with an error",
+						Timeout: 500 * time.Millisecond,
+						Command: suite.StringMapMessage(
+							testAdapterCmdTopic,
+							adapter.CmdThingDelete,
+							testAdapterName,
+							map[string]string{},
+						),
+						Expectations: []*suite.Expectation{
+							suite.ExpectError(testAdapterEvtTopic, testAdapterName).ExactlyOnce(),
+							expectAnyExclusion().Never(),
+						},
+					},
+					{
+						Name:    "a payload that is not a string map responds with an error",
+						Timeout: 500 * time.Millisecond,
+						Command: suite.StringMessage(
+							testAdapterCmdTopic,
+							adapter.CmdThingDelete,
+							testAdapterName,
+							testThingAddressB,
+						),
+						Expectations: []*suite.Expectation{
+							suite.ExpectError(testAdapterEvtTopic, testAdapterName).ExactlyOnce(),
+							expectAnyExclusion().Never(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}

--- a/adapter/routing_delete_test.go
+++ b/adapter/routing_delete_test.go
@@ -1,6 +1,7 @@
 package adapter_test
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -62,7 +63,16 @@ func (s *testSelection) set(next selection.Selection) error {
 	return nil
 }
 
-func setupAdapterWithDeletableThings(ad *adapter.Adapter, store *selection.Store) suite.BaseSetup {
+// failingRemover stands in for a selection whose configuration write fails, e.g. a full disk.
+type failingRemover struct{}
+
+func (failingRemover) Remove(string) error { return errors.New("selection write failed") }
+
+func setupAdapterWithDeletableThings(
+	ad *adapter.Adapter,
+	remover adapter.SelectionRemover,
+	locker router.MessageHandlerLocker,
+) suite.BaseSetup {
 	return func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
 		t.Helper()
 
@@ -79,7 +89,7 @@ func setupAdapterWithDeletableThings(ad *adapter.Adapter, store *selection.Store
 
 		*ad = adapterhelper.PrepareSeededAdapter(t, testAdapterWorkDir, mqtt, factory, seeds)
 
-		return adapter.RouteAdapter(*ad, adapter.WithSelectionRemover(store)), nil, nil
+		return adapter.RouteAdapter(*ad, adapter.WithSelection(remover, locker)), nil, nil
 	}
 }
 
@@ -102,7 +112,7 @@ func TestRouteAdapter_ThingDelete(t *testing.T) { //nolint:paralleltest
 			{
 				Name:     "cmd.thing.delete destroys the thing, announces it and deselects the device",
 				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
-				Setup:    setupAdapterWithDeletableThings(&ad, store),
+				Setup:    setupAdapterWithDeletableThings(&ad, store, router.NewMessageHandlerLocker()),
 				Nodes: []*suite.Node{
 					{
 						Name:    "deleting thing B excludes it",
@@ -179,6 +189,108 @@ func TestRouteAdapter_ThingDeleteWithoutSelection(t *testing.T) { //nolint:paral
 							expectExclusion(testThingAddressB).ExactlyOnce(),
 							suite.ExpectError(testAdapterEvtTopic, testAdapterName).Never(),
 						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func TestRouteAdapter_ThingDeleteRespectsExternalLock(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	store, sel := newTestSelection("B", "C")
+	// The same locker app.RouteApp holds while it rewrites the configuration. A delete that slipped
+	// past it would read a selection the configuration handler is midway through replacing, and the
+	// deselect would be lost.
+	locker := router.NewMessageHandlerLocker()
+
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "cmd.thing.delete is skipped while the configuration lock is held",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    setupAdapterWithDeletableThings(&ad, store, locker),
+				Nodes: []*suite.Node{
+					{
+						Name:    "a delete arriving under the held lock changes nothing",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							assert.True(t, locker.Lock(), "the test must own the lock the handler contends for")
+						}},
+						Command: deleteThingCommand(testThingAddressB),
+						Expectations: []*suite.Expectation{
+							suite.ExpectError(testAdapterEvtTopic, testAdapterName).ExactlyOnce(),
+							expectAnyExclusion().Never(),
+						},
+					},
+					{
+						Name:    "releasing the lock lets the same delete through",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							assert.NotNil(t, ad.ThingByAddress(testThingAddressB), "the blocked delete must not have destroyed it")
+							assert.Equal(t, selection.Selection{"B", "C"}, sel.get(), "the blocked delete must not have deselected it")
+
+							locker.Unlock()
+						}},
+						Command: deleteThingCommand(testThingAddressB),
+						Expectations: []*suite.Expectation{
+							expectExclusion(testThingAddressB).ExactlyOnce(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func TestRouteAdapter_WithSelectionRejectsNilArguments(t *testing.T) {
+	t.Parallel()
+
+	// A nil locker leaves the handler unlocked, which is exactly the race the option exists to
+	// close, so it must not be silently accepted.
+	assert.Panics(t, func() { adapter.WithSelection(nil, router.NewMessageHandlerLocker()) })
+	assert.Panics(t, func() { adapter.WithSelection(&selection.Store{}, nil) })
+}
+
+func TestRouteAdapter_ThingDeleteSelectionWriteFails(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	// The deselect runs before the destroy precisely so this case is recoverable: were the order
+	// reversed, the thing would be gone while the device stayed selected and the next sync would
+	// resurrect the device the user just deleted.
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "a failing deselect leaves the thing intact instead of resurrecting it",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    setupAdapterWithDeletableThings(&ad, failingRemover{}, router.NewMessageHandlerLocker()),
+				Nodes: []*suite.Node{
+					{
+						Name:    "the delete reports an error and announces no exclusion",
+						Timeout: 500 * time.Millisecond,
+						Command: deleteThingCommand(testThingAddressB),
+						Expectations: []*suite.Expectation{
+							suite.ExpectError(testAdapterEvtTopic, testAdapterName).ExactlyOnce(),
+							expectAnyExclusion().Never(),
+						},
+					},
+					{
+						Name:    "the thing survives, so retrying the delete is all it takes",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							assert.NotNil(t, ad.ThingByAddress(testThingAddressB), "thing B must survive a failed deselect")
+						}},
 					},
 				},
 			},

--- a/adapter/seeds.go
+++ b/adapter/seeds.go
@@ -2,16 +2,26 @@ package adapter
 
 import "slices"
 
-// SeedsFromSelection builds seeds for the available devices matching the selected IDs,
-// ready to be passed to EnsureThings.
+// SeedsFromSelection builds seeds for the available devices matching the selected IDs, ready to
+// be passed to EnsureThings. A nil selection selects every available device; a non-nil empty
+// selection selects none - unmarshalling a missing JSON key yields nil, so callers that mean
+// "none" must pass a non-nil empty slice. Duplicate entries yield a single seed: two seeds with
+// the same ID would create two things, the second stranded at a second address.
 func SeedsFromSelection[T any](available []T, selected []string, seed func(T) *ThingSeed) ThingSeeds {
 	var seeds ThingSeeds
 
 	for _, item := range available {
 		s := seed(item)
-		if slices.Contains(selected, s.ID) {
-			seeds = append(seeds, s)
+
+		if selected != nil && !slices.Contains(selected, s.ID) {
+			continue
 		}
+
+		if seeds.Contains(s.ID) {
+			continue
+		}
+
+		seeds = append(seeds, s)
 	}
 
 	return seeds

--- a/adapter/seeds_test.go
+++ b/adapter/seeds_test.go
@@ -24,7 +24,20 @@ func TestSeedsFromSelection(t *testing.T) {
 	assert.True(t, seeds.Contains("3"))
 	assert.False(t, seeds.Contains("2"))
 
-	assert.Empty(t, adapter.SeedsFromSelection(available, nil, func(d device) *adapter.ThingSeed {
+	// A nil selection is an application that has never been configured: include everything.
+	assert.Len(t, adapter.SeedsFromSelection(available, nil, func(d device) *adapter.ThingSeed {
+		return &adapter.ThingSeed{ID: d.ID}
+	}), 3)
+
+	// A non-nil empty selection is a user who deselected everything: include nothing.
+	assert.Empty(t, adapter.SeedsFromSelection(available, []string{}, func(d device) *adapter.ThingSeed {
 		return &adapter.ThingSeed{ID: d.ID}
 	}))
+
+	// A repeated third-party entry must not create a second thing at a second address.
+	duplicated := []device{{"1", "a"}, {"1", "a"}}
+
+	assert.Len(t, adapter.SeedsFromSelection(duplicated, []string{"1"}, func(d device) *adapter.ThingSeed {
+		return &adapter.ThingSeed{ID: d.ID}
+	}), 1)
 }

--- a/adapter/state.go
+++ b/adapter/state.go
@@ -193,7 +193,7 @@ func (s *thingState) Info(model any) error {
 
 	err := json.Unmarshal(s.model.Info, model)
 	if err != nil {
-		return fmt.Errorf("thing state: failed to unmarshal info of a thing with ID %s into a provided model: %w", s.ID(), err)
+		return fmt.Errorf("thing state: failed to unmarshal info of a thing with ID %s into a provided model: %w", s.model.ID, err)
 	}
 
 	return nil
@@ -209,7 +209,7 @@ func (s *thingState) State(model any) error {
 
 	err := json.Unmarshal(s.model.State, model)
 	if err != nil {
-		return fmt.Errorf("thing state: failed to unmarshal state of a thing with ID %s into a provided model: %w", s.ID(), err)
+		return fmt.Errorf("thing state: failed to unmarshal state of a thing with ID %s into a provided model: %w", s.model.ID, err)
 	}
 
 	return nil
@@ -221,14 +221,14 @@ func (s *thingState) SetState(model any) error {
 
 	b, err := json.Marshal(model)
 	if err != nil {
-		return fmt.Errorf("thing state: failed to marshal state of a thing with ID %s from a provided model: %w", s.ID(), err)
+		return fmt.Errorf("thing state: failed to marshal state of a thing with ID %s from a provided model: %w", s.model.ID, err)
 	}
 
 	s.model.State = b
 
 	err = s.state.Save()
 	if err != nil {
-		return fmt.Errorf("thing state: failed to persist state of a thing with ID %s: %w", s.ID(), err)
+		return fmt.Errorf("thing state: failed to persist state of a thing with ID %s: %w", s.model.ID, err)
 	}
 
 	return nil
@@ -249,7 +249,7 @@ func (s *thingState) SetInclusionChecksum(checksum uint32) error {
 
 	err := s.state.Save()
 	if err != nil {
-		return fmt.Errorf("thing state: failed to persist inclusion checksum of a thing with ID %s: %w", s.ID(), err)
+		return fmt.Errorf("thing state: failed to persist inclusion checksum of a thing with ID %s: %w", s.model.ID, err)
 	}
 
 	return nil

--- a/adapter/state_internal_test.go
+++ b/adapter/state_internal_test.go
@@ -1,0 +1,37 @@
+package adapter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestThingState_ErrorBranchesDoNotDeadlock pins that the error paths of the thing state do not
+// re-enter the state lock. They format the thing ID into their message, and reading it through
+// the ID() accessor would take a read lock on the non-reentrant mutex the writer already holds,
+// freezing the whole adapter permanently.
+func TestThingState_ErrorBranchesDoNotDeadlock(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewState(t.TempDir())
+	require.NoError(t, err)
+
+	ts, err := s.add(&thingStateModel{ID: "1", Address: "1"})
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+
+	go func() {
+		// A channel cannot be marshalled, so this takes the write lock and then fails.
+		done <- ts.SetState(make(chan int))
+	}()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("SetState deadlocked on its error branch")
+	}
+}

--- a/adapter/sync.go
+++ b/adapter/sync.go
@@ -1,26 +1,84 @@
 package adapter
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
-// ErrIncompleteFetch is returned by SyncThings when a fetched device list is missing a
-// currently-registered selected device, which usually means a partial or empty third-party
-// response. Reconciling on it would destroy live things, so it is skipped; callers typically
-// log and retry rather than treat it as fatal.
-var ErrIncompleteFetch = errors.New("adapter: incomplete device fetch, skipping reconcile")
+// SyncThings reconciles things to match the devices selected from a freshly fetched list and
+// returns the seeds it applied, ready to be passed to RebuildChangedThings without fetching
+// again.
+//
+// The fetch runs outside the adapter lock and is the sole authority. If it fails nothing is
+// mutated and the error is returned, so a network glitch can never wipe live things. If it
+// succeeds the response is complete by definition: every selected device absent from it is
+// destroyed, including when the response is empty. Adapters must therefore make their client
+// return an error - never a truncated or empty slice - on a non-2xx, a rate limit or an
+// unparsable body.
+//
+// A nil selection selects every available device; a non-nil empty selection selects none.
+//
+// Selected devices that vanished from the response and that the adapter does not own still get
+// an exclusion report, so an upgraded hub can drop stale nodes a legacy adapter left behind.
+// The device ID is used as the address of that report, which is only meaningful for adapters
+// pinning ThingSeed.CustomAddress to the device ID; it is suppressed whenever the ID is already
+// an ID or an address the adapter owns, so it can never exclude an unrelated thing.
+//
+// Every pass is best-effort per device: failures are collected with errors.Join and the seeds
+// are still returned, so a single broken device blocks neither the rest of the sync nor a
+// follow-up drift rebuild.
+//
+// SyncThings is not atomic: it takes and releases the adapter lock per operation. Adapters that
+// also handle cmd.thing.delete or configuration writes must serialise those against the sync
+// with a shared router.MessageHandlerLocker.
+func SyncThings[T any](
+	a Adapter,
+	fetch func() ([]T, error),
+	selected []string,
+	seed func(T) *ThingSeed,
+) (ThingSeeds, error) {
+	available, err := fetch()
+	if err != nil {
+		return nil, fmt.Errorf("adapter: fetch devices: %w", err)
+	}
 
-// SyncThings reconciles things to match the selected devices from a freshly fetched list: it
-// builds seeds with SeedsFromSelection and applies them via EnsureThings (create missing,
-// destroy stale). As a guard against a partial or empty fetch wiping live things, it refuses
-// to reconcile and returns ErrIncompleteFetch when a currently-registered selected device is
-// absent from available. The fetch, selection and device-to-seed mapping stay caller-supplied.
-func SyncThings[T any](a Adapter, available []T, selected []string, seed func(T) *ThingSeed) error {
 	seeds := SeedsFromSelection(available, selected, seed)
 
+	var errs []error
+
+	errs = append(errs, excludeVanishedDevices(a, selected, seeds)...)
+
+	if err := a.EnsureThings(seeds); err != nil {
+		errs = append(errs, err)
+	}
+
+	return seeds, errors.Join(errs...)
+}
+
+// excludeVanishedDevices announces an exclusion for every selected device the fetch no longer
+// lists and the adapter owns no thing for. It must run before EnsureThings: afterwards the
+// store entry is gone, so every legitimately destroyed device would look orphaned and be
+// excluded a second time at the wrong address.
+func excludeVanishedDevices(a Adapter, selected []string, seeds ThingSeeds) []error {
+	var errs []error
+
 	for _, id := range selected {
-		if a.ThingByID(id) != nil && !seeds.Contains(id) {
-			return ErrIncompleteFetch
+		if seeds.Contains(id) {
+			continue
+		}
+
+		if _, owned := a.ExchangeID(id); owned {
+			continue // EnsureThings destroys it and announces its real address.
+		}
+
+		if _, taken := a.ExchangeAddress(id); taken {
+			continue // The ID is another device's address; excluding it would kill that thing.
+		}
+
+		if err := a.DestroyThingByAddress(id); err != nil {
+			errs = append(errs, fmt.Errorf("adapter: exclude vanished device %s: %w", id, err))
 		}
 	}
 
-	return a.EnsureThings(seeds)
+	return errs
 }

--- a/adapter/sync.go
+++ b/adapter/sync.go
@@ -62,10 +62,20 @@ func SyncThings[T any](
 func excludeVanishedDevices(a Adapter, selected []string, seeds ThingSeeds) []error {
 	var errs []error
 
+	// Nothing dedupes the selection on the way into the configuration, and an ID repeated there
+	// would otherwise announce the same vanished device twice.
+	excluded := make(map[string]struct{}, len(selected))
+
 	for _, id := range selected {
 		if seeds.Contains(id) {
 			continue
 		}
+
+		if _, done := excluded[id]; done {
+			continue
+		}
+
+		excluded[id] = struct{}{}
 
 		if _, owned := a.ExchangeID(id); owned {
 			continue // EnsureThings destroys it and announces its real address.

--- a/adapter/sync_report_test.go
+++ b/adapter/sync_report_test.go
@@ -62,11 +62,15 @@ func TestSyncThings_AddsDeviceAndSendsInclusionReport(t *testing.T) { //nolint:p
 							t.Helper()
 
 							assert.Nil(t, ad.ThingByID("4"), "device 4 must not exist before the sync")
-							assert.NoError(t, adapter.SyncThings(ad, available, []string{"1", "2", "3", "4"}, seedByID))
+
+							_, err := adapter.SyncThings(ad, fetchOK(available), []string{"1", "2", "3", "4"}, seedByID)
+
+							assert.NoError(t, err)
 							assert.NotNil(t, ad.ThingByID("4"), "device 4 must be registered after the sync")
 						}},
 						Expectations: []*suite.Expectation{
-							expectInclusion("4").AtLeastOnce(),
+							expectInclusion("4").ExactlyOnce(),
+							expectAnyExclusion().Never(),
 						},
 					},
 				},
@@ -100,7 +104,10 @@ func TestSyncThings_RemovesDeviceAndSendsExclusionReport(t *testing.T) { //nolin
 							t.Helper()
 
 							assert.NotNil(t, ad.ThingByID("4"), "device 4 must exist before the sync")
-							assert.NoError(t, adapter.SyncThings(ad, available, []string{"1", "2", "3"}, seedByID))
+
+							_, err := adapter.SyncThings(ad, fetchOK(available), []string{"1", "2", "3"}, seedByID)
+
+							assert.NoError(t, err)
 							assert.Nil(t, ad.ThingByID("4"), "device 4 must be removed after the sync")
 						}},
 						Expectations: []*suite.Expectation{
@@ -189,6 +196,216 @@ func TestEnsureThings_RemovesDeviceAndSendsExclusionReport(t *testing.T) { //nol
 	}
 
 	s.Run(t)
+}
+
+func TestSyncThings_FetchFailureKeepsThings(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	// The device list cannot be fetched, e.g. the third party is down. Nothing may be touched:
+	// this is the guarantee that replaced the old refuse-to-reconcile guard.
+	seeds := adapter.ThingSeeds{seedByID(device{ID: "1"}), seedByID(device{ID: "2"}), seedByID(device{ID: "3"})}
+
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "a failed fetch destroys nothing",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    syncReportSetup(&ad, seeds),
+				Nodes: []*suite.Node{
+					{
+						Name:    "syncing with a failing fetch leaves every thing registered and silent",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							_, err := adapter.SyncThings(ad, fetchErr[device](errFetch), []string{"1", "2", "3"}, seedByID)
+
+							assert.ErrorIs(t, err, errFetch)
+							assert.NotNil(t, ad.ThingByID("1"), "device 1 must survive a failed fetch")
+							assert.NotNil(t, ad.ThingByID("2"), "device 2 must survive a failed fetch")
+							assert.NotNil(t, ad.ThingByID("3"), "device 3 must survive a failed fetch")
+						}},
+						Expectations: []*suite.Expectation{
+							expectAnyExclusion().Never(),
+							expectAnyInclusion().Never(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func TestSyncThings_EmptyFetchDestroysSelectedThings(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	// The fetch succeeded and reports no devices, so the account genuinely has none left. The
+	// inverse of the test above: a successful response is authoritative even when it is empty.
+	seeds := adapter.ThingSeeds{seedByID(device{ID: "1"}), seedByID(device{ID: "2"}), seedByID(device{ID: "3"})}
+
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "an empty successful fetch destroys every selected thing",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    syncReportSetup(&ad, seeds),
+				Nodes: []*suite.Node{
+					{
+						Name:    "syncing an empty device list excludes all three things",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							_, err := adapter.SyncThings(ad, fetchOK([]device{}), []string{"1", "2", "3"}, seedByID)
+
+							assert.NoError(t, err)
+							assert.Nil(t, ad.ThingByID("1"), "device 1 must be removed")
+							assert.Nil(t, ad.ThingByID("2"), "device 2 must be removed")
+							assert.Nil(t, ad.ThingByID("3"), "device 3 must be removed")
+						}},
+						Expectations: []*suite.Expectation{
+							expectExclusion("1").ExactlyOnce(),
+							expectExclusion("2").ExactlyOnce(),
+							expectExclusion("3").ExactlyOnce(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func TestSyncThings_ExcludesVanishedUnownedDevice(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	// Device "legacy" is selected but the adapter owns no thing for it - the state a hub is in
+	// after migrating from an adapter that predates the thing store. Its stale node must still
+	// be cleared, while the owned device is left untouched.
+	seeds := adapter.ThingSeeds{seedByID(device{ID: "1"})}
+
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "a vanished device the adapter does not own is still excluded",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    syncReportSetup(&ad, seeds),
+				Nodes: []*suite.Node{
+					{
+						Name:    "syncing without the legacy device excludes it at its own ID",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							_, err := adapter.SyncThings(ad, fetchOK([]device{{"1", "a"}}), []string{"1", "legacy"}, seedByID)
+
+							assert.NoError(t, err)
+							assert.NotNil(t, ad.ThingByID("1"), "the owned device must survive")
+						}},
+						Expectations: []*suite.Expectation{
+							expectExclusion("legacy").ExactlyOnce(),
+							expectExclusion("1").Never(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func TestEnsureThings_ContinuesAfterFactoryError(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	// One device cannot be built. Best effort means the other two are still created, and the
+	// broken one leaves no state record behind, so a later attempt retries it rather than
+	// treating it as present forever.
+	setup := suite.BaseSetup(func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
+		t.Helper()
+
+		factory := adapterhelper.FactoryHelper(func(_ adapter.Adapter, publisher adapter.Publisher, ts adapter.ThingState) (adapter.Thing, error) {
+			if ts.ID() == "bad" {
+				return nil, errFactory
+			}
+
+			cfg := &adapter.ThingConfig{
+				InclusionReport: &fimptype.ThingInclusionReport{Address: ts.Address()},
+				Connector:       mockedadapter.NewDefaultConnector(t),
+			}
+
+			return adapter.NewThing(publisher, ts, cfg), nil
+		})
+
+		ad = adapterhelper.SeedAdapter(t, adapterhelper.PrepareAdapter(t, testAdapterWorkDir, mqtt, factory), nil)
+
+		return adapter.RouteAdapter(ad), nil, nil
+	})
+
+	all := adapter.ThingSeeds{seedByID(device{ID: "good1"}), seedByID(device{ID: "bad"}), seedByID(device{ID: "good2"})}
+
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "a device that cannot be built does not block the others",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    setup,
+				Nodes: []*suite.Node{
+					{
+						Name:    "the two healthy devices are created and announced",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							err := ad.EnsureThings(all)
+
+							assert.ErrorIs(t, err, errFactory)
+							assert.NotNil(t, ad.ThingByID("good1"), "a healthy device must be created")
+							assert.NotNil(t, ad.ThingByID("good2"), "a healthy device after the broken one must be created")
+							assert.Nil(t, ad.ThingByID("bad"), "the broken device must not be registered")
+						}},
+						Expectations: []*suite.Expectation{
+							expectInclusion("good1").ExactlyOnce(),
+							expectInclusion("good2").ExactlyOnce(),
+						},
+					},
+					{
+						Name:    "the broken device is retried rather than persisted as a ghost",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							// A leftover state record would make EnsureThings treat "bad" as
+							// already present and silently succeed.
+							assert.ErrorIs(t, ad.EnsureThings(all), errFactory)
+						}},
+						Expectations: []*suite.Expectation{
+							expectAnyExclusion().Never(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func expectAnyInclusion() *suite.Expectation {
+	return suite.NewExpectation().
+		ExpectTopic(testAdapterEvtTopic).
+		ExpectType(adapter.EvtThingInclusionReport).
+		ExpectService(testAdapterName)
+}
+
+func expectAnyExclusion() *suite.Expectation {
+	return suite.NewExpectation().
+		ExpectTopic(testAdapterEvtTopic).
+		ExpectType(adapter.EvtThingExclusionReport).
+		ExpectService(testAdapterName)
 }
 
 func expectInclusion(address string) *suite.Expectation {

--- a/adapter/sync_test.go
+++ b/adapter/sync_test.go
@@ -1,6 +1,7 @@
 package adapter_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,8 +13,23 @@ import (
 
 type device struct{ ID, Name string }
 
+var (
+	errFetch   = errors.New("fetch failed")
+	errFactory = errors.New("factory failed")
+)
+
 func seedDevice(d device) *adapter.ThingSeed {
 	return &adapter.ThingSeed{ID: d.ID, Info: d.Name}
+}
+
+// fetchOK returns a fetch callback succeeding with the provided devices.
+func fetchOK[T any](items []T) func() ([]T, error) {
+	return func() ([]T, error) { return items, nil }
+}
+
+// fetchErr returns a fetch callback failing with the provided error.
+func fetchErr[T any](err error) func() ([]T, error) {
+	return func() ([]T, error) { return nil, err }
 }
 
 func TestSyncThings_ReconcilesSelectedDevices(t *testing.T) {
@@ -22,27 +38,102 @@ func TestSyncThings_ReconcilesSelectedDevices(t *testing.T) {
 	available := []device{{"1", "a"}, {"2", "b"}, {"3", "c"}}
 
 	a := mockedadapter.NewAdapter(t)
-	a.On("ThingByID", mock.Anything).Return(nil)
 	a.On("EnsureThings", mock.MatchedBy(func(seeds adapter.ThingSeeds) bool {
 		return len(seeds) == 2 && seeds.Contains("1") && seeds.Contains("3")
 	})).Return(nil)
 
-	assert.NoError(t, adapter.SyncThings(a, available, []string{"1", "3"}, seedDevice))
+	seeds, err := adapter.SyncThings(a, fetchOK(available), []string{"1", "3"}, seedDevice)
+
+	assert.NoError(t, err)
+	assert.Len(t, seeds, 2)
+	// Both selected devices are in the fetched list, so nothing looks vanished.
+	a.AssertNotCalled(t, "DestroyThingByAddress", mock.Anything)
 }
 
-func TestSyncThings_GuardsAgainstIncompleteFetch(t *testing.T) {
+func TestSyncThings_FetchFailureMutatesNothing(t *testing.T) {
 	t.Parallel()
 
-	// Device "2" is selected and already registered, but absent from the fetched list: a
-	// partial response. SyncThings must not destroy it, so EnsureThings is never called.
-	available := []device{{"1", "a"}}
+	// No expectations are registered: the mock fails the test on any adapter call, which is
+	// what proves a failed fetch mutates nothing.
+	a := mockedadapter.NewAdapter(t)
+
+	seeds, err := adapter.SyncThings(a, fetchErr[device](errFetch), []string{"1"}, seedDevice)
+
+	assert.ErrorIs(t, err, errFetch)
+	assert.Nil(t, seeds)
+	a.AssertNotCalled(t, "EnsureThings", mock.Anything)
+	a.AssertNotCalled(t, "DestroyThingByAddress", mock.Anything)
+}
+
+func TestSyncThings_ExcludesVanishedDevice(t *testing.T) {
+	t.Parallel()
+
+	// Device "2" is selected but the successful fetch no longer lists it, and the adapter owns
+	// no thing for it: a node left behind by a legacy adapter, which still needs an exclusion.
+	a := mockedadapter.NewAdapter(t)
+	a.On("ExchangeID", "2").Return("", false)
+	a.On("ExchangeAddress", "2").Return("", false)
+	a.On("DestroyThingByAddress", "2").Return(nil)
+	a.On("EnsureThings", mock.Anything).Return(nil)
+
+	_, err := adapter.SyncThings(a, fetchOK([]device{{"1", "a"}}), []string{"1", "2"}, seedDevice)
+
+	assert.NoError(t, err)
+}
+
+func TestSyncThings_DoesNotExcludeOwnedOrForeignAddress(t *testing.T) {
+	t.Parallel()
+
+	// "2" is owned by the adapter, so EnsureThings destroys it and announces its real address.
+	// "3" is not an owned ID but happens to be another thing's address, so excluding it would
+	// kill an unrelated thing.
+	a := mockedadapter.NewAdapter(t)
+	a.On("ExchangeID", "2").Return("20", true)
+	a.On("ExchangeID", "3").Return("", false)
+	a.On("ExchangeAddress", "3").Return("other", true)
+	a.On("EnsureThings", mock.Anything).Return(nil)
+
+	_, err := adapter.SyncThings(a, fetchOK([]device{{"1", "a"}}), []string{"1", "2", "3"}, seedDevice)
+
+	assert.NoError(t, err)
+	a.AssertNotCalled(t, "DestroyThingByAddress", mock.Anything)
+}
+
+func TestSyncThings_NilSelectionIncludesEverything(t *testing.T) {
+	t.Parallel()
+
+	available := []device{{"1", "a"}, {"2", "b"}}
 
 	a := mockedadapter.NewAdapter(t)
-	a.On("ThingByID", "1").Return(nil)
-	a.On("ThingByID", "2").Return(&mockedadapter.Thing{})
+	a.On("EnsureThings", mock.MatchedBy(func(seeds adapter.ThingSeeds) bool {
+		return len(seeds) == 2 && seeds.Contains("1") && seeds.Contains("2")
+	})).Return(nil)
 
-	err := adapter.SyncThings(a, available, []string{"1", "2"}, seedDevice)
+	seeds, err := adapter.SyncThings(a, fetchOK(available), nil, seedDevice)
 
-	assert.ErrorIs(t, err, adapter.ErrIncompleteFetch)
-	a.AssertNotCalled(t, "EnsureThings", mock.Anything)
+	assert.NoError(t, err)
+	assert.Len(t, seeds, 2)
+	// Nothing is selected by ID, so the vanished-device pass has nothing to iterate.
+	a.AssertNotCalled(t, "ExchangeID", mock.Anything)
+	a.AssertNotCalled(t, "DestroyThingByAddress", mock.Anything)
+}
+
+func TestSyncThings_AggregatesFailures(t *testing.T) {
+	t.Parallel()
+
+	errExclude, errEnsure := errors.New("exclude"), errors.New("ensure")
+
+	a := mockedadapter.NewAdapter(t)
+	a.On("ExchangeID", "2").Return("", false)
+	a.On("ExchangeAddress", "2").Return("", false)
+	a.On("DestroyThingByAddress", "2").Return(errExclude)
+	a.On("EnsureThings", mock.Anything).Return(errEnsure)
+
+	seeds, err := adapter.SyncThings(a, fetchOK([]device{{"1", "a"}}), []string{"1", "2"}, seedDevice)
+
+	// A failure of one device neither hides the other nor withholds the seeds a follow-up
+	// drift rebuild needs.
+	assert.ErrorIs(t, err, errExclude)
+	assert.ErrorIs(t, err, errEnsure)
+	assert.Len(t, seeds, 1)
 }

--- a/adapter/sync_test.go
+++ b/adapter/sync_test.go
@@ -81,6 +81,23 @@ func TestSyncThings_ExcludesVanishedDevice(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSyncThings_ExcludesDuplicatedSelectedDeviceOnce(t *testing.T) {
+	t.Parallel()
+
+	// Nothing dedupes the selection on the way into the configuration, so the same vanished ID can
+	// appear twice. Announcing an exclusion per occurrence is just confusing noise in the logs.
+	a := mockedadapter.NewAdapter(t)
+	a.On("ExchangeID", "2").Return("", false).Once()
+	a.On("ExchangeAddress", "2").Return("", false).Once()
+	a.On("DestroyThingByAddress", "2").Return(nil).Once()
+	a.On("EnsureThings", mock.Anything).Return(nil)
+
+	_, err := adapter.SyncThings(a, fetchOK([]device{{"1", "a"}}), []string{"1", "2", "2"}, seedDevice)
+
+	assert.NoError(t, err)
+	a.AssertNumberOfCalls(t, "DestroyThingByAddress", 1)
+}
+
 func TestSyncThings_DoesNotExcludeOwnedOrForeignAddress(t *testing.T) {
 	t.Parallel()
 

--- a/bootstrap/edge.go
+++ b/bootstrap/edge.go
@@ -17,6 +17,8 @@ import (
 // EdgeRouting combines the standard edge adapter routing (default, app and adapter routes)
 // with domain-specific extras. excludeAllThings is forwarded to app.RouteApp: typically
 // ad.DestroyAllThings, or nil when the application destroys things in Uninstall itself.
+// adapterOptions is forwarded to adapter.RouteAdapter: typically adapter.WithSelectionRemover
+// and adapter.WithLocker(locker) for an application with a device selection.
 func EdgeRouting[C any](
 	serviceName fimptype.ServiceNameT,
 	configGetter func() any,
@@ -28,12 +30,13 @@ func EdgeRouting[C any](
 	application app.App,
 	ad adapter.Adapter,
 	excludeAllThings func() error,
+	adapterOptions []adapter.RoutingOption,
 	extras ...[]*router.Routing,
 ) []*router.Routing {
 	routes := [][]*router.Routing{
 		DefaultRoute(serviceName, configGetter, tel),
 		app.RouteApp(serviceName, appLifecycle, configStorage, configFactory, locker, application, excludeAllThings),
-		adapter.RouteAdapter(ad),
+		adapter.RouteAdapter(ad, adapterOptions...),
 	}
 
 	return router.Combine(append(routes, extras...)...)

--- a/bootstrap/edge.go
+++ b/bootstrap/edge.go
@@ -17,8 +17,8 @@ import (
 // EdgeRouting combines the standard edge adapter routing (default, app and adapter routes)
 // with domain-specific extras. excludeAllThings is forwarded to app.RouteApp: typically
 // ad.DestroyAllThings, or nil when the application destroys things in Uninstall itself.
-// adapterOptions is forwarded to adapter.RouteAdapter: typically adapter.WithSelectionRemover
-// and adapter.WithLocker(locker) for an application with a device selection.
+// adapterOptions is forwarded to adapter.RouteAdapter: typically
+// adapter.WithSelection(store, locker) for an application with a device selection.
 func EdgeRouting[C any](
 	serviceName fimptype.ServiceNameT,
 	configGetter func() any,

--- a/selection/manifest.go
+++ b/selection/manifest.go
@@ -1,0 +1,85 @@
+package selection
+
+import (
+	"fmt"
+
+	"github.com/futurehomeno/cliffhanger/manifest"
+)
+
+// defaultLanguage is the language key of the block texts, matching the manifest templates.
+const defaultLanguage = "en"
+
+// Block identifies the manifest UI block and application config holding the device selector, and
+// the texts shown when the selector cannot be rendered.
+type Block struct {
+	// Block is the ID of the UI block hosting the selector.
+	Block string
+	// Config is the ID of the application config holding the multi-select.
+	Config string
+	// NotReady is the block text shown when the application is not ready to list devices, e.g.
+	// because the user is not logged in. It also hides the selector.
+	NotReady string
+	// Failed is the block text shown when the device fetch fails. The selector is left as the
+	// template defines it, so a stale option list is never presented as current.
+	Failed string
+}
+
+// PrepareManifest renders the device selector into the manifest, covering its three states: not
+// ready (show NotReady and hide the selector), fetch failed (show Failed and return the error for
+// the caller to log) and ready (fill the selector and show it).
+//
+// A manifest template that does not declare the referenced block or config is ignored rather than
+// dereferenced, so renaming either in packaging cannot panic the application.
+func PrepareManifest[T any](
+	m *manifest.Manifest,
+	b Block,
+	ready bool,
+	fetch func() ([]T, error),
+	option func(T) manifest.SelectOption,
+) error {
+	block, config := m.GetUIBlock(b.Block), m.GetAppConfig(b.Config)
+
+	if !ready {
+		setText(block, b.NotReady)
+
+		if config != nil {
+			config.Hide()
+		}
+
+		return nil
+	}
+
+	devices, err := fetch()
+	if err != nil {
+		setText(block, b.Failed)
+
+		return fmt.Errorf("selection: fetch available devices: %w", err)
+	}
+
+	if config == nil {
+		return nil
+	}
+
+	options := make([]manifest.SelectOption, 0, len(devices))
+
+	for _, device := range devices {
+		options = append(options, option(device))
+	}
+
+	config.UI.Select = options
+	config.Hidden = false
+
+	return nil
+}
+
+func setText(block *manifest.AppUBLock, text string) {
+	if block == nil || text == "" {
+		return
+	}
+
+	if block.Text == nil {
+		block.Text = manifest.MultilingualLabel{}
+	}
+
+	block.Text[defaultLanguage] = text
+}

--- a/selection/manifest_test.go
+++ b/selection/manifest_test.go
@@ -1,0 +1,107 @@
+package selection_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/futurehomeno/cliffhanger/manifest"
+	"github.com/futurehomeno/cliffhanger/selection"
+)
+
+const (
+	testBlockID  = "configuration"
+	testConfigID = "selected_devices"
+)
+
+var testBlock = selection.Block{
+	Block:    testBlockID,
+	Config:   testConfigID,
+	NotReady: "Please log in to continue.",
+	Failed:   "Failed to retrieve devices, please try again later.",
+}
+
+type testDevice struct{ ID, Name string }
+
+func testDeviceOption(d testDevice) manifest.SelectOption {
+	return manifest.SelectOption{Val: d.ID, Label: map[string]string{"en": d.Name}}
+}
+
+func testManifest() *manifest.Manifest {
+	return &manifest.Manifest{
+		UIBlocks: []manifest.AppUBLock{{ID: testBlockID, Text: manifest.MultilingualLabel{"en": "template"}}},
+		Configs:  []manifest.AppConfig{{ID: testConfigID, Hidden: true}},
+	}
+}
+
+func TestPrepareManifest_NotReadyHidesTheSelector(t *testing.T) {
+	t.Parallel()
+
+	m := testManifest()
+
+	err := selection.PrepareManifest(m, testBlock, false, func() ([]testDevice, error) {
+		t.Fatal("the device list must not be fetched when the application is not ready")
+
+		return nil, nil
+	}, testDeviceOption)
+
+	require.NoError(t, err)
+	assert.Equal(t, testBlock.NotReady, m.GetUIBlock(testBlockID).Text["en"])
+	assert.True(t, m.GetAppConfig(testConfigID).Hidden)
+}
+
+func TestPrepareManifest_FetchFailureLeavesTheSelectorAlone(t *testing.T) {
+	t.Parallel()
+
+	errFetch := errors.New("fetch failed")
+	m := testManifest()
+
+	err := selection.PrepareManifest(m, testBlock, true, func() ([]testDevice, error) {
+		return nil, errFetch
+	}, testDeviceOption)
+
+	assert.ErrorIs(t, err, errFetch)
+	assert.Equal(t, testBlock.Failed, m.GetUIBlock(testBlockID).Text["en"])
+	// A stale option list is never presented as current.
+	assert.True(t, m.GetAppConfig(testConfigID).Hidden)
+	assert.Nil(t, m.GetAppConfig(testConfigID).UI.Select)
+}
+
+func TestPrepareManifest_ReadyFillsTheSelector(t *testing.T) {
+	t.Parallel()
+
+	m := testManifest()
+
+	err := selection.PrepareManifest(m, testBlock, true, func() ([]testDevice, error) {
+		return []testDevice{{"1", "first"}, {"2", "second"}}, nil
+	}, testDeviceOption)
+
+	require.NoError(t, err)
+
+	config := m.GetAppConfig(testConfigID)
+
+	assert.False(t, config.Hidden)
+	assert.Equal(t, []manifest.SelectOption{
+		{Val: "1", Label: map[string]string{"en": "first"}},
+		{Val: "2", Label: map[string]string{"en": "second"}},
+	}, config.UI.Select)
+	// The block text is left as the template wrote it when there is nothing to explain.
+	assert.Equal(t, "template", m.GetUIBlock(testBlockID).Text["en"])
+}
+
+func TestPrepareManifest_ToleratesAMissingBlockOrConfig(t *testing.T) {
+	t.Parallel()
+
+	// Renaming either in packaging must not panic the application on cmd.app.get_manifest.
+	empty := &manifest.Manifest{}
+
+	require.NoError(t, selection.PrepareManifest(empty, testBlock, false, func() ([]testDevice, error) {
+		return nil, nil
+	}, testDeviceOption))
+
+	require.NoError(t, selection.PrepareManifest(empty, testBlock, true, func() ([]testDevice, error) {
+		return []testDevice{{"1", "first"}}, nil
+	}, testDeviceOption))
+}

--- a/selection/selection.go
+++ b/selection/selection.go
@@ -1,0 +1,69 @@
+// Package selection models the user-chosen subset of a third-party account's devices: its
+// storage in the application configuration, its rendering into the manifest and its maintenance
+// when a device is deleted from the hub.
+package selection
+
+import "slices"
+
+// Selection is a user's chosen subset of device IDs.
+//
+// A nil Selection includes every available device; a non-nil, zero-length Selection includes
+// none. The distinction is load-bearing - an application that has never been configured must not
+// be mistaken for one where the user deselected everything - and it survives JSON in both
+// directions: an absent key or null unmarshals to nil and marshals back to null, while []
+// unmarshals to an empty non-nil Selection and marshals back to [].
+//
+// Every copy taken in this package preserves it too. Note that the idiomatic
+// append([]string(nil), s...) and slices.Clone both collapse empty to nil, so use Clone.
+type Selection []string
+
+// IncludeAll reports whether the selection includes every available device.
+func (s Selection) IncludeAll() bool { return s == nil }
+
+// Contains reports whether a device is included. It is always true for a nil Selection.
+func (s Selection) Contains(id string) bool {
+	return s == nil || slices.Contains(s, id)
+}
+
+// Clone returns a copy that preserves the nil/empty distinction.
+func (s Selection) Clone() Selection {
+	if s == nil {
+		return nil
+	}
+
+	return append(make(Selection, 0, len(s)), s...)
+}
+
+// Without returns a copy with the device removed and reports whether anything was removed. A nil
+// Selection is returned unchanged: "every device" cannot express an exclusion, so an application
+// that supports device deletion must keep an explicit selection.
+func (s Selection) Without(id string) (Selection, bool) {
+	if s == nil || !slices.Contains(s, id) {
+		return s, false
+	}
+
+	next := make(Selection, 0, len(s)-1)
+
+	for _, v := range s {
+		if v != id {
+			next = append(next, v)
+		}
+	}
+
+	return next, true
+}
+
+// Devices is a configuration mixin carrying a device selection. Embed it in an application's
+// public configuration to get the standard selected_devices field.
+type Devices struct {
+	SelectedDevices Selection `json:"selected_devices"`
+}
+
+// Selection returns a pointer to the stored selection, satisfying Selectable.
+func (d *Devices) Selection() *Selection { return &d.SelectedDevices }
+
+// Selectable is a configuration model carrying a device selection. It is satisfied by any model
+// embedding Devices.
+type Selectable interface {
+	Selection() *Selection
+}

--- a/selection/selection_test.go
+++ b/selection/selection_test.go
@@ -1,0 +1,96 @@
+package selection_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/futurehomeno/cliffhanger/selection"
+)
+
+func TestSelection_NilMeansAllEmptyMeansNone(t *testing.T) {
+	t.Parallel()
+
+	var all selection.Selection
+
+	assert.True(t, all.IncludeAll())
+	assert.True(t, all.Contains("anything"))
+
+	none := selection.Selection{}
+
+	assert.False(t, none.IncludeAll())
+	assert.False(t, none.Contains("anything"))
+
+	some := selection.Selection{"a"}
+
+	assert.False(t, some.IncludeAll())
+	assert.True(t, some.Contains("a"))
+	assert.False(t, some.Contains("b"))
+}
+
+func TestSelection_CopiesPreserveTheDistinction(t *testing.T) {
+	t.Parallel()
+
+	// The trap this type exists to avoid: the idiomatic copy collapses empty to nil, which
+	// would silently turn "the user deselected everything" into "include every device".
+	require.Nil(t, append([]string(nil), selection.Selection{}...))
+
+	assert.NotNil(t, selection.Selection{}.Clone())
+	assert.False(t, selection.Selection{}.Clone().IncludeAll())
+	assert.Nil(t, selection.Selection(nil).Clone())
+
+	empty, removed := selection.Selection{}.Without("a")
+
+	assert.False(t, removed)
+	assert.False(t, empty.IncludeAll())
+
+	// Removing the last device leaves "none", never "all".
+	last, removed := selection.Selection{"a"}.Without("a")
+
+	assert.True(t, removed)
+	assert.False(t, last.IncludeAll())
+	assert.Empty(t, last)
+
+	// "Every device" cannot express an exclusion.
+	unchanged, removed := selection.Selection(nil).Without("a")
+
+	assert.False(t, removed)
+	assert.True(t, unchanged.IncludeAll())
+
+	remaining, removed := selection.Selection{"a", "b"}.Without("a")
+
+	assert.True(t, removed)
+	assert.Equal(t, selection.Selection{"b"}, remaining)
+}
+
+func TestSelection_SurvivesJSONInBothDirections(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		raw        string
+		includeAll bool
+		want       string
+	}{
+		{"absent key", `{}`, true, `{"selected_devices":null}`},
+		{"null", `{"selected_devices":null}`, true, `{"selected_devices":null}`},
+		{"empty list", `{"selected_devices":[]}`, false, `{"selected_devices":[]}`},
+		{"populated list", `{"selected_devices":["a"]}`, false, `{"selected_devices":["a"]}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var devices selection.Devices
+
+			require.NoError(t, json.Unmarshal([]byte(tc.raw), &devices))
+			assert.Equal(t, tc.includeAll, devices.Selection().IncludeAll())
+
+			out, err := json.Marshal(devices)
+
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(out))
+		})
+	}
+}

--- a/selection/store.go
+++ b/selection/store.go
@@ -27,7 +27,7 @@ func (s *Store) Set(sel Selection) error { return s.set(sel.Clone()) }
 // selected or when the selection includes every device.
 //
 // The read-then-write is not atomic, so it must run under the same handler lock as the
-// configuration writes it can race, which adapter.WithLocker provides.
+// configuration writes it can race, which adapter.WithSelection provides.
 func (s *Store) Remove(id string) error {
 	next, removed := s.get().Without(id)
 	if !removed {

--- a/selection/store.go
+++ b/selection/store.go
@@ -1,0 +1,38 @@
+package selection
+
+// Store reads and writes a Selection inside an application configuration. It borrows the
+// configuration service's lock and its configured-at stamping rather than introducing a second
+// lock over the same model.
+type Store struct {
+	get func() Selection
+	set func(Selection) error
+}
+
+// NewStore wires a Store to a configuration service's read and write paths. get must read a copy
+// under the service's read lock; set must apply the value under its write lock, stamp the
+// configuration time and save.
+func NewStore(get func() Selection, set func(Selection) error) *Store {
+	return &Store{get: get, set: set}
+}
+
+// Get returns the selection, preserving the nil/empty distinction.
+func (s *Store) Get() Selection { return s.get() }
+
+// Set replaces the selection with a copy of the provided one. The copy defends against a caller
+// mutating the slice it handed over.
+func (s *Store) Set(sel Selection) error { return s.set(sel.Clone()) }
+
+// Remove drops a device from the selection, e.g. after cmd.thing.delete, so the device is not
+// recreated by the next sync. It is a no-op - no write, no stamp - when the device is not
+// selected or when the selection includes every device.
+//
+// The read-then-write is not atomic, so it must run under the same handler lock as the
+// configuration writes it can race, which adapter.WithLocker provides.
+func (s *Store) Remove(id string) error {
+	next, removed := s.get().Without(id)
+	if !removed {
+		return nil
+	}
+
+	return s.set(next)
+}

--- a/selection/store_test.go
+++ b/selection/store_test.go
@@ -1,0 +1,82 @@
+package selection_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/futurehomeno/cliffhanger/selection"
+)
+
+// testStore returns a store over an in-memory selection along with the number of writes it
+// performed, so a no-op removal can be told apart from one that stamps the configuration.
+func testStore(initial selection.Selection) (*selection.Store, *selection.Selection, *int) {
+	sel, writes := initial, 0
+
+	store := selection.NewStore(
+		func() selection.Selection { return sel },
+		func(next selection.Selection) error { sel = next; writes++; return nil },
+	)
+
+	return store, &sel, &writes
+}
+
+func TestStore_GetSetRemove(t *testing.T) {
+	t.Parallel()
+
+	store, sel, writes := testStore(selection.Selection{"a", "b"})
+
+	assert.Equal(t, selection.Selection{"a", "b"}, store.Get())
+
+	require.NoError(t, store.Remove("a"))
+	assert.Equal(t, selection.Selection{"b"}, *sel)
+	assert.Equal(t, 1, *writes)
+
+	// Removing a device that is not selected must not stamp the configuration time.
+	require.NoError(t, store.Remove("missing"))
+	assert.Equal(t, 1, *writes)
+
+	require.NoError(t, store.Set(selection.Selection{"c"}))
+	assert.Equal(t, selection.Selection{"c"}, store.Get())
+}
+
+func TestStore_SetCopiesTheCallersSlice(t *testing.T) {
+	t.Parallel()
+
+	store, sel, _ := testStore(nil)
+
+	provided := selection.Selection{"a"}
+
+	require.NoError(t, store.Set(provided))
+
+	provided[0] = "mutated"
+
+	assert.Equal(t, selection.Selection{"a"}, *sel)
+}
+
+func TestStore_RemoveOnIncludeAllIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	// "Every device" cannot express an exclusion, so the selection is left alone rather than
+	// being silently materialised into an explicit list.
+	store, sel, writes := testStore(nil)
+
+	require.NoError(t, store.Remove("a"))
+	assert.True(t, sel.IncludeAll())
+	assert.Equal(t, 0, *writes)
+}
+
+func TestStore_RemovePropagatesWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	errWrite := errors.New("write failed")
+
+	store := selection.NewStore(
+		func() selection.Selection { return selection.Selection{"a"} },
+		func(selection.Selection) error { return errWrite },
+	)
+
+	assert.ErrorIs(t, store.Remove("a"), errWrite)
+}


### PR DESCRIPTION
## Why

Three edge adapters (sensibo, zaptec, easee) hand-roll the same device selection: a `selected_devices` config list, a manifest checkbox builder, a fetch/filter/seed pipeline and — in sensibo's case — an extra `cmd.thing.delete` route. Sensibo v3.0.1 (`0f321f2`) is the most complete version and its behaviour was verified by hand on a hub, which is what exposed the defects fixed here. This lifts the concept into the framework so those adapters can delete their copies.

No adapter is on v1.3.0 yet, so `SyncThings` / `SeedsFromSelection` / `RebuildChangedThings` have zero external callers and the breaking changes below are free.

## Fetch ownership replaces the anti-wipe guard

```go
func SyncThings[T any](a Adapter, fetch func() ([]T, error), selected []string, seed func(T) *ThingSeed) (ThingSeeds, error)
```

The sync now owns the fetch, so "never destroy on a failed call" is structurally impossible to get wrong — no caller can hand in a list it failed to fetch. A failed fetch returns before any adapter call; a successful one is authoritative, so a device it no longer lists is excluded **even when the response is empty**.

`ErrIncompleteFetch` is deleted. It refused the *whole* reconcile whenever a registered selected device was missing, which both blocked adding an unrelated present device and made a device genuinely deleted from the account impossible to exclude. The anti-wipe responsibility moves into each adapter's client, which must turn a partial or rate-limited response into an error rather than a short slice.

Returning the applied seeds means a follow-up `RebuildChangedThings` does not fetch again, and lets the caller filter them first — sensibo's null-capabilities guard needs no framework hook.

## Exclusion for devices the adapter does not own

`EnsureThings` only destroys what it owns, so an upgrade from a pre-cliffhanger adapter leaves stale hub nodes behind. Selected devices absent from the fetch now get an exclusion at their own ID, guarded so it can never fire for an owned ID or another thing's address.

## Best effort, per device

`EnsureThings`, `RebuildChangedThings` and `DestroyAllThings` aborted on the first bad device, so one broken device blocked every other one. They now continue and join their errors — a non-nil error therefore means *partially applied*, not "nothing happened".

`createThing` rolls its state record back on failure. A record with no live thing is a ghost `EnsureThings` treats as present forever, leaving the device permanently missing; best-effort passes make that far more likely, since a failure no longer aborts the sync.

## cmd.thing.delete

Resolves the device ID **before** the destroy — destroying drops the record mapping address to ID — and hands it to an optional `SelectionRemover`:

```go
adapter.RouteAdapter(ad, adapter.WithSelectionRemover(store), adapter.WithLocker(locker))
```

Folding this into the framework handler rather than leaving each adapter to register a second route makes the ordering structurally impossible to get wrong. Sensibo's own route works today only because its address *is* the device ID; zaptec and easee use assigned numeric addresses and a route running after the destroy would silently remove nothing.

An empty address is now rejected instead of publishing an exclusion report for address `""`.

## New `selection` package

`Selection` (nil = include all, non-nil empty = include none), the `Devices` config mixin carrying `selected_devices`, `Store`, and `PrepareManifest` for the selector's three states (not ready / fetch failed / ready).

The nil/empty distinction is load-bearing: an application that was never configured must not be mistaken for one where the user deselected everything. Both `append([]string(nil), s...)` and `slices.Clone` collapse empty to nil, which is why `Selection` owns its `Clone` — and there is a test asserting exactly that trap.

`selection` imports only `config` and `manifest`; `adapter.SelectionRemover` is a narrow consumer-side interface, so the `adapter ↮ app/config` rule is preserved.

## Drive-by: a real deadlock

`thingState.SetState` / `SetInclusionChecksum` took the write lock and then formatted the thing ID through `ID()`, which takes a read lock on the same **non-reentrant** mutex — a guaranteed self-deadlock. `Info` / `State` have the same shape under `RLock`. `RebuildChangedThings` reaches both branches while holding the adapter lock, and making these passes best-effort means the error branches get exercised instead of aborting first. Five lines, no API change, with a 2s-timeout regression test.

## Tests

New coverage for the flows verified by hand on sensibo, now pinned in the framework:

- select a new device → created, inclusion report exactly once, no exclusion
- deselect → destroyed + exclusion; deselected *and* absent from the fetch → still exactly one exclusion
- `cmd.thing.delete` → destroyed, excluded, deselected, **not** re-created by the next sync; re-selecting brings it back at the same address
- fetch fails → zero adapter calls, nothing destroyed, no reports
- fetch succeeds but empty → everything selected destroyed
- vanished device with no thing in the store → exclusion still emitted
- one device failing mid-pass → the others still reconcile, error aggregated, broken device retried rather than persisted as a ghost
- `cmd.thing.delete` with empty / missing / non-map address → error report, no exclusion
- nil vs empty survives `Clone`, `Without` and JSON round-trip in both directions

`make test` green (`selection` 97.7%), `golangci-lint run` 0 issues, `go vet` clean, `-race` clean on `adapter` and `selection`.

The API was also compile-checked against sensibo's real call sites: `collectSeeds`, `excludeVanishedDevices`, `reconcileThings`, `rebuildThing`, `checksum`, `inclusionChecksum`, `freshThingState`, `routeCmdThingDelete` and `prepareBlockConfiguration` all map onto it, and `ReloadNode` becomes `RebuildChangedThings(ThingSeeds{seed})`.

## Migration notes for the adapters

- **sensibo** — needs a config migration pinning `nil` → `Selection{}` before adopting nil-means-all, or a hub whose `config.json` lacks the key flips from "no pods" to "every pod in the account". Its defaults ship `[]`, so only odd installs are at risk, but the migration must land in the same release as the bump.
- **zaptec** — the one with teeth. Its 3-retry `missingSelected` budget must move **inside** its fetch closure and return an error, because with the framework guard gone a Zaptec outage answering `200 []` will destroy every charger. Existing installs already store `null`, so nil-means-all matches its current "empty = all chargers" with no migration, and it gains a working `cmd.thing.delete` it does not have today.
- **easee** — absent key → nil → all chargers is byte-identical to today, no migration.

`.claude/skills/port_to_cliffhanger_1.3` is updated in this PR; it documented the old signature and `ErrIncompleteFetch` in four places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)