### PR TITLE
Fix PR #212 review findings: destroy leak, delete ordering, option pairing

### DIFF
--- a/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/SKILL.md
@@ -83,7 +83,7 @@ hand-rolled code did. Diff a captured inclusion report + evt stream before/after
    `adapter.SeedsFromSelection` + `adapter.SyncThings` (the fetch is owned by the sync, so a
    failed fetch mutates nothing); replace a hand-rolled capability-drift rebuild (sensibo
    `reconcile.go`) with `adapter.RebuildChangedThings`; store the user's device selection in
-   `selection.Devices` and wire `adapter.WithSelectionRemover` so `cmd.thing.delete` deselects
+   `selection.Devices` and wire `adapter.WithSelection` so `cmd.thing.delete` deselects
    the device it deletes. (refs §7, worked recipe and its two hazards in §7.1)
 
 8. **Adopt the remaining blocks where they apply:** `stream.Supervisor` for a push transport's

--- a/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
+++ b/.claude/skills/port_to_cliffhanger_1.3/references/upgrade-to-1.3.md
@@ -29,7 +29,7 @@ The change landed in four "waves":
 | `lifecycle.MarkRunning/MarkNotConfigured` + `SetConnAndAuthState` | state-bundle helpers; atomic conn+auth in one event | four separate `Set*State` calls |
 | `storage.NewSecrets/NewCanonicalSecrets` | `Storage[T]` at 0640 (edge: `data/secrets.json`; canonical/core: `workDir/<name>`) | credentials living in world-readable `config.json` |
 | `stream.Supervisor` | `NewSupervisor(connect Connection, b backoff.Stateful)` → `Start()/Stop()/TriggerReconnect()` | bespoke SignalR/GENA/AMQP reconnect loops |
-| `adapter.SeedsFromSelection` + `SyncThings` + `RebuildChangedThings`, `selection` | `SeedsFromSelection[T](available, selected, seed)`, `SyncThings[T](a, fetch, selected, seed) (ThingSeeds, error)`, `RebuildChangedThings(seeds)`, `selection.Devices`/`Store`/`PrepareManifest`, `adapter.WithSelectionRemover` | fetch→filter→map→EnsureThings wrapper, sensibo `reconcile.go`, per-adapter `selected_devices` plumbing and `cmd.thing.delete` route |
+| `adapter.SeedsFromSelection` + `SyncThings` + `RebuildChangedThings`, `selection` | `SeedsFromSelection[T](available, selected, seed)`, `SyncThings[T](a, fetch, selected, seed) (ThingSeeds, error)`, `RebuildChangedThings(seeds)`, `selection.Devices`/`Store`/`PrepareManifest`, `adapter.WithSelection` | fetch→filter→map→EnsureThings wrapper, sensibo `reconcile.go`, per-adapter `selected_devices` plumbing and `cmd.thing.delete` route |
 | `bootstrap.EdgeRouting/EdgeTasks` | `EdgeRouting[C](...)`, `EdgeTasks(...)` bundles | repeated builder wiring |
 | `router.DefaultLogStats` | `DefaultLogStats(redactedInterfacePrefixes ...string) func(Stats)` | per-adapter `LogStats` with `cmd.auth.` masking |
 | `backoff.NewTolerantFixed` | `(tolerance uint32, delay time.Duration) Stateful` | fixed-after-N-tolerated backoff presets |
@@ -222,7 +222,7 @@ backed by this secrets storage.
 - **`selection`** owns the user's device selection: `selection.Devices` is the config mixin carrying
   `selected_devices`, `selection.Store` reads/writes it, and `selection.PrepareManifest` renders the
   device selector's three states (not ready / fetch failed / ready). Pass the store to
-  `adapter.RouteAdapter(ad, adapter.WithSelectionRemover(store), adapter.WithLocker(locker))` so
+  `adapter.RouteAdapter(ad, adapter.WithSelection(store, locker))` so
   `cmd.thing.delete` also deselects the device; without it the next sync recreates the deleted thing.
 - **Best effort**: `EnsureThings`, `RebuildChangedThings`, `DestroyAllThings` and `SyncThings` no
   longer abort on the first bad device — they continue and join the errors. A non-nil error means
@@ -269,9 +269,8 @@ thing store is empty — a partially lost store never recovers otherwise.
 Routing — delete the adapter's own `cmd.thing.delete` route and pass the store instead:
 
 ```go
-cliffAdapter.RouteAdapter(ad,
-	cliffAdapter.WithSelectionRemover(store),
-	cliffAdapter.WithLocker(configurationLocker)) // the same locker as app.RouteApp
+// the same locker as app.RouteApp
+cliffAdapter.RouteAdapter(ad, cliffAdapter.WithSelection(store, configurationLocker))
 ```
 
 Manifest — `selection.PrepareManifest(m, block, ready, fetch, option)` replaces the hand-rolled

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -49,12 +49,10 @@ type Adapter interface {
 	// CreateThing creates thing and adds it to the adapter.
 	CreateThing(seed *ThingSeed) error
 	// DestroyThingByID destroys thing and removes it from the adapter. An unknown ID is a no-op:
-	// there is no address to announce an exclusion for. Use DestroyThingByAddress when the
-	// exclusion must be sent regardless.
+	// there is no address to announce an exclusion for.
 	DestroyThingByID(id string) error
 	// DestroyThingByAddress destroys thing and removes it from the adapter. An unregistered
-	// address still emits the exclusion: an upgraded hub may hold a stale node the adapter's
-	// state never knew about, and exclusion reports are idempotent.
+	// address still emits the exclusion, clearing a stale hub node the state never knew about.
 	DestroyThingByAddress(address string) error
 	// DestroyAllThings destroys all things and removes them from the adapter.
 	DestroyAllThings() error
@@ -247,9 +245,7 @@ func (a *adapter) InitializeThings() error {
 }
 
 // EnsureThings creates and destroys things based on provided map of IDs and custom information objects.
-// The pass is best-effort per device: a failure on one device does not stop the others and all
-// failures are returned joined, so a single broken device can never block a whole sync. A non-nil
-// error therefore means partially applied, not "nothing happened".
+// Best-effort per device: failures are joined, so a non-nil error means partially applied.
 func (a *adapter) EnsureThings(seeds ThingSeeds) error {
 	a.lock.Lock()
 	defer a.lock.Unlock()
@@ -317,9 +313,8 @@ func (a *adapter) DestroyThingByAddress(address string) error {
 	return a.destroyThing(address)
 }
 
-// DestroyAllThings destroys all things and removes them from the adapter. The pass is
-// best-effort per device: the adapter is always left empty, so a single stuck device cannot
-// leave a half-reset adapter behind.
+// DestroyAllThings destroys all things and removes them from the adapter. Best-effort per
+// device: the adapter is always left empty, never half-reset.
 func (a *adapter) DestroyAllThings() error {
 	a.lock.Lock()
 	defer a.lock.Unlock()
@@ -378,9 +373,8 @@ func (a *adapter) createThing(seed *ThingSeed) (err error) {
 		return fmt.Errorf("failed to create state for thing with ID %s: %w", seed.ID, err)
 	}
 
-	// Roll the state record back on failure: a persisted record with no live thing is a ghost
-	// that EnsureThings treats as present forever, so the device stays missing until the store
-	// is reset. Best-effort passes make this likely, as a failure no longer aborts the sync.
+	// Roll the state record back on failure: a record with no live thing is a ghost that
+	// EnsureThings treats as present forever, so the device stays missing until a reset.
 	defer func() {
 		if err != nil {
 			_ = a.state.remove(seed.ID)

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/futurehomeno/fimpgo"
 	"github.com/futurehomeno/fimpgo/fimptype"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/futurehomeno/cliffhanger/event"
 )
@@ -376,8 +377,12 @@ func (a *adapter) createThing(seed *ThingSeed) (err error) {
 	// Roll the state record back on failure: a record with no live thing is a ghost that
 	// EnsureThings treats as present forever, so the device stays missing until a reset.
 	defer func() {
-		if err != nil {
-			_ = a.state.remove(seed.ID)
+		if err == nil {
+			return
+		}
+
+		if rollbackErr := a.state.remove(seed.ID); rollbackErr != nil {
+			log.Warnf("adapter: failed to roll back state of thing with ID %s: %v", seed.ID, rollbackErr)
 		}
 	}()
 
@@ -430,14 +435,16 @@ func (a *adapter) createThingState(seed *ThingSeed) (ThingState, error) {
 	return ts, nil
 }
 
+// destroyThing is best-effort across all three steps: a failed state write must not skip the
+// unregister, or the thing keeps its connector open while the adapter drops the last reference
+// to it. The state record is already gone from memory by then, so there is nothing to retry.
 func (a *adapter) destroyThing(address string) error {
-	var err error
+	var errs []error
 
 	ts := a.state.byAddress(address)
 	if ts != nil {
-		err = a.state.remove(ts.ID())
-		if err != nil {
-			return fmt.Errorf("failed to remove state for thing with ID %s: %w", ts.ID(), err)
+		if err := a.state.remove(ts.ID()); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove state for thing with ID %s: %w", ts.ID(), err))
 		}
 	}
 
@@ -446,12 +453,11 @@ func (a *adapter) destroyThing(address string) error {
 		a.unregisterThing(t)
 	}
 
-	err = a.sendExclusionReport(address)
-	if err != nil {
-		return fmt.Errorf("failed to send exclusion report for thing with address %s: %w", address, err)
+	if err := a.sendExclusionReport(address); err != nil {
+		errs = append(errs, fmt.Errorf("failed to send exclusion report for thing with address %s: %w", address, err))
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (a *adapter) sendExclusionReport(address string) error {

--- a/adapter/adapter_internal_test.go
+++ b/adapter/adapter_internal_test.go
@@ -1,0 +1,88 @@
+package adapter
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/futurehomeno/fimpgo"
+	"github.com/futurehomeno/fimpgo/fimptype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubPublisher swallows everything the adapter publishes; the destroy tests only care about
+// what happened to the thing, not about the exclusion report reaching MQTT.
+type stubPublisher struct{}
+
+func (stubPublisher) PublishAdapterMessage(*fimpgo.FimpMessage) error          { return nil }
+func (stubPublisher) PublishThingMessage(Thing, *fimpgo.FimpMessage) error     { return nil }
+func (stubPublisher) PublishThingEvent(ThingEvent)                             {}
+func (stubPublisher) PublishServiceMessage(Service, *fimpgo.FimpMessage) error { return nil }
+func (stubPublisher) PublishServiceEvent(Service, ServiceEvent)                {}
+
+// recordingConnector is a ControllableConnector that records whether the thing was disconnected.
+type recordingConnector struct {
+	lock         sync.Mutex
+	disconnected bool
+}
+
+func (c *recordingConnector) Connectivity() *ConnectivityDetails { return &ConnectivityDetails{} }
+func (c *recordingConnector) Ping() *PingDetails                 { return &PingDetails{} }
+func (c *recordingConnector) Connect(Thing)                      {}
+
+func (c *recordingConnector) Disconnect(Thing) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.disconnected = true
+}
+
+func (c *recordingConnector) wasDisconnected() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return c.disconnected
+}
+
+// failingRemoveState fails every removal, standing in for a state file that can no longer be
+// persisted. The in-memory record is dropped regardless, which is why destroyThing must carry on.
+type failingRemoveState struct {
+	State
+}
+
+func (failingRemoveState) remove(string) error { return errors.New("state write failed") }
+
+// TestDestroyThing_UnregistersWhenStateRemoveFails pins that a failed state write does not skip
+// the unregister. Returning early there left the thing connected while DestroyAllThings cleared
+// the map, dropping the last reference to a live connector and leaking it for the process
+// lifetime.
+func TestDestroyThing_UnregistersWhenStateRemoveFails(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewState(t.TempDir())
+	require.NoError(t, err)
+
+	ts, err := s.add(&thingStateModel{ID: "B", Address: "2"})
+	require.NoError(t, err)
+
+	connector := &recordingConnector{}
+
+	thing := NewThing(stubPublisher{}, ts, &ThingConfig{
+		InclusionReport: &fimptype.ThingInclusionReport{Address: "2"},
+		Connector:       connector,
+	})
+
+	a := &adapter{
+		publisher: stubPublisher{},
+		state:     failingRemoveState{State: s},
+		things:    map[string]Thing{"2": thing},
+		lock:      &sync.RWMutex{},
+	}
+
+	err = a.DestroyAllThings()
+
+	assert.Error(t, err, "the failed state write must still surface")
+	assert.True(t, connector.wasDisconnected(), "the connector must be released even when the state write fails")
+	assert.Empty(t, a.things, "the thing must not linger in the adapter")
+}

--- a/adapter/drift.go
+++ b/adapter/drift.go
@@ -11,13 +11,10 @@ import (
 
 // RebuildChangedThings rebuilds any already-registered thing whose seed would produce a
 // different service topology than the live thing. EnsureThings only reconciles presence, so
-// a device that gains a capability keeps its old services until it is rebuilt. The prospective
-// thing is built first, so a factory error returns before the destructive destroy.
+// a device that gains a capability keeps its old services until it is rebuilt.
 //
-// The pass is best-effort per seed: a failure on one device does not stop the others and all
-// failures are returned joined. The whole pass runs under the adapter lock, matching
-// EnsureThings, so no concurrent operation can destroy a thing between the lookup and its
-// rebuild.
+// Best-effort per seed: failures are joined. The whole pass runs under the adapter lock, so
+// nothing can destroy a thing between the lookup and its rebuild.
 func (a *adapter) RebuildChangedThings(seeds ThingSeeds) error {
 	a.lock.Lock()
 	defer a.lock.Unlock()
@@ -46,8 +43,8 @@ func (a *adapter) rebuildChangedThing(seed *ThingSeed) error {
 		return nil
 	}
 
-	// The prospective thing reuses the live address so only genuine capability changes,
-	// not address-derived fields, differ.
+	// Reuse the live address so only genuine capability changes, not address-derived fields,
+	// differ. Building before the destroy also means a factory error costs nothing.
 	prospective, err := a.factory.Create(a, a.publisher, newSeedState(seed, ts.Address()))
 	if err != nil {
 		return fmt.Errorf("build prospective thing: %w", err)
@@ -67,16 +64,15 @@ func (a *adapter) rebuildChangedThing(seed *ThingSeed) error {
 		return nil
 	}
 
-	// destroyThing drops the whole state record and createThing rebuilds only
-	// ID/Address/Info, so capture any persisted per-thing state and restore it after the
-	// swap; otherwise a topology rebuild would silently discard it.
+	// destroyThing drops the whole state record, so capture any persisted per-thing state and
+	// restore it after the swap; otherwise a rebuild would silently discard it.
 	var savedState json.RawMessage
 	if err := ts.State(&savedState); err != nil {
 		return fmt.Errorf("read state: %w", err)
 	}
 
-	// Preserve the live address so the rebuilt thing keeps its topic identity; a seed
-	// without a CustomAddress would otherwise be assigned a fresh address on recreation.
+	// Preserve the live address so the rebuilt thing keeps its topic identity; a seed without
+	// a CustomAddress would be assigned a fresh one on recreation.
 	rebuildSeed := &ThingSeed{ID: seed.ID, CustomAddress: ts.Address(), Info: seed.Info}
 
 	if err := a.destroyThing(ts.Address()); err != nil {

--- a/adapter/routing.go
+++ b/adapter/routing.go
@@ -28,6 +28,7 @@ const (
 // SelectionRemover drops a device from the user's device selection, so a thing deleted from the
 // hub is not recreated by the next sync. It is satisfied by *selection.Store.
 type SelectionRemover interface {
+	// Remove drops the device, and is a no-op when it is not selected.
 	Remove(id string) error
 }
 
@@ -39,20 +40,16 @@ type routingConfig struct {
 	locker    router.MessageHandlerLocker
 }
 
-// WithSelectionRemover makes cmd.thing.delete drop the deleted device from the user's device
-// selection in addition to destroying the thing. Without it a deleted thing comes back on the
-// next sync, as the selection still lists it.
-//
-// It has no effect on an adapter whose selection includes every device: "include all" cannot
-// express an exclusion, so an adapter with user-deletable devices must keep an explicit
-// selection.
+// WithSelectionRemover makes cmd.thing.delete deselect the device it deletes; without it the
+// next sync recreates the thing. It cannot help an "include all" selection, which has no way to
+// express an exclusion. Pair it with WithLocker.
 func WithSelectionRemover(remover SelectionRemover) RoutingOption {
 	return func(c *routingConfig) { c.selection = remover }
 }
 
-// WithLocker makes cmd.thing.delete share a lock with the application's configuration handlers,
-// so deleting a thing cannot interleave with cmd.config.extended_set rewriting the selection.
-// Pass the same locker as app.RouteApp.
+// WithLocker serialises cmd.thing.delete against the application's configuration handlers, so a
+// delete cannot interleave with cmd.config.extended_set rewriting the selection. Pass the same
+// locker as app.RouteApp.
 func WithLocker(locker router.MessageHandlerLocker) RoutingOption {
 	return func(c *routingConfig) { c.locker = locker }
 }
@@ -121,8 +118,7 @@ func handleCmdThingDelete(adapter Adapter, cfg *routingConfig) router.MessageHan
 				return nil, errors.New("provided address is empty")
 			}
 
-			// Resolve the device ID before the destroy: destroying a thing drops the state
-			// record mapping its address to its ID, so a later lookup would find nothing.
+			// Resolve before the destroy: it drops the record mapping address to ID.
 			id, ok := adapter.ExchangeAddress(address)
 
 			err = adapter.DestroyThingByAddress(address)
@@ -136,8 +132,7 @@ func handleCmdThingDelete(adapter Adapter, cfg *routingConfig) router.MessageHan
 
 			if !ok {
 				// No thing state: the hub is deleting a node this adapter never registered,
-				// which for an ID-addressed adapter is a device left behind by an older
-				// version. Removing an unselected ID is a no-op elsewhere.
+				// which for an ID-addressed adapter is a device left behind by an older version.
 				id = address
 			}
 

--- a/adapter/routing.go
+++ b/adapter/routing.go
@@ -40,18 +40,17 @@ type routingConfig struct {
 	locker    router.MessageHandlerLocker
 }
 
-// WithSelectionRemover makes cmd.thing.delete deselect the device it deletes; without it the
-// next sync recreates the thing. It cannot help an "include all" selection, which has no way to
-// express an exclusion. Pair it with WithLocker.
-func WithSelectionRemover(remover SelectionRemover) RoutingOption {
-	return func(c *routingConfig) { c.selection = remover }
-}
-
-// WithLocker serialises cmd.thing.delete against the application's configuration handlers, so a
-// delete cannot interleave with cmd.config.extended_set rewriting the selection. Pass the same
-// locker as app.RouteApp.
-func WithLocker(locker router.MessageHandlerLocker) RoutingOption {
-	return func(c *routingConfig) { c.locker = locker }
+// WithSelection makes cmd.thing.delete deselect the device it deletes; without it the next sync
+// recreates the thing. It cannot help an "include all" selection, which has no way to express an
+// exclusion. The locker serialises the delete against the application's configuration handlers,
+// so the remover's read-then-write cannot interleave with cmd.config.extended_set rewriting the
+// selection - pass the same locker as app.RouteApp. The two are a single option because the
+// remover is unsafe without the lock.
+func WithSelection(remover SelectionRemover, locker router.MessageHandlerLocker) RoutingOption {
+	return func(c *routingConfig) {
+		c.selection = remover
+		c.locker = locker
+	}
 }
 
 func RouteAdapter(adapter Adapter, options ...RoutingOption) []*router.Routing {
@@ -121,23 +120,25 @@ func handleCmdThingDelete(adapter Adapter, cfg *routingConfig) router.MessageHan
 			// Resolve before the destroy: it drops the record mapping address to ID.
 			id, ok := adapter.ExchangeAddress(address)
 
+			// Deselect before destroying. The reverse order resurrects the device: a failed
+			// deselect after a successful destroy leaves it selected, so the next sync recreates
+			// the thing the user just deleted. This way a failure leaves the thing intact and
+			// retryable, and a destroy that fails afterwards is undone by the next sync anyway.
+			if cfg.selection != nil {
+				if !ok {
+					// No thing state: the hub is deleting a node this adapter never registered,
+					// which for an ID-addressed adapter is a device left behind by an older version.
+					id = address
+				}
+
+				if err := cfg.selection.Remove(id); err != nil {
+					return nil, fmt.Errorf("failed to remove device %s from the selection: %w", id, err)
+				}
+			}
+
 			err = adapter.DestroyThingByAddress(address)
 			if err != nil {
 				return nil, fmt.Errorf("failed to delete thing with address %s: %w", address, err)
-			}
-
-			if cfg.selection == nil {
-				return nil, nil
-			}
-
-			if !ok {
-				// No thing state: the hub is deleting a node this adapter never registered,
-				// which for an ID-addressed adapter is a device left behind by an older version.
-				id = address
-			}
-
-			if err := cfg.selection.Remove(id); err != nil {
-				return nil, fmt.Errorf("failed to remove device %s from the selection: %w", id, err)
 			}
 
 			return nil, nil

--- a/adapter/routing.go
+++ b/adapter/routing.go
@@ -44,9 +44,14 @@ type routingConfig struct {
 // recreates the thing. It cannot help an "include all" selection, which has no way to express an
 // exclusion. The locker serialises the delete against the application's configuration handlers,
 // so the remover's read-then-write cannot interleave with cmd.config.extended_set rewriting the
-// selection - pass the same locker as app.RouteApp. The two are a single option because the
-// remover is unsafe without the lock.
+// selection - pass the same locker as app.RouteApp. Both are required: a nil locker leaves the
+// handler unlocked, silently defeating the serialisation the remover depends on, so it panics
+// at wiring time rather than handing back a selection that quietly loses updates.
 func WithSelection(remover SelectionRemover, locker router.MessageHandlerLocker) RoutingOption {
+	if remover == nil || locker == nil {
+		panic("adapter: WithSelection requires a non-nil remover and locker")
+	}
+
 	return func(c *routingConfig) {
 		c.selection = remover
 		c.locker = locker

--- a/adapter/routing_delete_test.go
+++ b/adapter/routing_delete_test.go
@@ -1,6 +1,7 @@
 package adapter_test
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -62,7 +63,12 @@ func (s *testSelection) set(next selection.Selection) error {
 	return nil
 }
 
-func setupAdapterWithDeletableThings(ad *adapter.Adapter, store *selection.Store) suite.BaseSetup {
+// failingRemover stands in for a selection whose configuration write fails, e.g. a full disk.
+type failingRemover struct{}
+
+func (failingRemover) Remove(string) error { return errors.New("selection write failed") }
+
+func setupAdapterWithDeletableThings(ad *adapter.Adapter, remover adapter.SelectionRemover) suite.BaseSetup {
 	return func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
 		t.Helper()
 
@@ -79,7 +85,7 @@ func setupAdapterWithDeletableThings(ad *adapter.Adapter, store *selection.Store
 
 		*ad = adapterhelper.PrepareSeededAdapter(t, testAdapterWorkDir, mqtt, factory, seeds)
 
-		return adapter.RouteAdapter(*ad, adapter.WithSelectionRemover(store)), nil, nil
+		return adapter.RouteAdapter(*ad, adapter.WithSelection(remover, nil)), nil, nil
 	}
 }
 
@@ -179,6 +185,45 @@ func TestRouteAdapter_ThingDeleteWithoutSelection(t *testing.T) { //nolint:paral
 							expectExclusion(testThingAddressB).ExactlyOnce(),
 							suite.ExpectError(testAdapterEvtTopic, testAdapterName).Never(),
 						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func TestRouteAdapter_ThingDeleteSelectionWriteFails(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	// The deselect runs before the destroy precisely so this case is recoverable: were the order
+	// reversed, the thing would be gone while the device stayed selected and the next sync would
+	// resurrect the device the user just deleted.
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "a failing deselect leaves the thing intact instead of resurrecting it",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    setupAdapterWithDeletableThings(&ad, failingRemover{}),
+				Nodes: []*suite.Node{
+					{
+						Name:    "the delete reports an error and announces no exclusion",
+						Timeout: 500 * time.Millisecond,
+						Command: deleteThingCommand(testThingAddressB),
+						Expectations: []*suite.Expectation{
+							suite.ExpectError(testAdapterEvtTopic, testAdapterName).ExactlyOnce(),
+							expectAnyExclusion().Never(),
+						},
+					},
+					{
+						Name:    "the thing survives, so retrying the delete is all it takes",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							assert.NotNil(t, ad.ThingByAddress(testThingAddressB), "thing B must survive a failed deselect")
+						}},
 					},
 				},
 			},

--- a/adapter/routing_delete_test.go
+++ b/adapter/routing_delete_test.go
@@ -68,7 +68,11 @@ type failingRemover struct{}
 
 func (failingRemover) Remove(string) error { return errors.New("selection write failed") }
 
-func setupAdapterWithDeletableThings(ad *adapter.Adapter, remover adapter.SelectionRemover) suite.BaseSetup {
+func setupAdapterWithDeletableThings(
+	ad *adapter.Adapter,
+	remover adapter.SelectionRemover,
+	locker router.MessageHandlerLocker,
+) suite.BaseSetup {
 	return func(t *testing.T, mqtt *fimpgo.MqttTransport) ([]*router.Routing, []*task.Task, []suite.Mock) {
 		t.Helper()
 
@@ -85,7 +89,7 @@ func setupAdapterWithDeletableThings(ad *adapter.Adapter, remover adapter.Select
 
 		*ad = adapterhelper.PrepareSeededAdapter(t, testAdapterWorkDir, mqtt, factory, seeds)
 
-		return adapter.RouteAdapter(*ad, adapter.WithSelection(remover, nil)), nil, nil
+		return adapter.RouteAdapter(*ad, adapter.WithSelection(remover, locker)), nil, nil
 	}
 }
 
@@ -108,7 +112,7 @@ func TestRouteAdapter_ThingDelete(t *testing.T) { //nolint:paralleltest
 			{
 				Name:     "cmd.thing.delete destroys the thing, announces it and deselects the device",
 				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
-				Setup:    setupAdapterWithDeletableThings(&ad, store),
+				Setup:    setupAdapterWithDeletableThings(&ad, store, router.NewMessageHandlerLocker()),
 				Nodes: []*suite.Node{
 					{
 						Name:    "deleting thing B excludes it",
@@ -194,6 +198,69 @@ func TestRouteAdapter_ThingDeleteWithoutSelection(t *testing.T) { //nolint:paral
 	s.Run(t)
 }
 
+func TestRouteAdapter_ThingDeleteRespectsExternalLock(t *testing.T) { //nolint:paralleltest
+	var ad adapter.Adapter
+
+	store, sel := newTestSelection("B", "C")
+	// The same locker app.RouteApp holds while it rewrites the configuration. A delete that slipped
+	// past it would read a selection the configuration handler is midway through replacing, and the
+	// deselect would be lost.
+	locker := router.NewMessageHandlerLocker()
+
+	s := &suite.Suite{
+		Cases: []*suite.Case{
+			{
+				Name:     "cmd.thing.delete is skipped while the configuration lock is held",
+				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
+				Setup:    setupAdapterWithDeletableThings(&ad, store, locker),
+				Nodes: []*suite.Node{
+					{
+						Name:    "a delete arriving under the held lock changes nothing",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							assert.True(t, locker.Lock(), "the test must own the lock the handler contends for")
+						}},
+						Command: deleteThingCommand(testThingAddressB),
+						Expectations: []*suite.Expectation{
+							suite.ExpectError(testAdapterEvtTopic, testAdapterName).ExactlyOnce(),
+							expectAnyExclusion().Never(),
+						},
+					},
+					{
+						Name:    "releasing the lock lets the same delete through",
+						Timeout: 500 * time.Millisecond,
+						InitCallbacks: []suite.Callback{func(t *testing.T) {
+							t.Helper()
+
+							assert.NotNil(t, ad.ThingByAddress(testThingAddressB), "the blocked delete must not have destroyed it")
+							assert.Equal(t, selection.Selection{"B", "C"}, sel.get(), "the blocked delete must not have deselected it")
+
+							locker.Unlock()
+						}},
+						Command: deleteThingCommand(testThingAddressB),
+						Expectations: []*suite.Expectation{
+							expectExclusion(testThingAddressB).ExactlyOnce(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s.Run(t)
+}
+
+func TestRouteAdapter_WithSelectionRejectsNilArguments(t *testing.T) {
+	t.Parallel()
+
+	// A nil locker leaves the handler unlocked, which is exactly the race the option exists to
+	// close, so it must not be silently accepted.
+	assert.Panics(t, func() { adapter.WithSelection(nil, router.NewMessageHandlerLocker()) })
+	assert.Panics(t, func() { adapter.WithSelection(&selection.Store{}, nil) })
+}
+
 func TestRouteAdapter_ThingDeleteSelectionWriteFails(t *testing.T) { //nolint:paralleltest
 	var ad adapter.Adapter
 
@@ -205,7 +272,7 @@ func TestRouteAdapter_ThingDeleteSelectionWriteFails(t *testing.T) { //nolint:pa
 			{
 				Name:     "a failing deselect leaves the thing intact instead of resurrecting it",
 				TearDown: adapterhelper.TearDownAdapter(testAdapterWorkDir),
-				Setup:    setupAdapterWithDeletableThings(&ad, failingRemover{}),
+				Setup:    setupAdapterWithDeletableThings(&ad, failingRemover{}, router.NewMessageHandlerLocker()),
 				Nodes: []*suite.Node{
 					{
 						Name:    "the delete reports an error and announces no exclusion",

--- a/bootstrap/edge.go
+++ b/bootstrap/edge.go
@@ -17,8 +17,8 @@ import (
 // EdgeRouting combines the standard edge adapter routing (default, app and adapter routes)
 // with domain-specific extras. excludeAllThings is forwarded to app.RouteApp: typically
 // ad.DestroyAllThings, or nil when the application destroys things in Uninstall itself.
-// adapterOptions is forwarded to adapter.RouteAdapter: typically adapter.WithSelectionRemover
-// and adapter.WithLocker(locker) for an application with a device selection.
+// adapterOptions is forwarded to adapter.RouteAdapter: typically
+// adapter.WithSelection(store, locker) for an application with a device selection.
 func EdgeRouting[C any](
 	serviceName fimptype.ServiceNameT,
 	configGetter func() any,

--- a/selection/store.go
+++ b/selection/store.go
@@ -27,7 +27,7 @@ func (s *Store) Set(sel Selection) error { return s.set(sel.Clone()) }
 // selected or when the selection includes every device.
 //
 // The read-then-write is not atomic, so it must run under the same handler lock as the
-// configuration writes it can race, which adapter.WithLocker provides.
+// configuration writes it can race, which adapter.WithSelection provides.
 func (s *Store) Remove(id string) error {
 	next, removed := s.get().Without(id)
 	if !removed {


### PR DESCRIPTION
Addresses the review findings on #212, plus the two follow-up findings this PR itself received.

### From #212

| Finding | Fix |
|---|---|
| [P2 DestroyAllThings orphans connected things on partial failure](https://github.com/futurehomeno/cliffhanger/pull/212#discussion_r3653507617) | `destroyThing` is best-effort across all three steps and joins errors, so a failed state write no longer skips `unregisterThing` |
| [P2 Thing delete and selection removal not atomic](https://github.com/futurehomeno/cliffhanger/pull/212#discussion_r3653507620) | `cmd.thing.delete` deselects before destroying, so a failure leaves the thing intact and retryable |
| [P3 Selection removal race requires callers to remember WithLocker](https://github.com/futurehomeno/cliffhanger/pull/212#discussion_r3653507622) | `WithSelectionRemover` + `WithLocker` collapse into `WithSelection(remover, locker)` |
| [P3 State rollback error silently discarded in createThing](https://github.com/futurehomeno/cliffhanger/pull/212#discussion_r3653507619) | The rollback failure is logged instead of discarded |

Dismissed as intentional: [EdgeRouting signature](https://github.com/futurehomeno/cliffhanger/pull/212#discussion_r3653507623) and [SyncThings signature](https://github.com/futurehomeno/cliffhanger/pull/212#discussion_r3653507624) — deliberate pre-1.3 API changes with zero external callers, as the findings themselves note.

### From this PR

| Finding | Fix |
|---|---|
| [P3 WithSelection accepts nil locker despite documented lock requirement](https://github.com/futurehomeno/cliffhanger/pull/214#discussion_r3682331338) | `WithSelection` panics on a nil remover or locker |
| [P4 Test passes nil locker, missing concurrent access coverage](https://github.com/futurehomeno/cliffhanger/pull/214#discussion_r3682331343) | Tests wire a real locker; new case covers the lock path |

The P3 was a fair hit on the first round of this PR: collapsing the two options made the remover/locker pairing *visible*, not *enforced*, because `router/handler.go:108` nil-checks the locker and silently runs unlocked. It now fails loudly at wiring time.

### Notes

The #212 P2 destroy finding's *primary* suggestion (track a `destroyed` slice) does not fix the leak it names — the thing stays `Connect()`ed, just reachable. The finding's own alternative ("ensure `destroyThing` always calls `unregisterThing`") is what landed, and it also closes the same hole in `DestroyThingByID`, `DestroyThingByAddress` and `EnsureThings`.

### Tests

- `TestDestroyThing_UnregistersWhenStateRemoveFails` (new `adapter/adapter_internal_test.go`) — failing state write must still disconnect the connector and empty the map.
- `TestRouteAdapter_ThingDeleteSelectionWriteFails` — a failing deselect announces no exclusion and leaves the thing intact.
- `TestRouteAdapter_ThingDeleteRespectsExternalLock` — a delete under the held configuration lock is rejected and changes nothing; it succeeds once released.
- `TestRouteAdapter_WithSelectionRejectsNilArguments` — nil remover or locker panics.
- No test for the rollback logging: log-only change with no observable behaviour.

`make test` (`go test -p 1 ./...`) is green across all 40 packages; `go build`, `go vet` and `golangci-lint run` are clean.

> Correction to the first revision of this description, which claimed `adapter/thing` fails on the base branch: it does not. That failure was an artifact of running several MQTT suite packages concurrently, which collide on the shared broker — hence `-p 1` in the Makefile. Nothing is failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
