### PR TITLE
Fix fan_ctrl mode contract: string value types, report actual mode

### DIFF
--- a/adapter/service/fanctrl/routing_test.go
+++ b/adapter/service/fanctrl/routing_test.go
@@ -121,6 +121,23 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 	s.Run(t)
 }
 
+func TestSpecification(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]fimptype.ValueTypeT{
+		fanctrl.CmdModeSet:       fimptype.VTypeString,
+		fanctrl.EvtModeReport:    fimptype.VTypeString,
+		fanctrl.CmdModeGetReport: fimptype.VTypeNull,
+		router.EvtErrorReport:    fimptype.VTypeString,
+	}
+
+	for _, intf := range fanctrl.Specification("test_adapter", "1", "2", nil, []string{"normal"}).Interfaces {
+		if intf.ValueType != want[intf.MsgType] {
+			t.Errorf("%s: declared value type %q, want %q", intf.MsgType, intf.ValueType, want[intf.MsgType])
+		}
+	}
+}
+
 func routeService(controller *mockedfanctrl.Controller) cliffSuite.BaseSetup {
 	return func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []cliffSuite.Mock) {
 		t.Helper()

--- a/adapter/service/fanctrl/routing_test.go
+++ b/adapter/service/fanctrl/routing_test.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/futurehomeno/fimpgo"
 	"github.com/futurehomeno/fimpgo/fimptype"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/futurehomeno/cliffhanger/adapter"
 	"github.com/futurehomeno/cliffhanger/adapter/service/fanctrl"
@@ -153,11 +156,36 @@ func TestSpecification(t *testing.T) {
 		router.EvtErrorReport:    fimptype.VTypeString,
 	}
 
+	got := make(map[string]fimptype.ValueTypeT)
+
 	for _, intf := range fanctrl.Specification("test_adapter", "1", "2", nil, []string{"normal"}).Interfaces {
-		if intf.ValueType != want[intf.MsgType] {
-			t.Errorf("%s: declared value type %q, want %q", intf.MsgType, intf.ValueType, want[intf.MsgType])
-		}
+		got[intf.MsgType] = intf.ValueType
 	}
+
+	assert.Equal(t, want, got)
+}
+
+func TestSendModeReportLogsOutOfSpecModeOnlyWhenPublished(t *testing.T) { //nolint:paralleltest
+	hook := test.NewGlobal()
+	defer hook.Reset()
+
+	publisher := mockedadapter.NewServicePublisher(t)
+	publisher.EXPECT().PublishServiceMessage(mock.Anything, mock.Anything).Return(nil).Once()
+
+	s := fanctrl.NewService(publisher, &fanctrl.Config{
+		Specification: fanctrl.Specification("test_adapter", "1", "2", nil, []string{"normal"}),
+		Controller:    mockedfanctrl.NewController(t).MockGetMode("turbo", nil, false),
+	})
+
+	sent, err := s.SendModeReport(false)
+	assert.NoError(t, err)
+	assert.True(t, sent)
+	assert.Len(t, hook.Entries, 1)
+
+	sent, err = s.SendModeReport(false)
+	assert.NoError(t, err)
+	assert.False(t, sent)
+	assert.Len(t, hook.Entries, 1)
 }
 
 func routeService(controller *mockedfanctrl.Controller) cliffSuite.BaseSetup {

--- a/adapter/service/fanctrl/routing_test.go
+++ b/adapter/service/fanctrl/routing_test.go
@@ -98,6 +98,28 @@ func TestRouteService(t *testing.T) { //nolint:paralleltest
 				},
 			},
 			{
+				Name:     "mode outside sup_modes is still reported",
+				TearDown: adapterhelper.TearDownAdapter("../../testdata/adapter/test_adapter"),
+				Setup: routeService(mockedfanctrl.NewController(t).
+					MockGetMode("turbo", nil, true),
+				),
+				Nodes: []*cliffSuite.Node{
+					{
+						Name: "Cmd mode get report",
+						Command: cliffSuite.NewMessageBuilder().
+							NullMessage(
+								"pt:j1/mt:cmd/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2",
+								"cmd.mode.get_report",
+								"fan_ctrl",
+							).
+							Build(),
+						Expectations: []*cliffSuite.Expectation{
+							cliffSuite.ExpectString("pt:j1/mt:evt/rt:dev/rn:test_adapter/ad:1/sv:fan_ctrl/ad:2", "evt.mode.report", "fan_ctrl", "turbo"),
+						},
+					},
+				},
+			},
+			{
 				Name:     "broken get mode in controller",
 				TearDown: adapterhelper.TearDownAdapter("../../testdata/adapter/test_adapter"),
 				Setup: routeService(mockedfanctrl.NewController(t).

--- a/adapter/service/fanctrl/service.go
+++ b/adapter/service/fanctrl/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/futurehomeno/fimpgo"
 	"github.com/futurehomeno/fimpgo/fimptype"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/futurehomeno/cliffhanger/adapter"
 	"github.com/futurehomeno/cliffhanger/adapter/cache"
@@ -111,8 +112,13 @@ func (s *service) SendModeReport(force bool) (bool, error) {
 		return false, fmt.Errorf("failed to get mode: %w", err)
 	}
 
+	// Report the mode the device is actually in even when the specification does not
+	// advertise it. sup_modes describes what may be set, and a device can sit in a
+	// mode outside it — set outside cliffhanger, or supported only in a state the
+	// specification was not derived from. Withholding the report leaves the hub
+	// holding a stale value rather than a truthful one.
 	if !slices.Contains(s.SupportedModes(), mode) {
-		return false, fmt.Errorf("mode %s is not supported", mode)
+		log.Warnf("fanctrl: reporting mode %s, which is not in sup_modes", mode)
 	}
 
 	if !force && !s.reportingCache.ReportRequired(s.reportingStrategy, EvtModeReport, "", mode) {

--- a/adapter/service/fanctrl/service.go
+++ b/adapter/service/fanctrl/service.go
@@ -112,6 +112,10 @@ func (s *service) SendModeReport(force bool) (bool, error) {
 		return false, fmt.Errorf("failed to get mode: %w", err)
 	}
 
+	if !force && !s.reportingCache.ReportRequired(s.reportingStrategy, EvtModeReport, "", mode) {
+		return false, nil
+	}
+
 	// Report the mode the device is actually in even when the specification does not
 	// advertise it. sup_modes describes what may be set, and a device can sit in a
 	// mode outside it — set outside cliffhanger, or supported only in a state the
@@ -119,10 +123,6 @@ func (s *service) SendModeReport(force bool) (bool, error) {
 	// holding a stale value rather than a truthful one.
 	if !slices.Contains(s.SupportedModes(), mode) {
 		log.Warnf("fanctrl: reporting mode %s, which is not in sup_modes", mode)
-	}
-
-	if !force && !s.reportingCache.ReportRequired(s.reportingStrategy, EvtModeReport, "", mode) {
-		return false, nil
 	}
 
 	message := fimpgo.NewStringMessage(

--- a/adapter/service/fanctrl/specification.go
+++ b/adapter/service/fanctrl/specification.go
@@ -36,13 +36,13 @@ func requiredInterfaces() []fimptype.Interface {
 		{
 			Type:      fimptype.TypeIn,
 			MsgType:   CmdModeSet,
-			ValueType: fimptype.VTypeNull,
+			ValueType: fimptype.VTypeString,
 			Version:   "1",
 		},
 		{
 			Type:      fimptype.TypeOut,
 			MsgType:   EvtModeReport,
-			ValueType: fimptype.VTypeIntMap,
+			ValueType: fimptype.VTypeString,
 			Version:   "1",
 		},
 		{


### PR DESCRIPTION
Two fixes to how `fan_ctrl` handles mode, both surfaced by porting the Sensibo adapter off its hand-written inclusion report.

## 1. Declared value types contradict the wire format

`fanctrl.Specification` declares the two mode interfaces as:

| interface | declared | actually sent |
|---|---|---|
| `cmd.mode.set` | `null` | `string` (`Payload.GetStringValue()` in `routing.go`) |
| `evt.mode.report` | `int_map` | `string` (`fimpgo.NewStringMessage` in `service.go`) |

The existing routing tests already assert the string form (`ExpectString(..., "evt.mode.report", ...)`), so the wire format is not in question — only the declaration is wrong.

**Cause.** The interfaces were copied from `colorctrl` when the package was added in `1b0404b` (DEV-2656), where `null` / `int_map` are correct for `cmd.color.set` / `evt.color.report`. Other traces of the copy survive: `handleReporting` in `tasks.go` still named its variable `colorCtrl` and logged `"failed to send color report"`. The sibling mode services declare this correctly — `thermostat` and `waterheater` both use `string` for `cmd.mode.set`. `fanctrl` is the only outlier.

**Impact.** Every thing built on `fanctrl` publishes an inclusion report whose declared contract contradicts its own traffic, so any consumer that trusts the declared value type (app rendering, message validation) works from bad metadata. Adapters inherit this silently when they stop hand-writing inclusion reports: the legacy Sensibo adapter (v1.4.2, still the production version) declared `string` for both, and the port flipped them with no adapter-side change. It also affects services that reuse `fanctrl` for something other than a fan — Sensibo models both swing axes on it, since FIMP has no swing service.

## 2. `evt.mode.report` was suppressed for modes outside `sup_modes`

`SendModeReport` refused to publish a mode absent from `sup_modes`, returning an error instead. But `sup_modes` describes what may be *set* — a device can legitimately sit in a mode outside it, either set outside cliffhanger or supported only in a state the specification was not derived from.

Concretely on Sensibo: fan levels are per AC mode, so a pod in `cool` can report a level the `fan` mode never lists. The report was dropped, the hub kept a stale fan level, and the reporting task logged an error on every poll.

Now the mode is published with a warning. Setting an unsupported mode is still rejected.

## Verification

`golangci-lint run` clean, `go test ./...` passes. Added `TestSpecification` over the declared value types and a routing case asserting a mode outside `sup_modes` is reported. (One `adapter/service/ota` failure seen locally is flaky — it passes on re-run and on unmodified `develop`.)

Based on `develop`, which carries the `v1.3.0` tag — there is no `version_1.3` branch on the remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
