### PR TITLE
Buffer log output in RAM to cut eMMC write amplification

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -29,6 +29,7 @@ type Default struct {
 	LogLevel           string                 `json:"log_level"`
 	LogFormat          string                 `json:"log_format"`
 	LogRevertTimeout   time.Duration          `json:"log_revert_timeout,omitempty"`
+	LogFlushInterval   time.Duration          `json:"log_flush_interval,omitempty"`
 	LogRevertAt        time.Time              `json:"log_revert_at"`
 	RestartsCount      int                    `json:"restarts_count,omitempty"`
 	Telemetry          *types.TelemetryConfig `json:"telemetry,omitempty"`
@@ -184,6 +185,13 @@ func (s *DefaultStore) SetLogRevertTimeout(d time.Duration) error {
 	s.accessor().LogRevertTimeout = d
 
 	return s.saveStamped()
+}
+
+func (s *DefaultStore) LogFlushInterval() time.Duration {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return s.accessor().LogFlushInterval
 }
 
 func (s *DefaultStore) LogRevertAt() time.Time {

--- a/debug/debug_test.go
+++ b/debug/debug_test.go
@@ -184,6 +184,33 @@ func TestInitializeLogger_ReinitializationFlushesPreviousBuffer(t *testing.T) { 
 		"reinitializing must flush the previous manager's buffer, not drop it")
 }
 
+// TestInitializeLogger_FailedReinitLeavesPreviousManagerUsable pins that a failed
+// InitializeLogger call (bad new log file) leaves the previous, still-good manager live and
+// wired into logrus, rather than one this call had already torn down before validating the
+// replacement.
+func TestInitializeLogger_FailedReinitLeavesPreviousManagerUsable(t *testing.T) { //nolint:paralleltest
+	_, logFile := initLogger(t, "info", "text")
+
+	logrus.Info("line-before-failed-reinit")
+
+	badCfg := &config.Default{LogLevel: "info", LogFormat: "text", LogFile: ""}
+	badStore := config.NewDefaultStore(
+		func() *config.Default { return badCfg },
+		func() error { return nil },
+	)
+
+	require.Error(t, debug.InitializeLogger(badStore), "empty log file must fail setLogOutput")
+
+	logrus.Info("line-after-failed-reinit")
+	debug.FlushLogs()
+
+	b, err := os.ReadFile(logFile) //nolint:gosec
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "line-before-failed-reinit")
+	assert.Contains(t, string(b), "line-after-failed-reinit",
+		"a failed reinit must not leave the previous manager torn down and unusable")
+}
+
 // TestLogBuffering_DebugLevelFlushesNearRealTime verifies that enabling
 // debug/trace shortens the periodic flush so a human tailing the log file
 // sees lines within a couple of seconds, not the long info-level interval.

--- a/debug/debug_test.go
+++ b/debug/debug_test.go
@@ -211,6 +211,32 @@ func TestInitializeLogger_FailedReinitLeavesPreviousManagerUsable(t *testing.T) 
 		"a failed reinit must not leave the previous manager torn down and unusable")
 }
 
+// TestInitializeLogger_FailedReinitRestoresFormatterAndLevel pins that a failed reinit rolls
+// back the format/level globals it mutated before validating the new output, not just the
+// logManager pointer - otherwise a failed attempt could leave the process on a mix of the old
+// manager and the new (unvalidated) format/level.
+func TestInitializeLogger_FailedReinitRestoresFormatterAndLevel(t *testing.T) { //nolint:paralleltest
+	initLogger(t, "warning", "json")
+
+	require.Equal(t, logrus.WarnLevel, logrus.GetLevel())
+
+	badCfg := &config.Default{LogLevel: "debug", LogFormat: "budzik", LogFile: ""}
+	badStore := config.NewDefaultStore(
+		func() *config.Default { return badCfg },
+		func() error { return nil },
+	)
+
+	require.Error(t, debug.InitializeLogger(badStore), "empty log file must fail setLogOutput")
+
+	assert.Equal(t, logrus.WarnLevel, logrus.GetLevel(),
+		"a failed reinit must not leave the process on the new (unvalidated) level")
+
+	unwrapper, ok := logrus.StandardLogger().Formatter.(interface{ Unwrap() logrus.Formatter })
+	require.True(t, ok)
+	assert.IsType(t, &logrus.JSONFormatter{}, unwrapper.Unwrap(),
+		"a failed reinit must not leave the process on the new (unvalidated) formatter")
+}
+
 // TestLogBuffering_DebugLevelFlushesNearRealTime verifies that enabling
 // debug/trace shortens the periodic flush so a human tailing the log file
 // sees lines within a couple of seconds, not the long info-level interval.
@@ -230,6 +256,50 @@ func TestLogBuffering_DebugLevelFlushesNearRealTime(t *testing.T) { //nolint:par
 	require.Eventually(t, func() bool {
 		return strings.Contains(read(), "debug-mode-info-line")
 	}, 3*time.Second, 100*time.Millisecond, "debug level should flush near real time")
+}
+
+// TestLogBuffering_DebugLevelSelfExpiresAfterRevertDeadline verifies that the fast debug-level
+// flush cadence stops on its own once the revert deadline elapses, rather than only on the next
+// unrelated SetLevel/SetFile call - otherwise a hub left running for weeks after someone enabled
+// debug (and forgot) would keep paying the fast-flush eMMC cost indefinitely.
+func TestLogBuffering_DebugLevelSelfExpiresAfterRevertDeadline(t *testing.T) { //nolint:paralleltest
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "app.log")
+
+	cfg := &config.Default{
+		LogLevel:    "debug",
+		LogFormat:   "text",
+		LogFile:     logFile,
+		LogRevertAt: time.Now().Add(300 * time.Millisecond),
+	}
+	store := config.NewDefaultStore(
+		func() *config.Default { return cfg },
+		func() error { return nil },
+	)
+
+	saved := logrus.GetLevel()
+	t.Cleanup(func() { logrus.SetLevel(saved) })
+
+	require.NoError(t, debug.InitializeLogger(store))
+
+	read := func() string {
+		b, err := os.ReadFile(logFile) //nolint:gosec
+		require.NoError(t, err)
+
+		return string(b)
+	}
+
+	// Past the 300ms deadline, and past the flusher's first 2s tick, so the self-correction
+	// check (run inside that tick) has already switched the ticker to the slow interval.
+	time.Sleep(2500 * time.Millisecond)
+
+	logrus.Info("line-after-deadline-elapsed")
+	require.Never(t, func() bool {
+		return strings.Contains(read(), "line-after-deadline-elapsed")
+	}, 2*time.Second, 200*time.Millisecond, "must no longer be flushing every 2s once the deadline has elapsed")
+
+	debug.FlushLogs()
+	assert.Contains(t, read(), "line-after-deadline-elapsed", "the line must still reach disk eventually")
 }
 
 func TestInitializeLogger_AppliesEachFormat(t *testing.T) { //nolint:paralleltest

--- a/debug/debug_test.go
+++ b/debug/debug_test.go
@@ -137,6 +137,32 @@ func TestInitializeLogger_EmptyLogFile_Errors(t *testing.T) { //nolint:parallelt
 	require.Error(t, err)
 }
 
+func TestLogBuffering_HoldsInfoUntilErrorOrExplicitFlush(t *testing.T) { //nolint:paralleltest
+	_, logFile := initLogger(t, "info", "text")
+
+	read := func() string {
+		b, err := os.ReadFile(logFile) //nolint:gosec
+		require.NoError(t, err)
+
+		return string(b)
+	}
+
+	logrus.Info("buffered-info-line")
+	assert.NotContains(t, read(), "buffered-info-line", "info level should stay in RAM")
+
+	logrus.Error("urgent-error-line")
+
+	got := read()
+	assert.Contains(t, got, "urgent-error-line", "error level should reach the file immediately")
+	assert.Contains(t, got, "buffered-info-line", "an error flush should carry preceding lines with it")
+
+	logrus.Info("second-info-line")
+	assert.NotContains(t, read(), "second-info-line")
+
+	debug.FlushLogs()
+	assert.Contains(t, read(), "second-info-line", "explicit flush should drain the buffer")
+}
+
 func TestInitializeLogger_AppliesEachFormat(t *testing.T) { //nolint:paralleltest
 	cases := []struct {
 		format string
@@ -153,7 +179,11 @@ func TestInitializeLogger_AppliesEachFormat(t *testing.T) { //nolint:paralleltes
 			initLogger(t, "info", tc.format)
 
 			got := logrus.StandardLogger().Formatter
-			assert.NotNil(t, got)
+			require.NotNil(t, got)
+
+			unwrapper, ok := got.(interface{ Unwrap() logrus.Formatter })
+			require.True(t, ok, "formatter should be wrapped for error-level flushing")
+			got = unwrapper.Unwrap()
 
 			switch tc.format {
 			case "json":

--- a/debug/debug_test.go
+++ b/debug/debug_test.go
@@ -164,6 +164,26 @@ func TestLogBuffering_HoldsInfoUntilErrorOrExplicitFlush(t *testing.T) { //nolin
 	assert.Contains(t, read(), "second-info-line", "explicit flush should drain the buffer")
 }
 
+// TestInitializeLogger_ReinitializationFlushesPreviousBuffer pins that re-calling
+// InitializeLogger - which discards the previous logManager - does not drop log lines still
+// sitting in the old manager's RAM buffer.
+func TestInitializeLogger_ReinitializationFlushesPreviousBuffer(t *testing.T) { //nolint:paralleltest
+	_, firstFile := initLogger(t, "info", "text")
+
+	logrus.Info("line-buffered-before-reinit")
+
+	b, err := os.ReadFile(firstFile) //nolint:gosec
+	require.NoError(t, err)
+	require.NotContains(t, string(b), "line-buffered-before-reinit", "should still be buffered, not yet flushed")
+
+	initLogger(t, "info", "text") // second InitializeLogger call, pointing at a new temp file
+
+	b, err = os.ReadFile(firstFile) //nolint:gosec
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "line-buffered-before-reinit",
+		"reinitializing must flush the previous manager's buffer, not drop it")
+}
+
 // TestLogBuffering_DebugLevelFlushesNearRealTime verifies that enabling
 // debug/trace shortens the periodic flush so a human tailing the log file
 // sees lines within a couple of seconds, not the long info-level interval.

--- a/debug/debug_test.go
+++ b/debug/debug_test.go
@@ -3,6 +3,7 @@ package debug_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -161,6 +162,27 @@ func TestLogBuffering_HoldsInfoUntilErrorOrExplicitFlush(t *testing.T) { //nolin
 
 	debug.FlushLogs()
 	assert.Contains(t, read(), "second-info-line", "explicit flush should drain the buffer")
+}
+
+// TestLogBuffering_DebugLevelFlushesNearRealTime verifies that enabling
+// debug/trace shortens the periodic flush so a human tailing the log file
+// sees lines within a couple of seconds, not the long info-level interval.
+func TestLogBuffering_DebugLevelFlushesNearRealTime(t *testing.T) { //nolint:paralleltest
+	_, logFile := initLogger(t, "debug", "text")
+
+	read := func() string {
+		b, err := os.ReadFile(logFile) //nolint:gosec
+		require.NoError(t, err)
+
+		return string(b)
+	}
+
+	logrus.Info("debug-mode-info-line")
+	assert.NotContains(t, read(), "debug-mode-info-line", "still buffered immediately after logging")
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(read(), "debug-mode-info-line")
+	}, 3*time.Second, 100*time.Millisecond, "debug level should flush near real time")
 }
 
 func TestInitializeLogger_AppliesEachFormat(t *testing.T) { //nolint:paralleltest

--- a/debug/log_manager.go
+++ b/debug/log_manager.go
@@ -71,18 +71,7 @@ type Store interface {
 }
 
 func InitializeLogger(store Store) error {
-	if logManager != nil {
-		logManager.stopFlusher()
-
-		// Close (which flushes) rather than drop: the old logOutput may hold up to
-		// logBufferSize of not-yet-written lines, and nothing else keeps a reference to it
-		// once logManager is reassigned below.
-		if logManager.logOutput != nil {
-			if err := logManager.logOutput.Close(); err != nil {
-				logrus.Errorf("[cliff] close previous log output err: %v", err)
-			}
-		}
-	}
+	previous := logManager
 
 	logManager = &logManagerT{
 		store: store,
@@ -96,11 +85,29 @@ func InitializeLogger(store Store) error {
 	// startup.
 	_ = logManager.applyPersistedLevel()
 
+	// The new output is validated (and, on success, wired into logrus) before the previous
+	// manager is torn down. On failure, restore it: logrus keeps pointing at a manager that is
+	// still open and still flushing, rather than one this call already closed.
 	if err := logManager.setLogOutput(store.LogFile()); err != nil {
+		logManager = previous
+
 		return err
 	}
 
 	logManager.startFlusher()
+
+	if previous != nil {
+		previous.stopFlusher()
+
+		// Close (which flushes) rather than drop: the old logOutput may hold up to
+		// logBufferSize of not-yet-written lines, and nothing else keeps a reference to it
+		// now that logrus has been switched to the new one above.
+		if previous.logOutput != nil {
+			if err := previous.logOutput.Close(); err != nil {
+				logrus.Errorf("[cliff] close previous log output err: %v", err)
+			}
+		}
+	}
 
 	return nil
 }

--- a/debug/log_manager.go
+++ b/debug/log_manager.go
@@ -73,6 +73,15 @@ type Store interface {
 func InitializeLogger(store Store) error {
 	if logManager != nil {
 		logManager.stopFlusher()
+
+		// Close (which flushes) rather than drop: the old logOutput may hold up to
+		// logBufferSize of not-yet-written lines, and nothing else keeps a reference to it
+		// once logManager is reassigned below.
+		if logManager.logOutput != nil {
+			if err := logManager.logOutput.Close(); err != nil {
+				logrus.Errorf("[cliff] close previous log output err: %v", err)
+			}
+		}
 	}
 
 	logManager = &logManagerT{
@@ -135,7 +144,19 @@ func (ptr *logManagerT) flushInterval() time.Duration {
 	return interval
 }
 
+// startFlusher and stopFlusher guard flushStop with ptr.lock, like every other field on
+// logManagerT, for callers (InitializeLogger) that do not already hold it. restartFlusher is
+// called from within SetLevel, which already holds ptr.lock for its whole body, so it uses the
+// Locked variants directly - sync.Mutex is not reentrant, and going through startFlusher /
+// stopFlusher there would deadlock on every SetLevel call.
 func (ptr *logManagerT) startFlusher() {
+	ptr.lock.Lock()
+	defer ptr.lock.Unlock()
+
+	ptr.startFlusherLocked()
+}
+
+func (ptr *logManagerT) startFlusherLocked() {
 	interval := ptr.flushInterval()
 
 	stop := make(chan struct{})
@@ -157,6 +178,13 @@ func (ptr *logManagerT) startFlusher() {
 }
 
 func (ptr *logManagerT) stopFlusher() {
+	ptr.lock.Lock()
+	defer ptr.lock.Unlock()
+
+	ptr.stopFlusherLocked()
+}
+
+func (ptr *logManagerT) stopFlusherLocked() {
 	if ptr.flushStop != nil {
 		close(ptr.flushStop)
 		ptr.flushStop = nil
@@ -168,8 +196,8 @@ func (ptr *logManagerT) stopFlusher() {
 // (or from) near-real-time flushing takes effect immediately rather than on
 // the next tick.
 func (ptr *logManagerT) restartFlusher() {
-	ptr.stopFlusher()
-	ptr.startFlusher()
+	ptr.stopFlusherLocked()
+	ptr.startFlusherLocked()
 }
 
 // applyPersistedLevel applies the persisted log level at startup. Unlike

--- a/debug/log_manager.go
+++ b/debug/log_manager.go
@@ -44,7 +44,16 @@ const (
 	// block on every filesystem commit; batching trades that write
 	// amplification for losing the tail of the log on power loss.
 	defaultLogFlushInterval = 240 * time.Second
-	logBufferSize           = 64 * 1024
+
+	// debugLogFlushInterval applies while the level is debug/trace: someone
+	// enabling debug is almost always about to tail the log file, and the
+	// long interval would make a running adapter look hung. Debug is also a
+	// bounded, operator-armed window (log_revert_timeout reverts it to info
+	// on its own), so trading some of the write-amplification protection for
+	// near-real-time tailing only lasts as long as the window does.
+	debugLogFlushInterval = 2 * time.Second
+
+	logBufferSize = 64 * 1024
 )
 
 type Store interface {
@@ -110,11 +119,24 @@ func (ptr *logManagerT) flush() {
 	}
 }
 
-func (ptr *logManagerT) startFlusher() {
+// flushInterval returns the interval the periodic flusher should currently
+// use: short while debug/trace is active, the configured (or default) one
+// otherwise.
+func (ptr *logManagerT) flushInterval() time.Duration {
+	if logrus.GetLevel() >= logrus.DebugLevel {
+		return debugLogFlushInterval
+	}
+
 	interval := ptr.store.LogFlushInterval()
 	if interval <= 0 {
 		interval = defaultLogFlushInterval
 	}
+
+	return interval
+}
+
+func (ptr *logManagerT) startFlusher() {
+	interval := ptr.flushInterval()
 
 	stop := make(chan struct{})
 	ptr.flushStop = stop
@@ -139,6 +161,15 @@ func (ptr *logManagerT) stopFlusher() {
 		close(ptr.flushStop)
 		ptr.flushStop = nil
 	}
+}
+
+// restartFlusher re-picks the flush interval and restarts the ticker. Called
+// whenever the log level crosses the debug/trace boundary so the switch to
+// (or from) near-real-time flushing takes effect immediately rather than on
+// the next tick.
+func (ptr *logManagerT) restartFlusher() {
+	ptr.stopFlusher()
+	ptr.startFlusher()
 }
 
 // applyPersistedLevel applies the persisted log level at startup. Unlike
@@ -315,6 +346,7 @@ func (ptr *logManagerT) SetLevel(level string) error {
 		}
 
 		logrus.SetLevel(logLevel)
+		ptr.restartFlusher()
 		logrus.Infof("[cliff] Log level updated to %s", logLevel)
 
 		return nil
@@ -334,6 +366,7 @@ func (ptr *logManagerT) SetLevel(level string) error {
 	}
 
 	logrus.SetLevel(logLevel)
+	ptr.restartFlusher()
 	logrus.Infof("[cliff] Log level updated to %s; will revert to info on next startup after %s", logLevel, timeout)
 
 	return nil

--- a/debug/log_manager.go
+++ b/debug/log_manager.go
@@ -72,6 +72,8 @@ type Store interface {
 
 func InitializeLogger(store Store) error {
 	previous := logManager
+	previousFormatter := logrus.StandardLogger().Formatter
+	previousLevel := logrus.GetLevel()
 
 	logManager = &logManagerT{
 		store: store,
@@ -86,10 +88,14 @@ func InitializeLogger(store Store) error {
 	_ = logManager.applyPersistedLevel()
 
 	// The new output is validated (and, on success, wired into logrus) before the previous
-	// manager is torn down. On failure, restore it: logrus keeps pointing at a manager that is
-	// still open and still flushing, rather than one this call already closed.
+	// manager is torn down. On failure, restore it along with the format/level globals set above:
+	// logrus keeps pointing at a manager that is still open and still flushing, using the same
+	// settings it had before this call, rather than one this call already closed with a mix of
+	// old and new global state.
 	if err := logManager.setLogOutput(store.LogFile()); err != nil {
 		logManager = previous
+		logrus.SetFormatter(previousFormatter)
+		logrus.SetLevel(previousLevel)
 
 		return err
 	}
@@ -135,12 +141,17 @@ func (ptr *logManagerT) flush() {
 	}
 }
 
-// flushInterval returns the interval the periodic flusher should currently
-// use: short while debug/trace is active, the configured (or default) one
-// otherwise.
+// flushInterval returns the interval the periodic flusher should currently use: short while
+// debug/trace is active and its revert deadline (if any) has not yet elapsed, the configured (or
+// default) one otherwise. Called fresh on every tick by the flusher goroutine (see
+// startFlusherLocked), so a deadline elapsing mid-run is noticed on its own within one
+// debug-interval tick - not just the next time something else happens to call restartFlusher.
 func (ptr *logManagerT) flushInterval() time.Duration {
 	if logrus.GetLevel() >= logrus.DebugLevel {
-		return debugLogFlushInterval
+		revertAt := ptr.store.LogRevertAt()
+		if revertAt.IsZero() || time.Now().Before(revertAt) {
+			return debugLogFlushInterval
+		}
 	}
 
 	interval := ptr.store.LogFlushInterval()
@@ -177,6 +188,14 @@ func (ptr *logManagerT) startFlusherLocked() {
 			select {
 			case <-ticker.C:
 				ptr.flush()
+
+				// The revert deadline (or log_flush_interval itself) can change without any
+				// SetLevel/SetFile call in between - just time passing. Recheck each tick so the
+				// ticker adjusts on its own instead of staying fast indefinitely once armed.
+				if next := ptr.flushInterval(); next != interval {
+					interval = next
+					ticker.Reset(interval)
+				}
 			case <-stop:
 				return
 			}
@@ -371,6 +390,11 @@ func (ptr *logManagerT) SetLevel(level string) error {
 	ptr.lock.Lock()
 	defer ptr.lock.Unlock()
 
+	// Only a change to the flush cadence itself justifies restarting the ticker: doing it
+	// unconditionally on every SetLevel (e.g. info -> warn, or re-setting the same level) would
+	// reset an already-close-to-due flush back to a full interval for no reason.
+	oldInterval := ptr.flushInterval()
+
 	if logLevel < logrus.DebugLevel {
 		if err := ptr.store.SetLevel(logLevel.String()); err != nil {
 			return err
@@ -381,7 +405,11 @@ func (ptr *logManagerT) SetLevel(level string) error {
 		}
 
 		logrus.SetLevel(logLevel)
-		ptr.restartFlusher()
+
+		if ptr.flushInterval() != oldInterval {
+			ptr.restartFlusher()
+		}
+
 		logrus.Infof("[cliff] Log level updated to %s", logLevel)
 
 		return nil
@@ -401,7 +429,11 @@ func (ptr *logManagerT) SetLevel(level string) error {
 	}
 
 	logrus.SetLevel(logLevel)
-	ptr.restartFlusher()
+
+	if ptr.flushInterval() != oldInterval {
+		ptr.restartFlusher()
+	}
+
 	logrus.Infof("[cliff] Log level updated to %s; will revert to info on next startup after %s", logLevel, timeout)
 
 	return nil

--- a/debug/log_manager.go
+++ b/debug/log_manager.go
@@ -1,10 +1,12 @@
 package debug
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -15,17 +17,35 @@ import (
 
 var (
 	logManager *logManagerT
+
+	// urgent is set by levelFormatter for entries at error level or above and
+	// consumed by bufferedWriter.Write, which logrus calls immediately after
+	// Format under the same logger mutex. A level hook cannot serve here:
+	// hooks fire before the entry is written, so they cannot flush the very
+	// line that triggered them.
+	urgent atomic.Bool
 )
 
 type logManagerT struct {
-	logOutput *lumberjack.Logger
+	logOutput *bufferedWriter
 	store     Store
 	lock      sync.Mutex
+	flushStop chan struct{}
 }
 
 // defaultLogRevertTimeout is the timeout after which a verbose log level
 // (debug/trace) is automatically reverted to the previous level (info/warn)
 const defaultLogRevertTimeout = 7 * 24 * time.Hour
+
+const (
+	// defaultLogFlushInterval bounds how long a line may sit in RAM before it
+	// reaches the log file. The hub stores logs on eMMC, where an idle adapter
+	// appending one short line at a time still dirties a page plus a journal
+	// block on every filesystem commit; batching trades that write
+	// amplification for losing the tail of the log on power loss.
+	defaultLogFlushInterval = 240 * time.Second
+	logBufferSize           = 64 * 1024
+)
 
 type Store interface {
 	Level() string
@@ -38,9 +58,14 @@ type Store interface {
 	SetLogRevertTimeout(d time.Duration) error
 	LogRevertAt() time.Time
 	SetLogRevertAt(t time.Time) error
+	LogFlushInterval() time.Duration
 }
 
 func InitializeLogger(store Store) error {
+	if logManager != nil {
+		logManager.stopFlusher()
+	}
+
 	logManager = &logManagerT{
 		store: store,
 	}
@@ -53,7 +78,67 @@ func InitializeLogger(store Store) error {
 	// startup.
 	_ = logManager.applyPersistedLevel()
 
-	return logManager.setLogOutput(store.LogFile())
+	if err := logManager.setLogOutput(store.LogFile()); err != nil {
+		return err
+	}
+
+	logManager.startFlusher()
+
+	return nil
+}
+
+// FlushLogs writes buffered log lines to the log file. Error-level entries and
+// the periodic flusher do this on their own; call it before a deliberate exit
+// so the closing lines are not lost with the process.
+func FlushLogs() {
+	if logManager != nil {
+		logManager.flush()
+	}
+}
+
+func (ptr *logManagerT) flush() {
+	ptr.lock.Lock()
+	out := ptr.logOutput
+	ptr.lock.Unlock()
+
+	if out == nil {
+		return
+	}
+
+	if err := out.Flush(); err != nil {
+		logrus.Errorf("[cliff] flush log output err: %v", err)
+	}
+}
+
+func (ptr *logManagerT) startFlusher() {
+	interval := ptr.store.LogFlushInterval()
+	if interval <= 0 {
+		interval = defaultLogFlushInterval
+	}
+
+	stop := make(chan struct{})
+	ptr.flushStop = stop
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				ptr.flush()
+			case <-stop:
+				return
+			}
+		}
+	}()
+}
+
+func (ptr *logManagerT) stopFlusher() {
+	if ptr.flushStop != nil {
+		close(ptr.flushStop)
+		ptr.flushStop = nil
+	}
 }
 
 // applyPersistedLevel applies the persisted log level at startup. Unlike
@@ -97,14 +182,75 @@ func (ptr *logManagerT) applyPersistedLevel() error {
 }
 
 func setLogFormat(logFormat string) {
+	var formatter logrus.Formatter
+
 	switch logFormat {
 	case "json":
-		logrus.SetFormatter(&logrus.JSONFormatter{TimestampFormat: "2006-01-02 15:04:05.999"})
+		formatter = &logrus.JSONFormatter{TimestampFormat: "2006-01-02 15:04:05.999"}
 	case "budzik":
-		logrus.SetFormatter(formatters.NewBudzikFormatter())
+		formatter = formatters.NewBudzikFormatter()
 	default:
-		logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true, ForceColors: true, TimestampFormat: "2006-01-02T15:04:05.999"})
+		formatter = &logrus.TextFormatter{FullTimestamp: true, ForceColors: true, TimestampFormat: "2006-01-02T15:04:05.999"}
 	}
+
+	logrus.SetFormatter(&levelFormatter{Formatter: formatter})
+}
+
+type levelFormatter struct {
+	logrus.Formatter
+}
+
+func (f *levelFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	urgent.Store(entry.Level <= logrus.ErrorLevel)
+
+	return f.Formatter.Format(entry)
+}
+
+func (f *levelFormatter) Unwrap() logrus.Formatter {
+	return f.Formatter
+}
+
+// bufferedWriter batches log lines in RAM ahead of the rotating log file,
+// flushing on error-level entries, on a full buffer, and on the manager's
+// periodic tick.
+type bufferedWriter struct {
+	lock sync.Mutex
+	buf  *bufio.Writer
+	file *lumberjack.Logger
+}
+
+func newBufferedWriter(file *lumberjack.Logger) *bufferedWriter {
+	return &bufferedWriter{buf: bufio.NewWriterSize(file, logBufferSize), file: file}
+}
+
+func (w *bufferedWriter) Write(p []byte) (int, error) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	n, err := w.buf.Write(p)
+	if err != nil || !urgent.Load() {
+		return n, err
+	}
+
+	return n, w.buf.Flush()
+}
+
+func (w *bufferedWriter) Flush() error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	return w.buf.Flush()
+}
+
+func (w *bufferedWriter) Close() error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	if err := w.buf.Flush(); err != nil {
+		return err
+	}
+
+	return w.file.Close()
 }
 
 func (ptr *logManagerT) setLogOutput(logFile string) error {
@@ -122,17 +268,17 @@ func (ptr *logManagerT) setLogOutput(logFile string) error {
 		logrus.Errorf("close err: %v", cerr)
 	}
 
-	newOutput := &lumberjack.Logger{
+	newOutput := newBufferedWriter(&lumberjack.Logger{
 		Filename:   logFile,
 		MaxSize:    5, // MiB
 		MaxBackups: 4,
-	}
+	})
 
 	previous := ptr.logOutput
 	ptr.logOutput = newOutput
 	logrus.SetOutput(newOutput)
 
-	if previous != nil && previous != newOutput {
+	if previous != nil {
 		if err := previous.Close(); err != nil {
 			logrus.Errorf("close previous log output err: %v", err)
 		}

--- a/debug/log_manager_internal_test.go
+++ b/debug/log_manager_internal_test.go
@@ -1,0 +1,90 @@
+package debug
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/futurehomeno/cliffhanger/config"
+)
+
+func TestFlushInterval_DebugPastRevertDeadline_FallsBackToConfiguredInterval(t *testing.T) { //nolint:paralleltest
+	saved := logrus.GetLevel()
+	t.Cleanup(func() { logrus.SetLevel(saved) })
+	logrus.SetLevel(logrus.DebugLevel)
+
+	cfg := &config.Default{LogRevertAt: time.Now().Add(-time.Minute)}
+	store := config.NewDefaultStore(func() *config.Default { return cfg }, func() error { return nil })
+
+	ptr := &logManagerT{store: store}
+
+	assert.Equal(t, defaultLogFlushInterval, ptr.flushInterval(),
+		"an elapsed revert deadline must fall back to the slow interval even though the process-wide level is still debug")
+}
+
+func TestFlushInterval_DebugBeforeRevertDeadline_StaysFast(t *testing.T) { //nolint:paralleltest
+	saved := logrus.GetLevel()
+	t.Cleanup(func() { logrus.SetLevel(saved) })
+	logrus.SetLevel(logrus.DebugLevel)
+
+	cfg := &config.Default{LogRevertAt: time.Now().Add(time.Hour)}
+	store := config.NewDefaultStore(func() *config.Default { return cfg }, func() error { return nil })
+
+	ptr := &logManagerT{store: store}
+
+	assert.Equal(t, debugLogFlushInterval, ptr.flushInterval())
+}
+
+func TestFlushInterval_DebugNoRevertDeadlineArmed_StaysFast(t *testing.T) { //nolint:paralleltest
+	saved := logrus.GetLevel()
+	t.Cleanup(func() { logrus.SetLevel(saved) })
+	logrus.SetLevel(logrus.DebugLevel)
+
+	cfg := &config.Default{} // zero LogRevertAt: not armed, e.g. a persisted level applied without SetLevel having run this boot
+	store := config.NewDefaultStore(func() *config.Default { return cfg }, func() error { return nil })
+
+	ptr := &logManagerT{store: store}
+
+	assert.Equal(t, debugLogFlushInterval, ptr.flushInterval())
+}
+
+func TestSetLevel_FlusherRestartsOnlyWhenCadenceChanges(t *testing.T) { //nolint:paralleltest
+	cases := []struct {
+		name          string
+		newLevel      string
+		wantRestarted bool
+	}{
+		{"same-side change (info -> warn) does not restart", "warn", false},
+		{"crossing into debug restarts", "debug", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) { //nolint:paralleltest
+			saved := logrus.GetLevel()
+			savedOut := logrus.StandardLogger().Out
+			t.Cleanup(func() {
+				logrus.SetLevel(saved)
+				logrus.SetOutput(savedOut)
+			})
+
+			dir := t.TempDir()
+			cfg := &config.Default{LogLevel: "info", LogFormat: "text", LogFile: filepath.Join(dir, "app.log")}
+			store := config.NewDefaultStore(func() *config.Default { return cfg }, func() error { return nil })
+
+			require.NoError(t, InitializeLogger(store))
+			t.Cleanup(func() { logManager.stopFlusher() })
+
+			before := logManager.flushStop
+
+			require.NoError(t, logManager.SetLevel(tc.newLevel))
+
+			restarted := before != logManager.flushStop
+			assert.Equal(t, tc.wantRestarted, restarted,
+				"the flusher must restart exactly when the flush cadence actually changes")
+		})
+	}
+}

--- a/root/app.go
+++ b/root/app.go
@@ -16,6 +16,7 @@ import (
 
 	cliffapp "github.com/futurehomeno/cliffhanger/app"
 	"github.com/futurehomeno/cliffhanger/config"
+	"github.com/futurehomeno/cliffhanger/debug"
 	"github.com/futurehomeno/cliffhanger/lifecycle"
 	"github.com/futurehomeno/cliffhanger/notification"
 	"github.com/futurehomeno/cliffhanger/router"
@@ -364,6 +365,9 @@ func (a *app) doStop() error {
 	a.mqtt.Stop()
 
 	a.running = false
+
+	debug.FlushLogs()
+
 	return nil
 }
 

--- a/root/app.go
+++ b/root/app.go
@@ -332,6 +332,10 @@ func (a *app) doStop() error {
 		return nil
 	}
 
+	// Deferred so buffered diagnostics leading up to a failure are not lost on an early
+	// return below - exactly the case where they matter most.
+	defer debug.FlushLogs()
+
 	a.stopAuthLossWatcher()
 
 	if a.lifecycle != nil {
@@ -365,8 +369,6 @@ func (a *app) doStop() error {
 	a.mqtt.Stop()
 
 	a.running = false
-
-	debug.FlushLogs()
 
 	return nil
 }

--- a/root/doStop_flush_internal_test.go
+++ b/root/doStop_flush_internal_test.go
@@ -1,0 +1,58 @@
+package root
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/futurehomeno/cliffhanger/config"
+	"github.com/futurehomeno/cliffhanger/debug"
+	"github.com/futurehomeno/cliffhanger/task"
+)
+
+// TestDoStop_FlushesLogsEvenOnEarlyFailure pins that a doStop() failure path still flushes
+// the buffered log lines leading up to it - exactly where they matter most for diagnosing
+// the failure. taskManager.Stop() on a never-started manager is the cheapest way to force
+// doStop() to return before reaching its old, success-only flush call.
+func TestDoStop_FlushesLogsEvenOnEarlyFailure(t *testing.T) { //nolint:paralleltest
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "app.log")
+
+	cfg := &config.Default{LogLevel: "info", LogFormat: "text", LogFile: logFile}
+	store := config.NewDefaultStore(
+		func() *config.Default { return cfg },
+		func() error { return nil },
+	)
+
+	savedLevel := logrus.GetLevel()
+	savedOut := logrus.StandardLogger().Out
+	t.Cleanup(func() {
+		logrus.SetLevel(savedLevel)
+		logrus.SetOutput(savedOut)
+	})
+
+	require.NoError(t, debug.InitializeLogger(store))
+
+	a := &app{
+		running:     true,
+		taskManager: task.NewManager(), // never started: Stop() fails immediately
+	}
+
+	logrus.Info("buffered-line-before-failed-stop")
+
+	b, err := os.ReadFile(logFile) //nolint:gosec
+	require.NoError(t, err)
+	require.NotContains(t, string(b), "buffered-line-before-failed-stop", "should still be buffered, not yet flushed")
+
+	err = a.doStop()
+	require.Error(t, err, "an unstarted task manager must fail Stop()")
+
+	b, err = os.ReadFile(logFile) //nolint:gosec
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "buffered-line-before-failed-stop",
+		"doStop() must flush buffered logs even when it returns early on error")
+}


### PR DESCRIPTION
## Why

Logs go to `/var/log/futurehome/<app>/<app>.log` on the hub's eMMC, appended one short line at a time. Nothing in the path calls `fsync` — the kernel page cache already absorbs the bytes — but an *idle* adapter still dirties a 4 KiB page plus an ext4 journal block on every filesystem commit (~5s). The flash traffic is therefore dominated by write amplification, not by the actual log volume: a handful of Info lines a minute costs far more than their size.

## What

A 64 KiB `bufio.Writer` now sits between logrus and lumberjack. It drains on:

- **Error, Fatal, Panic** — immediately, so the lines that matter before a crash are already on disk
- **Buffer full** — free, from `bufio`
- **Periodic tick** — `log_flush_interval`, default 240s, shortened to 2s while the level is debug/trace (see below)
- **`debug.FlushLogs()`** — called from `doStop`, so graceful shutdown keeps its closing lines

Effect: an idle adapter goes from ~12 writeback cycles/minute to one per 4 minutes — roughly a 48x cut in amplified flash traffic for the same log volume.

## Why a formatter wrapper and not a logrus hook

This looks like a job for a level hook, and it isn't. `fireHooks()` runs *before* `entry.write()` and the logger mutex is released between the two, so a hook cannot flush the line that triggered it, and concurrent goroutines would interleave the flag. `Formatter.Format()` runs *inside* `entry.write()` under the same mutex as `Out.Write()`, which gives exactly the ordering guarantee needed. This is commented in the source, since the hook approach is the tempting wrong answer.

## Live tailing stays fast at debug/trace

The 240s interval would make a live adapter look hung right when someone enables debug to tail it — and enabling debug is almost always exactly that. So the flush interval drops to 2s the moment the level is debug/trace, switching immediately on `SetLevel` rather than waiting for the next tick, and reverting the moment the level drops back. Error+ was already immediate regardless of level.

This piggybacks on a window that's already bounded: `log_revert_timeout` reverts debug/trace to info on its own, so the reduced eMMC protection only lasts as long as the operator-armed debug window does. Info-level behavior (240s, the normal running state) is unaffected.

## Config

`log_flush_interval` in `config.json`, `omitempty`, falls back to 240s when absent or <= 0 — existing adapter configs need no change. Encoded as a raw `time.Duration` (nanoseconds), matching the neighbouring `log_revert_timeout`. The 2s debug-level interval is not configurable — it's a fixed tradeoff for a fixed, self-expiring state.

## Testing

`make test` green across all 40 packages; `go vet` and `golangci-lint run` clean (0 issues). New tests cover: Info stays buffered, Error flushes immediately and carries preceding lines with it, explicit flush drains, and debug-level entries reach the file within ~2s instead of waiting for the long interval.

Note for anyone testing locally: run tests via `make test` (which uses `-p 1`). Running packages in parallel makes `TestRouteConfig` fail ~90% of the time, because every suite-based test shares the MQTT client ID `cliffhanger_test_suite` on one broker and the second connection kicks the first. That is pre-existing on `develop` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
