### PR TITLE
Stop feeding unchanged level events to the virtual meter

### DIFF
--- a/adapter/event.go
+++ b/adapter/event.go
@@ -109,3 +109,12 @@ func WaitForServiceEvent() event.Filter {
 func WaitForThingEvent() event.Filter {
 	return event.WaitFor[ThingEvent]()
 }
+
+// WaitForChange returns a filter accepting only service events carrying a changed value.
+func WaitForChange() event.Filter {
+	return event.FilterFn(func(ev event.Event) bool {
+		e, ok := ev.(ServiceEvent)
+
+		return ok && e.HasChanged()
+	})
+}

--- a/adapter/service/virtualmeter/listener.go
+++ b/adapter/service/virtualmeter/listener.go
@@ -37,7 +37,7 @@ func NewHandlers(mr Manager, handlersBufferSize int) []*event.Handler {
 	}
 
 	return []*event.Handler{
-		event.NewHandler(&levelEventProcessor{processor{manager: m}}, "virtual_meter_level", handlersBufferSize, outlvlswitch.WaitForLevelEvent()),
+		event.NewHandler(&levelEventProcessor{processor{manager: m}}, "virtual_meter_level", handlersBufferSize, outlvlswitch.WaitForLevelEvent(), adapter.WaitForChange()),
 		event.NewHandler(&connectivityEventProcessor{processor{manager: m}}, "virtual_meter_connectivity", handlersBufferSize, adapter.WaitForConnectivityEvent()),
 	}
 }

--- a/adapter/service/virtualmeter/listener_test.go
+++ b/adapter/service/virtualmeter/listener_test.go
@@ -102,6 +102,8 @@ func TestHandlerLevelEvent(t *testing.T) { //nolint:paralleltest
 
 			if v.thing != nil {
 				ad := mockedadapter.NewAdapter(t)
+				// A filtered event leaves the mock without expectations on purpose: the assertion is that
+				// ThingByTopic is never called, so adding one unconditionally would silently gut the case.
 				if !v.filtered {
 					ad = ad.WithThingByTopic("", false, v.thing)
 				}

--- a/adapter/service/virtualmeter/listener_test.go
+++ b/adapter/service/virtualmeter/listener_test.go
@@ -45,14 +45,14 @@ func TestHandlerLevelEvent(t *testing.T) { //nolint:paralleltest
 	testCases := []struct {
 		name           string
 		thing          adapter.Thing
+		filtered       bool
 		levelEvent     *outlvlswitch.LevelEvent
 		expectedDevice *Device
 	}{
 		{
-			name: "level shouldn't call update if level hasn't changed and update isn't required",
-			thing: mockedadapter.NewThing(t).
-				WithServices(VirtualMeterElec, true, []adapter.Service{vms}).
-				WithServices(outlvlswitch.OutLvlSwitch, true, []adapter.Service{lvlService}),
+			name:     "level shouldn't reach the processor if level hasn't changed",
+			thing:    mockedadapter.NewThing(t),
+			filtered: true,
 			levelEvent: &outlvlswitch.LevelEvent{
 				Level:        0,
 				ServiceEvent: adapter.NewServiceEvent("type", false),
@@ -101,7 +101,12 @@ func TestHandlerLevelEvent(t *testing.T) { //nolint:paralleltest
 			m := mr.(*manager) //nolint:forcetypeassert
 
 			if v.thing != nil {
-				m.ad = mockedadapter.NewAdapter(t).WithThingByTopic("", false, v.thing)
+				ad := mockedadapter.NewAdapter(t)
+				if !v.filtered {
+					ad = ad.WithThingByTopic("", false, v.thing)
+				}
+
+				m.ad = ad
 				m.virtualServices[addr] = outLvlSwitchService
 			}
 

--- a/adapter/service/virtualmeter/manager.go
+++ b/adapter/service/virtualmeter/manager.go
@@ -60,14 +60,16 @@ func (m *manager) RegisterThing(thing adapter.Thing, publisher adapter.Publisher
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	for _, group := range thing.InclusionReport().Groups {
+	report := thing.InclusionReport()
+
+	for _, group := range report.Groups {
 		vmsSpec, numericSpec := m.createVirtualServicesForThing(thing, group)
 
 		if vmsSpec == nil || numericSpec == nil {
 			continue
 		}
 
-		log.Debugf("[cliff] Register services %s and %s for group %s", vmsSpec.Name, numericSpec.Name, group)
+		log.Debugf("[cliff] Register %s+%s dev=%s group=%s", vmsSpec.Name, numericSpec.Name, report.Address, group)
 
 		if err := m.registerVirtualServices(thing, publisher, vmsSpec, numericSpec); err != nil {
 			return err


### PR DESCRIPTION
## Problem

`outlvlswitch` publishes a `LevelEvent` on **every** `SendLevelReport`, including the branch where the reporting strategy suppressed the FIMP message (`adapter/service/outlvlswitch/service.go:139`).

The virtual meter's level handler subscribes to all of them. Unchanged reports are discarded only inside `manager.update`, and only *after* a buntdb read taken under the manager's global write lock — and the DB opens with `SyncPolicy: buntdb.Always`.

On an adapter driven by a push stream (hue, via SSE) this bites. A burst of stream events — a dim ramp, or a bridge reconnect — pushes hundreds of mostly-unchanged level events at a handler that is simultaneously stalled behind `updateDeviceActivity` holding the same lock across fsync'd writes. The subscriber buffer fills and the bus starts dropping:

```
W [cliff] Event subscriber ID=virtual_meter_level busy, event domain=adapter_service class=out_lvl_switch dropped
```

Those drops are not all harmless. A dropped event carrying a *real* level change is never applied, so the meter keeps accruing energy at the stale level until the next change arrives.

## Change

`ServiceEvent` already exposes `HasChanged()` and **nothing in cliffhanger consumed it**. This puts it to work:

- adds `adapter.WaitForChange()`, a filter accepting only service events with a changed value
- applies it to the `virtual_meter_level` handler alongside the existing type filter (handler filters are ANDed in `subscription.filter`)

Unchanged reports now never reach the processor, so they cost neither a lock acquisition nor a storage read, and no longer crowd out real changes.

## Correctness

All three built-in reporting strategies (`ReportAlways`, `ReportOnChangeOnly`, `ReportAtLeastEvery`) return true whenever the value changed, so `hasChanged=false` implies the value is genuinely unchanged — no real transition is filtered out.

Worth flagging for reviewers: a *custom* `ReportingStrategyFn` that ignores its `hasChanged` argument could report `false` for a changed value, and that transition would now be filtered. No such strategy ships in cliffhanger.

One behavioural trade-off, stated plainly: today an unchanged event is the only thing that re-syncs the meter if its stored level drifts from the reporting cache — which is exactly what a dropped event causes. This is self-consistent (far fewer events ⇒ no drops ⇒ nothing to re-sync), but it is a real change, not a pure win.

## Tests

`TestHandlerLevelEvent` already had a case named *"level shouldn't call update if level hasn't changed"* — the intent was documented, just enforced deep inside `manager.update`. That case now asserts it at the subscription: the adapter mock is given **no** expectations, so if the event ever reaches the processor again the unexpected `ThingByTopic` call fails the test. Verified non-vacuous by reverting the filter and watching it go red.

`make test` passes — 42 packages, no failures.

## Not addressed here

`updateDeviceActivity` holds the manager write lock across one fsync'd buntdb write *per virtual service*. That is what stalls the level goroutine in the first place; this PR reduces the queue pressure but does not remove the stall. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
