### PR TITLE
Do not abort a rebuild on a destroy error, exclude a vanished device once

### DIFF
--- a/adapter/adapter_internal_test.go
+++ b/adapter/adapter_internal_test.go
@@ -45,13 +45,18 @@ func (c *recordingConnector) wasDisconnected() bool {
 	return c.disconnected
 }
 
-// failingRemoveState fails every removal, standing in for a state file that can no longer be
-// persisted. The in-memory record is dropped regardless, which is why destroyThing must carry on.
+// failingRemoveState stands in for a state file that can no longer be persisted. It mirrors
+// state.remove faithfully: the in-memory record is dropped first and only the save fails, which
+// is why every caller of destroyThing must treat the error as already-applied rather than retry.
 type failingRemoveState struct {
 	State
 }
 
-func (failingRemoveState) remove(string) error { return errors.New("state write failed") }
+func (f failingRemoveState) remove(id string) error {
+	_ = f.State.remove(id)
+
+	return errors.New("state write failed")
+}
 
 // TestDestroyThing_UnregistersWhenStateRemoveFails pins that a failed state write does not skip
 // the unregister. Returning early there left the thing connected while DestroyAllThings cleared

--- a/adapter/drift.go
+++ b/adapter/drift.go
@@ -7,6 +7,7 @@ import (
 	"hash/crc32"
 
 	"github.com/futurehomeno/fimpgo/fimptype"
+	log "github.com/sirupsen/logrus"
 )
 
 // RebuildChangedThings rebuilds any already-registered thing whose seed would produce a
@@ -75,8 +76,11 @@ func (a *adapter) rebuildChangedThing(seed *ThingSeed) error {
 	// a CustomAddress would be assigned a fresh one on recreation.
 	rebuildSeed := &ThingSeed{ID: seed.ID, CustomAddress: ts.Address(), Info: seed.Info}
 
+	// destroyThing is best-effort and has already completed the in-memory removal by the time it
+	// reports an error, so aborting here would leave the device excluded and never recreated -
+	// and discard savedState with it. Carry on and let the recreate put the thing back.
 	if err := a.destroyThing(ts.Address()); err != nil {
-		return fmt.Errorf("destroy: %w", err)
+		log.Warnf("adapter: rebuild of thing with ID %s: destroy reported errors, recreating anyway: %v", seed.ID, err)
 	}
 
 	if err := a.createThing(rebuildSeed); err != nil {

--- a/adapter/drift_internal_test.go
+++ b/adapter/drift_internal_test.go
@@ -1,6 +1,14 @@
 package adapter
 
-import "testing"
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/futurehomeno/fimpgo/fimptype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestTopologyChecksum_NilReportDoesNotPanic(t *testing.T) {
 	t.Parallel()
@@ -9,4 +17,70 @@ func TestTopologyChecksum_NilReportDoesNotPanic(t *testing.T) {
 	if err != nil || sum != 0 {
 		t.Fatalf("nil report: got (%d, %v), want (0, nil)", sum, err)
 	}
+}
+
+// groupsInfo drives the topology checksum: changing the groups makes a seed drift from the live
+// thing, which is what triggers a rebuild.
+type groupsInfo struct {
+	Groups []string `json:"groups"`
+}
+
+// groupsFactory builds a thing whose inclusion report carries the groups held in its state.
+type groupsFactory struct{}
+
+func (groupsFactory) Create(_ Adapter, publisher Publisher, ts ThingState) (Thing, error) {
+	var info groupsInfo
+
+	if err := ts.Info(&info); err != nil {
+		return nil, err
+	}
+
+	return NewThing(publisher, ts, &ThingConfig{
+		InclusionReport: &fimptype.ThingInclusionReport{Address: ts.Address(), Groups: info.Groups},
+		Connector:       &recordingConnector{},
+	}), nil
+}
+
+// TestRebuildChangedThing_RecreatesWhenDestroyReportsError pins that a destroy reporting an error
+// does not abort the rebuild. destroyThing is best-effort and has already removed the thing from
+// memory by the time it returns, so aborting left the device excluded and never recreated, taking
+// the persisted state the rebuild had just captured down with it.
+func TestRebuildChangedThing_RecreatesWhenDestroyReportsError(t *testing.T) {
+	t.Parallel()
+
+	s, err := NewState(t.TempDir())
+	require.NoError(t, err)
+
+	ts, err := s.add(&thingStateModel{ID: "B", Address: "2", Info: json.RawMessage(`{"groups":["g1"]}`)})
+	require.NoError(t, err)
+
+	require.NoError(t, ts.SetState(map[string]string{"keep": "me"}))
+
+	live, err := groupsFactory{}.Create(nil, stubPublisher{}, ts)
+	require.NoError(t, err)
+
+	a := &adapter{
+		publisher: stubPublisher{},
+		state:     failingRemoveState{State: s},
+		factory:   groupsFactory{},
+		things:    map[string]Thing{"2": live},
+		lock:      &sync.RWMutex{},
+	}
+
+	// The seed gains a group, so the topology drifts and the thing is rebuilt.
+	err = a.RebuildChangedThings(ThingSeeds{{ID: "B", Info: groupsInfo{Groups: []string{"g1", "g2"}}}})
+
+	assert.NoError(t, err, "a destroy that only reports an error must not fail the rebuild")
+
+	rebuilt := a.things["2"]
+	require.NotNil(t, rebuilt, "the thing must be recreated, not left excluded")
+	assert.Equal(t, []string{"g1", "g2"}, rebuilt.InclusionReport().Groups, "the rebuilt thing must carry the fresh topology")
+
+	newTS := a.state.byID("B")
+	require.NotNil(t, newTS, "the state record must be back")
+
+	var kept map[string]string
+
+	require.NoError(t, newTS.State(&kept))
+	assert.Equal(t, map[string]string{"keep": "me"}, kept, "persisted state must survive the rebuild")
 }

--- a/adapter/sync.go
+++ b/adapter/sync.go
@@ -62,10 +62,20 @@ func SyncThings[T any](
 func excludeVanishedDevices(a Adapter, selected []string, seeds ThingSeeds) []error {
 	var errs []error
 
+	// Nothing dedupes the selection on the way into the configuration, and an ID repeated there
+	// would otherwise announce the same vanished device twice.
+	excluded := make(map[string]struct{}, len(selected))
+
 	for _, id := range selected {
 		if seeds.Contains(id) {
 			continue
 		}
+
+		if _, done := excluded[id]; done {
+			continue
+		}
+
+		excluded[id] = struct{}{}
 
 		if _, owned := a.ExchangeID(id); owned {
 			continue // EnsureThings destroys it and announces its real address.

--- a/adapter/sync_test.go
+++ b/adapter/sync_test.go
@@ -81,6 +81,23 @@ func TestSyncThings_ExcludesVanishedDevice(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSyncThings_ExcludesDuplicatedSelectedDeviceOnce(t *testing.T) {
+	t.Parallel()
+
+	// Nothing dedupes the selection on the way into the configuration, so the same vanished ID can
+	// appear twice. Announcing an exclusion per occurrence is just confusing noise in the logs.
+	a := mockedadapter.NewAdapter(t)
+	a.On("ExchangeID", "2").Return("", false).Once()
+	a.On("ExchangeAddress", "2").Return("", false).Once()
+	a.On("DestroyThingByAddress", "2").Return(nil).Once()
+	a.On("EnsureThings", mock.Anything).Return(nil)
+
+	_, err := adapter.SyncThings(a, fetchOK([]device{{"1", "a"}}), []string{"1", "2", "2"}, seedDevice)
+
+	assert.NoError(t, err)
+	a.AssertNumberOfCalls(t, "DestroyThingByAddress", 1)
+}
+
 func TestSyncThings_DoesNotExcludeOwnedOrForeignAddress(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Addresses the two actionable findings from the latest review on #212.

| Finding | Fix |
|---|---|
| [P1 rebuildChangedThing aborts after destroyThing error, leaving device excluded](https://github.com/futurehomeno/cliffhanger/pull/212#discussion_r3682906134) | `rebuildChangedThing` logs the destroy error and continues to the recreate |
| [P3 Duplicate selected IDs trigger duplicate exclusion reports](https://github.com/futurehomeno/cliffhanger/pull/212#discussion_r3682906141) | `excludeVanishedDevices` announces each vanished ID once |

Not fixed: [P3 Store.Remove is a no-op for nil selection](https://github.com/futurehomeno/cliffhanger/pull/212#discussion_r3682906138) — the finding closes with "No code change is required", and both remedies it proposes already exist in the code docs and the upgrade guide.

### On the P1

This was fallout from the previous round. Making `destroyThing` best-effort (#214) changed its contract for four call sites; three were re-read and `rebuildChangedThing` was not. Destroy now always completes the in-memory removal before reporting an error, so returning at the destroy step left the device unregistered and excluded but never recreated — and discarded the `savedState` captured a few lines above, which is the very thing that capture exists to protect.

Two corrections to the finding's reasoning, neither of which changes the verdict:

- "remains missing until the adapter restarts" is not right — the next `SyncThings`/`EnsureThings` sees no in-memory record and recreates the device, so it self-heals within a sync cycle.
- The finding misses the worse consequence: whichever path heals it creates a **fresh** record with no persisted per-thing state, so the state is silently lost.

The alternative it offers (join the destroy error with any `createThing` error) is deliberately not taken — a rebuild that recreated successfully should report success, not surface an already-recovered error as a rebuild failure.

### Tests

Both pinned by tests verified to fail without the production change:

- `TestRebuildChangedThing_RecreatesWhenDestroyReportsError` (`adapter/drift_internal_test.go`) — without the fix: `rebuild B: destroy: ... state write failed` and the thing left destroyed. In-package because `State` has unexported methods, so a destroy failure cannot be injected from `adapter_test`.
- `TestSyncThings_ExcludesDuplicatedSelectedDeviceOnce` (`adapter/sync_test.go`) — without the fix the `.Once()` mock expectation is exceeded.

`failingRemoveState` was also made faithful to `state.remove`: the in-memory delete now happens and only the save fails, which is the real failure mode every caller has to reason about.

`make test` green across all 42 packages; `go build`, `go vet` and `golangci-lint run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)